### PR TITLE
Loudness sensor

### DIFF
--- a/src/Catty/SensorHandler.m
+++ b/src/Catty/SensorHandler.m
@@ -275,7 +275,6 @@ static SensorHandler* sharedSensorHandler = nil;
                                                        selector: @selector(programTimerCallback:)
                                                        userInfo: nil
                                                         repeats: NO];
-    
 }
 
 
@@ -293,9 +292,6 @@ static SensorHandler* sharedSensorHandler = nil;
     CGFloat percent = pow (10, decibel / 20);
     return percent * 100.0f;
 }
-
-
-
 
 
 


### PR DESCRIPTION
Fixes the broken loudness sensor since iOS 7.

Stackoverflow topic:

http://stackoverflow.com/questions/18853990/how-to-get-mic-volume-in-ios-7
