### PR TITLE
fixes chrash if application is suspended while loudness sensor is active

### DIFF
--- a/src/Catty/AppDelegate.m
+++ b/src/Catty/AppDelegate.m
@@ -24,6 +24,7 @@
 #import "FileManager.h"
 #import "Util.h"
 #import "UIColor+CatrobatUIColorExtensions.h"
+#import <AVFoundation/AVFoundation.h>
 
 void uncaughtExceptionHandler(NSException *exception)
 {
@@ -56,6 +57,16 @@ void uncaughtExceptionHandler(NSException *exception)
     application.statusBarHidden = NO;
     application.statusBarStyle = UIStatusBarStyleLightContent;
     return YES;
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application
+{
+    [[AVAudioSession sharedInstance] setActive:YES error:nil];
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+    [[AVAudioSession sharedInstance] setActive:NO error:nil];
 }
 
 - (void)initNavigationBar


### PR DESCRIPTION
The AVAudioSession is not allowed to record if the application is suspended. Disabiling it in the app delegate solves this problem.
