### PR TITLE
fixes #244

### DIFF
--- a/src/Catty/ProjectParser.m
+++ b/src/Catty/ProjectParser.m
@@ -189,10 +189,8 @@
             else { // NOT ARRAY
                 id value = [self getSingleValue:child ofType:propertyType withParent:ref];
                 [object setValue:value forKey:child.name];
-                NSString *attributes = [NSString stringWithUTF8String:property_getAttributes(property)];
-                attributes = [attributes stringByReplacingOccurrencesOfString:propertyType withString:@""];
-                
-                if(![propertyType isEqualToString:kParserObjectTypeSprite]&& [attributes hasPrefix:@",W"] && value != nil) {
+          
+                if(![propertyType isEqualToString:kParserObjectTypeSprite] && [self isWeakProperty:property] && value != nil) {
                     [self.weakPropertyRetainer addObject:value];
                 }
             }
@@ -695,6 +693,14 @@ const char* property_getTypeString(objc_property_t property) {
         index = 0;
     }
     return index;
+}
+
+- (BOOL)isWeakProperty:(objc_property_t)property
+{
+    NSString *propertyType = [NSString stringWithUTF8String:property_getTypeString(property)];
+    NSString *attributes = [NSString stringWithUTF8String:property_getAttributes(property)];
+    attributes = [attributes stringByReplacingOccurrencesOfString:propertyType withString:@""];
+    return [attributes hasPrefix:kPropertyWeak];
 }
 
 @end


### PR DESCRIPTION
In Release build, weak properties would be set to nil, before we had the chance to retain a strong pointer. 
This fix introduces a Weak Property Retainer, to keep the properties in memory until they are needed.
