### PR TITLE
IOS-139 #done

### DIFF
--- a/src/Catty/Defines/UIDefines.h
+++ b/src/Catty/Defines/UIDefines.h
@@ -22,12 +22,28 @@
 
 #import "LanguageTranslationDefines.h"
 
+// Screen Sizes in Points
+#define kIphone4ScreenHeight 480.0f
+#define kIphone4ScreenWidth 320.0f
+#define kIphone5ScreenHeight 568.0f
+#define kIphone5ScreenWidth 320.0f
+#define kIphone6ScreenHeight 667.0f
+#define kIphone6ScreenWidth 375.0f
+#define kIphone6PScreenHeight 736.0f
+#define kIphone6PScreenWidth 414.0f
+#define kIpadScreenHeight 1028.0f
+#define kIpadScreenWidth 768.0f
+#define kIpadRetinaScreenHeight 2048.0f
+#define kIpadRetinaScreenWidth 1536.0f
+
+// CatrobatTableViewController
+#define kIconDownsizeFactorIphone4 0.85f
+
 // ScenePresenterViewController
 #define kWidthSlideMenu 150
 #define kBounceEffect 5
 #define kPlaceOfButtons 17
 #define kSlidingStartArea 40
-#define kIphone4ScreenHeight 480.0f
 #define kContinueButtonSize 85
 #define kContinueOffset 15
 #define kMenuButtonSize 44
@@ -57,16 +73,12 @@
 #define kLoadingViewTag 99998
 #define kSavedViewTag   99999
 
-#define kIphone5ScreenHeight 568.0f
-#define kIphone4ScreenHeight 480.0f
-#define kIpadScreenHeight 1028.0f
 #define kAddScriptCategoryTableViewBottomMargin 15.0f
 
 // delete button bricks
 #define kBrickCellDeleteButtonWidthHeight 22.0f
 #define kSelectButtonnOffset 30.0f
 #define kSelectButtonTranslationOffsetX 60.0f
-
 #define kScriptCollectionViewTopInsets 10.0f
 #define kScriptCollectionViewBottomInsets 5.0f
 

--- a/src/Catty/Helpers/Util/Util.h
+++ b/src/Catty/Helpers/Util/Util.h
@@ -24,10 +24,14 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 #import "FormulaEditorTextView.h"
+#import "UIDefines.h"
 
 #define IS_IPAD (UI_USER_INTERFACE_IDIOM()==UIUserInterfaceIdiomPad)
 #define IS_IPHONE (UI_USER_INTERFACE_IDIOM()==UIUserInterfaceIdiomPhone)
-#define IS_IPHONE5 ((UIScreen.mainScreen.bounds.size.height - 568) ? NO : YES)
+#define IS_IPHONE4 (([Util screenHeight] - kIphone4ScreenHeight) ? NO : YES)
+#define IS_IPHONE5 (([Util screenHeight] - kIphone5ScreenHeight) ? NO : YES)
+#define IS_IPHONE6 (([Util screenHeight] - kIphone6ScreenHeight) ? NO : YES)
+#define IS_IPHONE6P (([Util screenHeight] - kIphone6PScreenHeight) ? NO : YES)
 
 #define IS_OS_5_OR_LATER ([[[UIDevice currentDevice] systemVersion] floatValue] >= 5.0)
 #define IS_OS_6_OR_LATER ([[[UIDevice currentDevice] systemVersion] floatValue] >= 6.0)
@@ -135,6 +139,8 @@
 + (NSString*)platformName;
 
 + (NSString*)platformVersion;
+
++ (CGSize)screenSize;
 
 + (CGFloat)screenHeight;
 

--- a/src/Catty/Helpers/Util/Util.m
+++ b/src/Catty/Helpers/Util/Util.m
@@ -327,16 +327,27 @@
   return [[UIDevice currentDevice] systemVersion];
 }
 
++ (CGSize)screenSize
+{
+    CGSize screenSize = [[UIScreen mainScreen] bounds].size;
+    float iOSVersion = [[[UIDevice currentDevice] systemVersion] floatValue];
+    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    if (iOSVersion < 8 && UIInterfaceOrientationIsLandscape(orientation))
+    {
+        screenSize.height = screenSize.width;
+        screenSize.width = [[UIScreen mainScreen] bounds].size.height;
+    }
+    return screenSize;
+}
+
 + (CGFloat)screenHeight
 {
-    CGRect screenRect = [[UIScreen mainScreen] bounds];
-    return screenRect.size.height;
+    return [self screenSize].height;
 }
 
 + (CGFloat)screenWidth
 {
-  CGRect screenRect = [[UIScreen mainScreen] bounds];
-  return screenRect.size.width;
+    return [self screenSize].width;
 }
 
 + (CATransition*)getPushCATransition

--- a/src/Catty/ViewController/CatrobatTableViewController/CatrobatTableViewController.m
+++ b/src/Catty/ViewController/CatrobatTableViewController/CatrobatTableViewController.m
@@ -342,6 +342,12 @@ static NSCharacterSet *blockedCharacterSet = nil;
 {
     cell.titleLabel.text = [self.cells objectAtIndex:indexPath.row];
     cell.iconImageView.image = [UIImage imageNamed:[self.imageNames objectAtIndex:indexPath.row]];
+    if(IS_IPHONE4 && (indexPath.row!=0)) {
+        CGRect frame = cell.iconImageView.frame;
+        frame.size.height = kIconDownsizeFactorIphone4*cell.iconImageView.frame.size.height;
+        cell.iconImageView.frame= frame;
+        cell.iconImageView.contentMode = UIViewContentModeScaleAspectFit;
+    }
 }
 
 - (void)configureSubtitleLabelForCell:(UITableViewCell*)cell

--- a/src/Catty/ViewController/Download/ProgramDetailStoreViewController.m
+++ b/src/Catty/ViewController/Download/ProgramDetailStoreViewController.m
@@ -46,8 +46,6 @@
 
 #define kScrollViewOffset 0.0f
 
-#define kIphone5ScreenHeight 568.0f
-#define kIphone4ScreenHeight 480.0f
 
 @interface ProgramDetailStoreViewController () <ProgramUpdateDelegate>
 

--- a/src/iOS_Lang/en.lproj/Localizable.strings
+++ b/src/iOS_Lang/en.lproj/Localizable.strings
@@ -263,6 +263,9 @@
 "Download" = "Download";
 
 /* No comment provided by engineer. */
+"Download sucessful" = "Download sucessful";
+
+/* No comment provided by engineer. */
 "Downloads" = "Downloads";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
Adopted size of icons in CatrobatTableView (Startscreen) and tidied up
defines concerning screen sizes, added fix for pre iOS 8 devices to
check orientation (only portrait used, but for consistency reasons and
future use) and added macro to figure out the device’s screen class.