### PR TITLE
IOS-111

### DIFF
--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
@@ -583,17 +583,14 @@ willBeginDraggingItemAtIndexPath:(NSIndexPath*)indexPath
         return;
     }
 
-    // empty script list, insert start script + brick
+    // empty script list, insert start script and continue to insert brick
     if (self.object.scriptList.count == 0) {
         StartScript *script = [StartScript new];
         script.object = self.object;
         [self.object.scriptList addObject:script];
         script.animate = YES;
-        Brick *brick = (Brick*)scriptOrBrick;
-        brick.animate = YES;
-        [script.brickList addObject:brick];
         [self.collectionView reloadData];
-        return;
+        [self.object.program saveToDisk];
     }
     
     NSInteger targetScriptIndex = 0;

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
@@ -583,7 +583,7 @@ willBeginDraggingItemAtIndexPath:(NSIndexPath*)indexPath
         return;
     }
 
-    // empty script list, insert start script and continue to insert brick
+    // empty script list, insert start script and continue to insert the chosen brick
     if (self.object.scriptList.count == 0) {
         StartScript *script = [StartScript new];
         script.object = self.object;

--- a/src/iOS_Lang/en.lproj/Localizable.strings
+++ b/src/iOS_Lang/en.lproj/Localizable.strings
@@ -263,6 +263,9 @@
 "Download" = "Download";
 
 /* No comment provided by engineer. */
+"Download sucessful" = "Download sucessful";
+
+/* No comment provided by engineer. */
 "Downloads" = "Downloads";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
Fixed bug of missing end of loops (and crash) when no script is already
in and brick of type “LoopBeginBrick” is added . Fixed for all
subclasses of “LoopBeginBrick” by adding a StartScript if there is none
and continue as if there was one.