### PR TITLE
IOS-388 #done

### DIFF
--- a/src/Catty.xcodeproj/xcshareddata/xcschemes/Catty (RELEASE).xcscheme
+++ b/src/Catty.xcodeproj/xcshareddata/xcschemes/Catty (RELEASE).xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "NO"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CA7698A91B0E4A97000D0340"


### PR DESCRIPTION
Removed test-target from release build as it is not possible to build
it with the build option ENABLE_TESTABILITY set to „no“.