### PR TITLE
IOS-414 loading indicator in FeaturedProgramsStoreViewController is now appearing properly

### DIFF
--- a/src/Catty/ViewController/Download/FeaturedProgramsStoreViewController.m
+++ b/src/Catty/ViewController/Download/FeaturedProgramsStoreViewController.m
@@ -47,6 +47,7 @@
 @property (nonatomic, strong) NSArray *featuredSize;
 @property (nonatomic, strong) LoadingView* loadingView;
 @property (nonatomic) BOOL shouldShowAlert;
+@property (nonatomic) BOOL shouldHideLoadingView;
 
 @end
 
@@ -87,6 +88,7 @@
     self.tableView.rowHeight = UITableViewAutomaticDimension;
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.shouldShowAlert = YES;
+    self.shouldHideLoadingView = NO;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -202,6 +204,7 @@
         if (error) {
             if ([Util isNetworkError:error]) {
                 [Util defaultAlertForNetworkError];
+                self.shouldHideLoadingView = YES;
                 [self hideLoadingView];
             }
         } else {
@@ -251,6 +254,7 @@
             }
         } else {
             [Util defaultAlertForUnknownError];
+            self.shouldHideLoadingView = YES;
             [self hideLoadingView];
             return;
         }
@@ -330,6 +334,7 @@
         }
     }
     [self update];
+    self.shouldHideLoadingView = YES;
     [self hideLoadingView];
    
 }
@@ -347,8 +352,11 @@
 
 - (void)hideLoadingView
 {
-    [self.loadingView hide];
-    [self loadingIndicator:NO];
+    if(self.shouldHideLoadingView) {
+        [self.loadingView hide];
+        [self loadingIndicator:NO];
+        self.shouldHideLoadingView = NO;
+    }
 }
 
 - (void)loadingIndicator:(BOOL)value


### PR DESCRIPTION
Quick solution, but not sure if this is the ideal solution.

Basic Problem: 
The "viewWillAppear"-Method of "BaseTableViewController (which is the base class of "FeaturedProgramsStoreViewController") was always hiding the loading indicator. Since the loading process of the resources takes longer, the loading indicator should also be visible after executing "viewWillAppear".

My solution:
Commands to hide the loading view are ignored if they come from the base class (BaseTableViewController) by introducing the "shouldHideLoadingView" property.

Other possible solutions:
- not subclassing from "BaseTableViewController"
- renaming the methods "hideLoadingView" and the property "loadingView" in "FeaturedProgramsStoreViewController" so the base class does not access them
- not calling "[super viewWillAppear:animated];" in the "viewWillAppear"-method of "FeaturedProgramsStoreViewController"