### PR TITLE
Ios 402

### DIFF
--- a/src/Catty/ViewController/CatrobatTableViewController/AboutPoketCodeOptionTableViewController.m
+++ b/src/Catty/ViewController/CatrobatTableViewController/AboutPoketCodeOptionTableViewController.m
@@ -31,9 +31,12 @@
     self.title = kLocalizedAboutPocketCode;
     self.view.backgroundColor = [UIColor backgroundColor];
     self.view.tintColor = [UIColor globalTintColor];
-    [self addSection:[BOTableViewSection sectionWithHeaderTitle:kLocalizedAboutPocketCode handler:^(BOTableViewSection *section) {
+    [self addSection:[BOTableViewSection sectionWithHeaderTitle:@"" handler:^(BOTableViewSection *section) {
         
-        section.headerTitle = kLocalizedAboutPocketCodeDescription;
+        [section addCell:[BOTableViewCell cellWithTitle:kLocalizedAboutPocketCodeDescription key:nil handler:^(BOButtonTableViewCell *cell) {
+            cell.backgroundColor = [UIColor backgroundColor];
+        }]];
+        
         __unsafe_unretained typeof(self) weakSelf = self;
         [section addCell:[BOButtonTableViewCell cellWithTitle:kLocalizedSourceCodeLicenseButtonLabel key:nil handler:^(BOButtonTableViewCell *cell) {
             cell.backgroundColor = [UIColor backgroundColor];

--- a/src/Catty/ViewController/CatrobatTableViewController/AboutPoketCodeOptionTableViewController.m
+++ b/src/Catty/ViewController/CatrobatTableViewController/AboutPoketCodeOptionTableViewController.m
@@ -24,6 +24,7 @@
 #import "LanguageTranslationDefines.h"
 #import "NetworkDefines.h"
 #import "UIColor+CatrobatUIColorExtensions.h"
+#import "Util.h"
 
 @implementation AboutPoketCodeOptionTableViewController
 
@@ -58,10 +59,18 @@
 
 - (void)openAboutURL
 {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kAboutCatrobatURL]];
+    if (IS_OS_10_OR_LATER) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kAboutCatrobatURL] options:[NSDictionary dictionary] completionHandler:nil];
+    } else {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kAboutCatrobatURL]];
+    }
 }
 - (void)openSourceCodeLicenseURL
 {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kSourceCodeLicenseURL]];
+    if (IS_OS_10_OR_LATER) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kSourceCodeLicenseURL] options:[NSDictionary dictionary] completionHandler:nil];
+    } else {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kSourceCodeLicenseURL]];
+    }
 }
 @end

--- a/src/Catty/ViewController/CatrobatTableViewController/TermsOfUseOptionTableViewController.m
+++ b/src/Catty/ViewController/CatrobatTableViewController/TermsOfUseOptionTableViewController.m
@@ -28,15 +28,15 @@
 @implementation TermsOfUseOptionTableViewController
 
 - (void)setup {
-    CGFloat yOffset = self.navigationController.navigationBar.frame.origin.y + self.navigationController.navigationBar.frame.size.height + 20;
-    self.tableView.contentInset = UIEdgeInsetsMake(yOffset, 0, 0, 0);     //Fixes Issue 402: Avoid TableView-Top beeing beneath NavigationBar (if too much lines of text)
-    
     self.title = kLocalizedTermsOfUse;
     self.view.backgroundColor = [UIColor backgroundColor];
     self.view.tintColor = [UIColor globalTintColor];
-    [self addSection:[BOTableViewSection sectionWithHeaderTitle:kLocalizedTermsOfUse handler:^(BOTableViewSection *section) {
+    [self addSection:[BOTableViewSection sectionWithHeaderTitle:@"" handler:^(BOTableViewSection *section) {
         
-        section.headerTitle = kLocalizedTermsOfUseDescription;
+        [section addCell:[BOTableViewCell cellWithTitle:kLocalizedTermsOfUseDescription key:nil handler:^(BOButtonTableViewCell *cell) {
+            cell.backgroundColor = [UIColor backgroundColor];
+        }]];
+        
         __unsafe_unretained typeof(self) weakSelf = self;
         [section addCell:[BOButtonTableViewCell cellWithTitle:kLocalizedTermsOfUse key:nil handler:^(BOButtonTableViewCell *cell) {
             cell.backgroundColor = [UIColor backgroundColor];

--- a/src/Catty/ViewController/CatrobatTableViewController/TermsOfUseOptionTableViewController.m
+++ b/src/Catty/ViewController/CatrobatTableViewController/TermsOfUseOptionTableViewController.m
@@ -24,6 +24,7 @@
 #import "LanguageTranslationDefines.h"
 #import "NetworkDefines.h"
 #import "UIColor+CatrobatUIColorExtensions.h"
+#import "Util.h"
 
 @implementation TermsOfUseOptionTableViewController
 
@@ -51,7 +52,11 @@
 
 - (void)openTermsOfUse
 {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kTermsOfUseURL]];
+    if (IS_OS_10_OR_LATER) {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kTermsOfUseURL] options:[NSDictionary dictionary] completionHandler:nil];
+    } else {
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:kTermsOfUseURL]];
+    }
 }
 
 

--- a/src/Catty/ViewController/CatrobatTableViewController/TermsOfUseOptionTableViewController.m
+++ b/src/Catty/ViewController/CatrobatTableViewController/TermsOfUseOptionTableViewController.m
@@ -28,10 +28,13 @@
 @implementation TermsOfUseOptionTableViewController
 
 - (void)setup {
+    CGFloat yOffset = self.navigationController.navigationBar.frame.origin.y + self.navigationController.navigationBar.frame.size.height + 20;
+    self.tableView.contentInset = UIEdgeInsetsMake(yOffset, 0, 0, 0);     //Fixes Issue 402: Avoid TableView-Top beeing beneath NavigationBar (if too much lines of text)
+    
     self.title = kLocalizedTermsOfUse;
     self.view.backgroundColor = [UIColor backgroundColor];
     self.view.tintColor = [UIColor globalTintColor];
-    [self addSection:[BOTableViewSection sectionWithHeaderTitle:kLocalizedAboutPocketCode handler:^(BOTableViewSection *section) {
+    [self addSection:[BOTableViewSection sectionWithHeaderTitle:kLocalizedTermsOfUse handler:^(BOTableViewSection *section) {
         
         section.headerTitle = kLocalizedTermsOfUseDescription;
         __unsafe_unretained typeof(self) weakSelf = self;


### PR DESCRIPTION
In AboutPocketCodeVC und TermsOfUseVC the section-header of the TableView was misused for displaying the description text, instead of adding a cell for this text. Because of this the text was pushed up to, or even underneath the NavigationBar, if there were to much lines of text
