### PR TITLE
[Fix][IOS-451] Keyboard Hides Note-Brick

### DIFF
--- a/src/Catty/Extension&Delegate&Protocol/Protocols/Bricks/BrickCellDataProtocol.h
+++ b/src/Catty/Extension&Delegate&Protocol/Protocols/Bricks/BrickCellDataProtocol.h
@@ -38,5 +38,6 @@
 
 @required
 - (void)updateBrickCellData:(id<BrickCellDataProtocol>)brickCellData withValue:(id)value;
+-(void)enableUserInteractionAndResetHighlight;
 - (void)disableUserInteractionAndHighlight:(BrickCell*)brickCell withMarginBottom:(CGFloat)marginBottom;
 @end

--- a/src/Catty/Extension&Delegate&Protocol/Protocols/Bricks/BrickCellDataProtocol.h
+++ b/src/Catty/Extension&Delegate&Protocol/Protocols/Bricks/BrickCellDataProtocol.h
@@ -38,6 +38,5 @@
 
 @required
 - (void)updateBrickCellData:(id<BrickCellDataProtocol>)brickCellData withValue:(id)value;
--(void)enableUserInteractionAndResetHighlight;
 - (void)disableUserInteractionAndHighlight:(BrickCell*)brickCell withMarginBottom:(CGFloat)marginBottom;
 @end

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
@@ -1258,8 +1258,8 @@ willBeginDraggingItemAtIndexPath:(NSIndexPath*)indexPath
     }
     
     for (BrickCell *cell in self.collectionView.visibleCells) {
-        cell.enabled = NO;
         if (cell != brickCell) {
+            cell.enabled = NO;
             cell.alpha = kBrickCellInactiveWhileEditingOpacity;
         }
     }

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellTextData.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellTextData.m
@@ -30,7 +30,6 @@
 
 @interface BrickCellTextData() <UITextFieldDelegate>
 @property (nonatomic, strong) CAShapeLayer *border;
-@property bool isEditing;
 @end
 
 @implementation BrickCellTextData
@@ -43,7 +42,6 @@
 - (instancetype)initWithFrame:(CGRect)frame andBrickCell:(BrickCell*)brickCell andLineNumber:(NSInteger)line andParameterNumber:(NSInteger)parameter
 {
     if(self = [super initWithFrame:frame]) {
-        _isEditing = false;
         _brickCell = brickCell;
         _lineNumber = line;
         _parameterNumber = parameter;
@@ -87,7 +85,7 @@
 
 - (void)keyboardDidAppear:(NSNotification*)notification
 {
-    if (_isEditing) {
+    if (self.isFirstResponder) {
         NSDictionary* keyboardInfo = [notification userInfo];
         NSValue* keyboardFrameBegin = [keyboardInfo valueForKey:UIKeyboardFrameBeginUserInfoKey];
         CGRect keyboardFrameBeginRect = [keyboardFrameBegin CGRectValue];
@@ -175,16 +173,9 @@
 
 #pragma mark - delegates
 
--(void)textFieldDidBeginEditing:(UITextField *)textField
-{
-    _isEditing = true;
-}
-
 -(void)textFieldDidEndEditing:(UITextField *)textField
 {
-    _isEditing = false;
     [textField resignFirstResponder];
-    [self.brickCell.dataDelegate enableUserInteractionAndResetHighlight];
 }
 
 - (void)textFieldDone:(id)sender


### PR DESCRIPTION
* Added `enableUserInteractionAndResetHighlight` to `BrickCellDataProtocol.h` header.
* Selected brick not disabled when dimming other bricks in `disableUserInteractionAndHighlight`
* Added `UIKeyboardWillChangeFrameNotification` observer in `BrickCellTextData.h`, calling `disableUserInteractionAndHighlight` on dataDelegate if editing enabled.

@m-herold everything looks good. Could you please take a look?