### PR TITLE
IOS-431 application crashes when deleting scripts

### DIFF
--- a/src/Catty/Defines/ActionSheetAlertViewTags.h
+++ b/src/Catty/Defines/ActionSheetAlertViewTags.h
@@ -48,6 +48,8 @@
 #define kConfirmAlertViewTag 200
 #define kResourcesAlertView 201
 
+#define kConfirmDeletingSelectedItemsAlertViewTag 300
+
 // Alert view button indexes
 #define kAlertViewButtonOK 1
 #define kAlertViewCancel 0

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
@@ -367,7 +367,7 @@ minimumLineSpacingForSectionAtIndex:(NSInteger)section
     if ([[[BrickSelectionManager sharedInstance] selectedIndexPaths] count])
     {
         NSString *alertTitle = title;
-        [Util confirmAlertWithTitle:alertTitle message:kLocalizedThisActionCannotBeUndone delegate:self tag:kConfirmAlertViewTag];
+        [Util confirmAlertWithTitle:alertTitle message:kLocalizedThisActionCannotBeUndone delegate:self tag:kConfirmDeletingSelectedItemsAlertViewTag];
     }
 }
 
@@ -390,8 +390,10 @@ minimumLineSpacingForSectionAtIndex:(NSInteger)section
     } 
     */
     
-    if (alertView.tag == kConfirmAlertViewTag && buttonIndex == 1)
-    {
+    if (alertView.tag == kConfirmDeletingSelectedItemsAlertViewTag && buttonIndex == 1) {
+        [self deleteSelectedBricks];
+        self.allBricksSelected = NO;
+    } else if (alertView.tag == kConfirmAlertViewTag && buttonIndex == 1) {
         BrickCell *brickCell = (BrickCell*)[self.collectionView cellForItemAtIndexPath:self.selectedIndexPathForDeletion];
         [self removeBrickOrScript:brickCell.scriptOrBrick atIndexPath:self.selectedIndexPathForDeletion];
     }


### PR DESCRIPTION
The reason was that multiple `alertView`s had the same `tag`. Don't you mind if I refactor/redesign `CatrobatAlertController` to make it easier to use and less error prone?