### PR TITLE
IOS-221 Crash when generating infinite broadcast recursion

### DIFF
--- a/src/Catty/PlayerEngine/Scheduler/CBBroadcastHandler.swift
+++ b/src/Catty/PlayerEngine/Scheduler/CBBroadcastHandler.swift
@@ -141,17 +141,11 @@ final class CBBroadcastHandler: CBBroadcastHandlerProtocol {
             counter = counterNumber
         }
         counter += 1
-        if counter % PlayerConfig.MaxRecursionLimitOfSelfBroadcasts == 0 { // XXX: DIRTY PERFORMANCE HACK!!
-            // TODO: restart special case issue
-            dispatch_async(dispatch_get_main_queue(), { [weak self] in
-                // restart this self-listening BroadcastScript
-                self?.scheduler?.scheduleContext(context)
-                self?.scheduler?.runNextInstructionsGroup()
-                })
-        } else {
-            scheduler?.scheduleContext(context)
-            // Don't run next instruction here, or else infinite recursive broadcasts will cause a crash
-        }
+        dispatch_async(dispatch_get_main_queue(), { [weak self] in
+            // restart this self-listening BroadcastScript
+            self?.scheduler?.scheduleContext(context)
+            self?.scheduler?.runNextInstructionsGroup()
+        })
         _selfBroadcastCounters[message] = counter
         logger.debug("BROADCASTSCRIPT HAS BEEN RESTARTED DUE TO SELF-BROADCAST!!")
     }

--- a/src/Catty/PlayerEngine/Scheduler/CBBroadcastHandler.swift
+++ b/src/Catty/PlayerEngine/Scheduler/CBBroadcastHandler.swift
@@ -150,7 +150,7 @@ final class CBBroadcastHandler: CBBroadcastHandlerProtocol {
                 })
         } else {
             scheduler?.scheduleContext(context)
-            scheduler?.runNextInstructionsGroup()
+            // Don't run next instruction here, or else infinite recursive broadcasts will cause a crash
         }
         _selfBroadcastCounters[message] = counter
         logger.debug("BROADCASTSCRIPT HAS BEEN RESTARTED DUE TO SELF-BROADCAST!!")

--- a/src/Catty/PlayerEngine/Scheduler/CBScheduler.swift
+++ b/src/Catty/PlayerEngine/Scheduler/CBScheduler.swift
@@ -33,7 +33,7 @@ final class CBScheduler: CBSchedulerProtocol {
     private var _whenContexts = [String:[CBWhenScriptContext]]()
     private var _scheduledContexts = OrderedDictionary<String,[CBScriptContextProtocol]>()
     private var _contextsWaitingToBeScheduled = OrderedDictionary<String,[CBScriptContextProtocol]>()
-    private var _hasNewBroadcastContextBeenScheduled = false;
+    private var _hasNewBroadcastContextBeenScheduled = false
     
     private var _availableWaitQueues = [dispatch_queue_t]()
     private var _availableBufferQueues = [dispatch_queue_t]()
@@ -151,7 +151,7 @@ final class CBScheduler: CBSchedulerProtocol {
                     nextActionElements.forEach { $0.context.state = .Runnable }
                     self?.runNextInstructionsGroup()
                     self?.scheduleBroadcastContext(spriteName, checkForOtherContexts: true)
-                    while self?._hasNewBroadcastContextBeenScheduled != nil && self!._hasNewBroadcastContextBeenScheduled {
+                    while self?._hasNewBroadcastContextBeenScheduled == true {
                         self?._hasNewBroadcastContextBeenScheduled = false;
                         self?.runNextInstructionsGroup()
                     }
@@ -171,7 +171,7 @@ final class CBScheduler: CBSchedulerProtocol {
                     context.state = .Runnable
                     self?.runNextInstructionsGroup()
                     self?.scheduleBroadcastContext(spriteName, checkForOtherContexts: true)
-                    while self?._hasNewBroadcastContextBeenScheduled != nil && self!._hasNewBroadcastContextBeenScheduled {
+                    while self?._hasNewBroadcastContextBeenScheduled == true {
                         self?._hasNewBroadcastContextBeenScheduled = false;
                         self?.runNextInstructionsGroup()
                     }


### PR DESCRIPTION
While inspecting what is happening when infinite broadcast recursion is made, I made two changes to scheduling.

1. There was a problem with how broadcasts are handled when there are no actions active in the context that is broadcast. Essentially broadcast contexts would become active too late. I corrected this behaviour by starting those contexts more or less immediately, as they do not have to wait for anything.

2. An infinite broadcast recursion would in fact still happen with my solution proposed above. Therefore I changed the code to not actually enter the runNextInstructionGroup() method over and over again in such a case of self broadcasts, eventually running into a EXC_BAD_ACCESS error. Instead, the runNextInstructionGroup() method will be called at a later point in time, when the program has left the preceding runNextInstructionGroup() call.