### PR TITLE
IOS-525 ShowVariableBrick - Uninitialized variable

### DIFF
--- a/src/Catty/PlayerEngine/Instructions/Data/ShowTextBrick+Instruction.swift
+++ b/src/Catty/PlayerEngine/Instructions/Data/ShowTextBrick+Instruction.swift
@@ -45,7 +45,7 @@ extension ShowTextBrick: CBInstructionProtocol {
                     let string:NSString = userVariable.value as! NSString
                     value = string as String
                 } else {
-                    value = ""
+                    value = "0"
                 }
                 userVariable.textLabel.text = value
                 


### PR DESCRIPTION
Behaviour is now equivalent to Catroid, where ShowVariable with an uninitialised user variable shows a "0" instead of nothing.