### PR TITLE
IOS-632 Fix pick media

### DIFF
--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LookImageViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LookImageViewController.m
@@ -150,20 +150,8 @@
 
     NSData *imageData = UIImagePNGRepresentation(image);
     NSDebug(@"Writing file to disk");
-        // leaving the main queue here!
-    NSBlockOperation* saveOp = [NSBlockOperation blockOperationWithBlock:^{
-            // save image to programs directory
-        [imageData writeToFile:self.imagePath atomically:YES];
-    }];
-        // completion block is NOT executed on the main queue
-    [saveOp setCompletionBlock:^{
-            // execute this on the main queue
-        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
 
-        }];
-    }];
-    NSOperationQueue *queue = [[NSOperationQueue alloc] init];
-    [queue addOperation:saveOp];
+    [imageData writeToFile:self.imagePath atomically:YES];
     
     NSString *imageDirPath = [[self.spriteObject projectPath] stringByAppendingString:kProgramImagesDirName];
     NSString * fileName = [self.imagePath stringByReplacingOccurrencesOfString:imageDirPath withString:@""];


### PR DESCRIPTION
picking media (photos) or using a photo from the camera was broken as an AlertController was trying to show itself on the UIImagePickerController which was already dismissed.
moving the corresponding code into the completion block of dismissViewControllerAnimated fixed the problem