### PR TITLE
IOS-626 reload program overview / overwrite program preview thumbnail

### DIFF
--- a/src/Catty/Defines/LanguageTranslationDefines.h
+++ b/src/Catty/Defines/LanguageTranslationDefines.h
@@ -255,6 +255,7 @@
 #define kLocalizedOn NSLocalizedString(@"on", nil)
 #define kLocalizedCameraBack NSLocalizedString(@"back", nil)
 #define kLocalizedCameraFront NSLocalizedString(@"front", nil)
+#define kLocalizedSetAsPreviewImage NSLocalizedString(@"Set as Preview Image", nil)
 
 //************************************************************************************************************
 //**********************************       SHORT DESCRIPTIONS      *******************************************

--- a/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
+++ b/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
@@ -255,6 +255,7 @@ let kLocalizedOff = NSLocalizedString("off", comment: "")
 let kLocalizedOn = NSLocalizedString("on", comment: "")
 let kLocalizedCameraBack = NSLocalizedString("back", comment: "")
 let kLocalizedCameraFront = NSLocalizedString("front", comment: "")
+let kLocalizedSetAsPreviewImage = NSLocalizedString("Set as Preview Image", comment: "")
 
 //************************************************************************************************************
 //**********************************       SHORT DESCRIPTIONS      *******************************************

--- a/src/Catty/ViewController/Programs/MyProgramsViewController.m
+++ b/src/Catty/ViewController/Programs/MyProgramsViewController.m
@@ -99,7 +99,7 @@ static NSCharacterSet *blockedCharacterSet = nil;
     self.selectedProgram = nil;
     [self.navigationController setNavigationBarHidden:NO];
     [self.navigationController setToolbarHidden:NO];
-    [self.tableView reloadData];
+    [self reloadTableView];
 }
 
 #pragma mark - system events

--- a/src/Catty/ViewController/Scene/SaveToProjectActivity.m
+++ b/src/Catty/ViewController/Scene/SaveToProjectActivity.m
@@ -22,6 +22,7 @@
 
 #import "SaveToProjectActivity.h"
 #import "LanguageTranslationDefines.h"
+#import "RuntimeImageCache.h"
 
 @implementation SaveToProjectActivity
 
@@ -40,7 +41,7 @@
 }
 
 - (NSString *)activityTitle {
-    return kLocalizedSaveToPocketCode;
+    return kLocalizedSetAsPreviewImage;
 }
 
 - (UIImage *)activityImage
@@ -67,11 +68,12 @@
 
 - (void)performActivity
 {
-    //Dimensions of Screenshot???
-    NSString *pngFilePath = [NSString stringWithFormat:@"%@/manual_screenshot.png",self.path];
+    NSString *fileName = @"manual_screenshot.png";
+    NSString *pngFilePath = [NSString stringWithFormat:@"%@%@",self.path, fileName];
     NSData *data = [NSData dataWithData:UIImagePNGRepresentation(self.image)];
     [data writeToFile:pngFilePath atomically:YES];
-
+    [[RuntimeImageCache sharedImageCache] overwriteThumbnailImageFromDiskWithThumbnailPath:[NSString stringWithFormat:@"%@%@%@",self.path, kScreenshotThumbnailPrefix, fileName] image:self.image thumbnailFrameSize:CGSizeMake(kPreviewImageWidth, kPreviewImageHeight)];
+    
     [self activityDidFinish:YES];
 }
 

--- a/src/Catty/ViewController/Scene/ScenePresenterViewController.m
+++ b/src/Catty/ViewController/Scene/ScenePresenterViewController.m
@@ -503,9 +503,9 @@
 
 -(void)takeAutomaticScreenshot
 {
-    NSArray *fallbackPaths = @[[[NSString alloc] initWithFormat:@"%@/screenshot.png",[self.program projectPath]],
-                               [[NSString alloc] initWithFormat:@"%@/manual_screenshot.png", [self.program projectPath]],
-                               [[NSString alloc] initWithFormat:@"%@/automatic_screenshot.png", [self.program projectPath]]];
+    NSArray *fallbackPaths = @[[[NSString alloc] initWithFormat:@"%@screenshot.png",[self.program projectPath]],
+                               [[NSString alloc] initWithFormat:@"%@manual_screenshot.png", [self.program projectPath]],
+                               [[NSString alloc] initWithFormat:@"%@automatic_screenshot.png", [self.program projectPath]]];
     BOOL fileExists = NO;
     for (NSString *fallbackPath in fallbackPaths) {
         NSString *fileName = [fallbackPath lastPathComponent];
@@ -522,9 +522,11 @@
         UIGraphicsEndImageContext();
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            NSString *pngFilePath = [NSString stringWithFormat:@"%@/automatic_screenshot.png",[self.program projectPath]];
+            NSString *fileName = @"automatic_screenshot.png";
+            NSString *pngFilePath = [NSString stringWithFormat:@"%@%@",[self.program projectPath], fileName];
             NSData *data = [NSData dataWithData:UIImagePNGRepresentation(image)];
             [data writeToFile:pngFilePath atomically:YES];
+            [[RuntimeImageCache sharedImageCache] overwriteThumbnailImageFromDiskWithThumbnailPath:[NSString stringWithFormat:@"%@%@%@",[self.program projectPath], kScreenshotThumbnailPrefix, fileName] image:image thumbnailFrameSize:CGSizeMake(kPreviewImageWidth, kPreviewImageHeight)];
         });
     }
 }
@@ -546,7 +548,9 @@
                                          UIActivityTypePostToVimeo,
                                          UIActivityTypePostToWeibo,
                                          UIActivityTypePostToTwitter,
-                                         UIActivityTypeMail]; //or whichever you don't need
+                                         UIActivityTypeMail,
+                                         UIActivityTypePrint,
+                                         UIActivityTypeCopyToPasteboard]; //or whichever you don't need
     __weak ScenePresenterViewController *weakself = self;
     [activityVC setCompletionWithItemsHandler:^(NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
         SKView *view = weakself.skView;

--- a/src/iOS_Lang/en.lproj/Localizable.strings
+++ b/src/iOS_Lang/en.lproj/Localizable.strings
@@ -1373,6 +1373,9 @@
 "Set Arduino PWM~ pin" = "Set Arduino PWM~ pin";
 
 /* No comment provided by engineer. */
+"Set as Preview Image" = "Set as Preview Image";
+
+/* No comment provided by engineer. */
 "Set background" = "Set background";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
includes following changes

- reload program overview (program name did not get updated before i.e.)
- fix program preview image: overwriting of thumbnails when creating new previews
- rename: "Save to PocketCode" to "Set as Preview Image" for preview image functionality