### PR TITLE
CATTY-58: The function POW doesn't exist in Pocket Code

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -1315,7 +1315,7 @@
 		F4A2AFB72110D49900C53234 /* LetterFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A2AFB62110D49900C53234 /* LetterFunction.swift */; };
 		F4A2AFB92110D4A800C53234 /* LengthFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4A2AFB82110D4A800C53234 /* LengthFunction.swift */; };
 		F4E6E579210DDD5C00D86FE6 /* CosFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E6E578210DDD5C00D86FE6 /* CosFunction.swift */; };
-		F4E6E580210DE61900D86FE6 /* PowFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E6E57F210DE61900D86FE6 /* PowFunction.swift */; };
+		F4E6E580210DE61900D86FE6 /* PowerFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E6E57F210DE61900D86FE6 /* PowerFunction.swift */; };
 		F4E6E584210DFD4300D86FE6 /* TanFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E6E583210DFD4300D86FE6 /* TanFunction.swift */; };
 		F4E6E586210DFE0800D86FE6 /* LnFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E6E585210DFE0800D86FE6 /* LnFunction.swift */; };
 		F4E6E588210DFE8800D86FE6 /* LogFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E6E587210DFE8800D86FE6 /* LogFunction.swift */; };
@@ -3216,7 +3216,7 @@
 		F4A2AFB62110D49900C53234 /* LetterFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterFunction.swift; sourceTree = "<group>"; };
 		F4A2AFB82110D4A800C53234 /* LengthFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LengthFunction.swift; sourceTree = "<group>"; };
 		F4E6E578210DDD5C00D86FE6 /* CosFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CosFunction.swift; sourceTree = "<group>"; };
-		F4E6E57F210DE61900D86FE6 /* PowFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowFunction.swift; sourceTree = "<group>"; };
+		F4E6E57F210DE61900D86FE6 /* PowerFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerFunction.swift; sourceTree = "<group>"; };
 		F4E6E583210DFD4300D86FE6 /* TanFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TanFunction.swift; sourceTree = "<group>"; };
 		F4E6E585210DFE0800D86FE6 /* LnFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LnFunction.swift; sourceTree = "<group>"; };
 		F4E6E587210DFE8800D86FE6 /* LogFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogFunction.swift; sourceTree = "<group>"; };
@@ -5048,7 +5048,7 @@
 			children = (
 				4CE67898210C6EEE00D90B5D /* SinFunction.swift */,
 				F4E6E578210DDD5C00D86FE6 /* CosFunction.swift */,
-				F4E6E57F210DE61900D86FE6 /* PowFunction.swift */,
+				F4E6E57F210DE61900D86FE6 /* PowerFunction.swift */,
 				F4E6E583210DFD4300D86FE6 /* TanFunction.swift */,
 				F4E6E585210DFE0800D86FE6 /* LnFunction.swift */,
 				F4E6E587210DFE8800D86FE6 /* LogFunction.swift */,
@@ -9876,7 +9876,7 @@
 				9218B2111CC4AB75007B4C60 /* PointerTool.m in Sources */,
 				AA74F0CE1BC05FCE00D1E954 /* WhenScriptCell.m in Sources */,
 				5EA1089421B8FBD200B837B9 /* AVAudioSession+Extensions.swift in Sources */,
-				F4E6E580210DE61900D86FE6 /* PowFunction.swift in Sources */,
+				F4E6E580210DE61900D86FE6 /* PowerFunction.swift in Sources */,
 				92FF32B91A24E2F400093DA7 /* DarkBlueGradientCell.m in Sources */,
 				AA74EF551BC0586F00D1E954 /* PointToBrick+CBXMLHandler.m in Sources */,
 				F4201CFB20D7A1060030181B /* TimeMinuteSensor.swift in Sources */,

--- a/src/Catty/Functions/Math/PowerFunction.swift
+++ b/src/Catty/Functions/Math/PowerFunction.swift
@@ -20,8 +20,8 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-class PowFunction: DoubleParameterDoubleFunction {
-    static var tag = "POW"
+class PowerFunction: DoubleParameterDoubleFunction {
+    static var tag = "POWER"
     static var name = "power"
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources

--- a/src/Catty/Settings.bundle/Root.plist
+++ b/src/Catty/Settings.bundle/Root.plist
@@ -30,7 +30,7 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
-			<string>0.6.10</string>
+			<string>0.6.11</string>
 			<key>Key</key>
 			<string>versionNumberSettings</string>
 			<key>Title</key>

--- a/src/Catty/Setup/CatrobatSetup+Functions.swift
+++ b/src/Catty/Setup/CatrobatSetup+Functions.swift
@@ -39,7 +39,7 @@ extension CatrobatSetup {
             AcosFunction(),
             AtanFunction(),
             ExpFunction(),
-            PowFunction(),
+            PowerFunction(),
             FloorFunction(),
             CeilFunction(),
             MaxFunction(),

--- a/src/CattyTests/Formula/FormulaParserTest.m
+++ b/src/CattyTests/Formula/FormulaParserTest.m
@@ -361,7 +361,7 @@
 - (void) testOperatorChain
 {
     NSMutableArray *internTokenList = [[NSMutableArray alloc] init];
-    [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_NAME AndValue:@"POW"]]; // TODO use Function property
+    [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_NAME AndValue:@"POWER"]]; // TODO use Function property
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_PARAMETERS_BRACKET_OPEN]];
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_NUMBER AndValue:@"1"]];
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_OPERATOR AndValue:PlusOperator.tag]];
@@ -384,7 +384,7 @@
     internTokenList = [[NSMutableArray alloc] init];
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_NUMBER AndValue:@"1"]];
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_OPERATOR AndValue:PlusOperator.tag]];
-    [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_NAME AndValue:@"POW"]]; // TODO use Function property
+    [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_NAME AndValue:@"POWER"]]; // TODO use Function property
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_PARAMETERS_BRACKET_OPEN]];
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_NUMBER AndValue:@"2"]];
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_PARAMETER_DELIMITER]];
@@ -426,7 +426,7 @@
     internTokenList = [[NSMutableArray alloc] init];
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_OPERATOR AndValue:MinusOperator.tag]];
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_BRACKET_OPEN]];
-        [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_NAME AndValue:@"POW"]]; // TODO use Function property
+        [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_NAME AndValue:@"POWER"]]; // TODO use Function property
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_PARAMETERS_BRACKET_OPEN]];
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_NUMBER AndValue:@"1"]];
     [internTokenList addObject:[[InternToken alloc] initWithType:TOKEN_TYPE_FUNCTION_PARAMETER_DELIMITER]];

--- a/src/CattyTests/PlayerEngine/Functions/Math/PowFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/PowFunctionTest.swift
@@ -26,11 +26,11 @@ import XCTest
 
 class PowFunctionTest: XCTestCase {
 
-    var function: PowFunction!
+    var function: PowerFunction!
 
     override func setUp() {
         super.setUp()
-        function = PowFunction()
+        function = PowerFunction()
     }
 
     override func tearDown() {
@@ -63,7 +63,7 @@ class PowFunctionTest: XCTestCase {
     }
 
     func testTag() {
-        XCTAssertEqual("POW", type(of: function).tag)
+        XCTAssertEqual("POWER", type(of: function).tag)
     }
 
     func testName() {


### PR DESCRIPTION
Change the .tag attribute of the power function to 'POWER' to be inline with Catroid
Also change class name: PowFunction -> PowerFunction
and filename: PowFunction.swift -> PowerFunction.swift

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#ios-general* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
