### PR TITLE
CATTY-35 Fix division by zero

### DIFF
--- a/src/Catty/PlayerEngine/Formula/FormulaManager+Interpreter.swift
+++ b/src/Catty/PlayerEngine/Formula/FormulaManager+Interpreter.swift
@@ -173,6 +173,15 @@ extension FormulaManager {
             result = formulaElement.value as AnyObject
         }
 
+        if let doubleValue = result as? Double {
+            if doubleValue == Double.infinity {
+                result = Double.greatestFiniteMagnitude as AnyObject
+            }
+            if doubleValue == Double.infinity * (-1) {
+                result = Double.greatestFiniteMagnitude * (-1) as AnyObject
+            }
+        }
+
         if isIdempotent(formulaElement) {
             formulaCache.insert(object: result, forKey: formulaElement)
         }

--- a/src/Catty/Settings.bundle/Root.plist
+++ b/src/Catty/Settings.bundle/Root.plist
@@ -30,7 +30,7 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
-			<string>0.6.10</string>
+			<string>0.6.11</string>
 			<key>Key</key>
 			<string>versionNumberSettings</string>
 			<key>Title</key>

--- a/src/CattyTests/PlayerEngine/AudioEngine/IntegrationTests/AudioPlayerIntegrationTests.swift
+++ b/src/CattyTests/PlayerEngine/AudioEngine/IntegrationTests/AudioPlayerIntegrationTests.swift
@@ -94,7 +94,7 @@ final class AudioPlayerIntegrationTests: AudioEngineAbstractTest {
     func testPlaySoundAndWaitExpectScriptToContinueWhenSoundFinished() {
         let referenceSimHash = "01100011001111101000000011001001"
         let scene = self.createScene(xmlFile: "PlaySoundAndWaitBrickContinueWhenFinished")
-     
+
         // Run program and record
         let recordedTape = self.runAndRecord(duration: 3, scene: scene, muted: true)
 

--- a/src/CattyTests/PlayerEngine/Formula/FormulaManagerInterpreterTests.swift
+++ b/src/CattyTests/PlayerEngine/Formula/FormulaManagerInterpreterTests.swift
@@ -168,10 +168,10 @@ final class FormulaManagerInterpreterTests: XCTestCase {
                                  parent: nil)
 
         formula = Formula(formulaElement: element)!
-        XCTAssertEqual(-Double.infinity, interpreter.interpretDouble(formula, for: object))
+        XCTAssertEqual(-Double.greatestFiniteMagnitude, interpreter.interpretDouble(formula, for: object))
     }
 
-    func testDivisionByZero() {
+    func testDivisionZeroByZero() {
         let leftChild = FormulaElement(double: 0)
         let rightChild = FormulaElement(double: 0)
         let element = FormulaElement(elementType: ElementType.OPERATOR,
@@ -182,6 +182,28 @@ final class FormulaManagerInterpreterTests: XCTestCase {
         let formula = Formula(formulaElement: element)!
 
         XCTAssertTrue(interpreter.interpretDouble(formula, for: object).isNaN)
+    }
+
+    func testDivisionByZeroAndExpectMaxDouble() {
+        let element = FormulaElement(elementType: ElementType.OPERATOR,
+                                     value: DivideOperator.tag,
+                                     leftChild: FormulaElement(double: 1),
+                                     rightChild: FormulaElement(double: 0),
+                                     parent: nil)
+        let formula = Formula(formulaElement: element)!
+
+        XCTAssertEqual(Double.greatestFiniteMagnitude, interpreter.interpretDouble(formula, for: object))
+    }
+
+    func testDivisionNegativeNumberByZeroAndExpectMinDouble() {
+        let element = FormulaElement(elementType: ElementType.OPERATOR,
+                                     value: DivideOperator.tag,
+                                     leftChild: FormulaElement(double: -1),
+                                     rightChild: FormulaElement(double: 0),
+                                     parent: nil)
+        let formula = Formula(formulaElement: element)!
+
+        XCTAssertEqual(-Double.greatestFiniteMagnitude, interpreter.interpretDouble(formula, for: object))
     }
 
     func testDivision() {


### PR DESCRIPTION
Ticket description: 
The evaluation of infinity differs between Catroid and Catty:
1/0 = -Double.MAX_VALUE in Catroid and "inf" in Catty
-1/0 = -Double.MAX_VALUE in Catroid and "-inf" in Catty

Added Tests for -1/0 and 1/0. Returned double.greatestFiniteMagnitude instead of "inf".

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#ios-general* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
