### PR TITLE
CATTY-126 add enumeration for downloaded projects with same name

### DIFF
--- a/src/Catty/ViewController/Download/ProjectDetailStoreViewController.m
+++ b/src/Catty/ViewController/Download/ProjectDetailStoreViewController.m
@@ -311,7 +311,8 @@
     [self.projectView viewWithTag:kDownloadButtonTag].hidden = YES;
     button.hidden = NO;
     button.progress = 0;
-    [self downloadWithName:self.project.name];
+    self.duplicateName = [Util uniqueName:self.project.name existingNames:[Project allProjectNames]];
+    [self downloadWithName:self.duplicateName];
 }
 
 - (void)downloadButtonPressed:(id)sender


### PR DESCRIPTION
added enumeration for downloaded projects with the same name (e.g. "Galaxy War" and "Galaxy War (1)" instead of both having the same name)


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#ios-general* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
