### PR TITLE
CATTY-122 Order elements in FormulaEditor

### DIFF
--- a/src/Catty/Functions/List/ContainsFunction.swift
+++ b/src/Catty/Functions/List/ContainsFunction.swift
@@ -26,7 +26,7 @@ class ContainsFunction: DoubleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = false
-    static let position = 260
+    static let position = 60
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/List/ElementFunction.swift
+++ b/src/Catty/Functions/List/ElementFunction.swift
@@ -26,7 +26,7 @@ class ElementFunction: DoubleParameterFunction {
     static var defaultValue = "" as AnyObject
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = false
-    static let position = 250
+    static let position = 40
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/List/NumberOfItemsFunction.swift
+++ b/src/Catty/Functions/List/NumberOfItemsFunction.swift
@@ -27,7 +27,7 @@ class NumberOfItemsFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = false
-    static let position = 240
+    static let position = 50
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/AbsFunction.swift
+++ b/src/Catty/Functions/Math/AbsFunction.swift
@@ -27,7 +27,7 @@ class AbsFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 90
+    static let position = 110
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/AcosFunction.swift
+++ b/src/Catty/Functions/Math/AcosFunction.swift
@@ -27,7 +27,7 @@ class AcosFunction: SingleParameterDoubleFunction {
     static var defaultValue = Double.pi / 2
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 130
+    static let position = 190
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/AsinFunction.swift
+++ b/src/Catty/Functions/Math/AsinFunction.swift
@@ -27,7 +27,7 @@ class AsinFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 120
+    static let position = 180
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/AtanFunction.swift
+++ b/src/Catty/Functions/Math/AtanFunction.swift
@@ -27,7 +27,7 @@ class AtanFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 140
+    static let position = 200
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/CeilFunction.swift
+++ b/src/Catty/Functions/Math/CeilFunction.swift
@@ -27,7 +27,7 @@ class CeilFunction: SingleParameterDoubleFunction {
     static var defaultValue = 1.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 180
+    static let position = 240
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/CosFunction.swift
+++ b/src/Catty/Functions/Math/CosFunction.swift
@@ -27,7 +27,7 @@ class CosFunction: SingleParameterDoubleFunction {
     static var defaultValue = 1.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 20
+    static let position = 160
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/ExpFunction.swift
+++ b/src/Catty/Functions/Math/ExpFunction.swift
@@ -27,7 +27,7 @@ class ExpFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 150
+    static let position = 270
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/FalseFunction.swift
+++ b/src/Catty/Functions/Math/FalseFunction.swift
@@ -26,7 +26,7 @@ class FalseFunction: ZeroParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 310
+    static let position = 30
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/FloorFunction.swift
+++ b/src/Catty/Functions/Math/FloorFunction.swift
@@ -26,7 +26,7 @@ class FloorFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 170
+    static let position = 210
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/LnFunction.swift
+++ b/src/Catty/Functions/Math/LnFunction.swift
@@ -27,7 +27,7 @@ class LnFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 40
+    static let position = 260
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/LogFunction.swift
+++ b/src/Catty/Functions/Math/LogFunction.swift
@@ -27,7 +27,7 @@ class LogFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 50
+    static let position = 250
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/MaxFunction.swift
+++ b/src/Catty/Functions/Math/MaxFunction.swift
@@ -26,7 +26,7 @@ class MaxFunction: DoubleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 190
+    static let position = 220
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/MinFunction.swift
+++ b/src/Catty/Functions/Math/MinFunction.swift
@@ -26,7 +26,7 @@ class MinFunction: DoubleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 200
+    static let position = 230
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/ModFunction.swift
+++ b/src/Catty/Functions/Math/ModFunction.swift
@@ -26,7 +26,7 @@ class ModFunction: DoubleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 110
+    static let position = 70
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/PiFunction.swift
+++ b/src/Catty/Functions/Math/PiFunction.swift
@@ -26,7 +26,7 @@ class PiFunction: ZeroParameterDoubleFunction {
     static var defaultValue = Double.pi
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 60
+    static let position = 280
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/PowerFunction.swift
+++ b/src/Catty/Functions/Math/PowerFunction.swift
@@ -26,7 +26,7 @@ class PowerFunction: DoubleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 160
+    static let position = 130
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/RandFunction.swift
+++ b/src/Catty/Functions/Math/RandFunction.swift
@@ -26,7 +26,7 @@ class RandFunction: DoubleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = false
-    static let position = 80
+    static let position = 10
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/RoundFunction.swift
+++ b/src/Catty/Functions/Math/RoundFunction.swift
@@ -27,7 +27,7 @@ class RoundFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 100
+    static let position = 120
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/SinFunction.swift
+++ b/src/Catty/Functions/Math/SinFunction.swift
@@ -27,7 +27,7 @@ class SinFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 10
+    static let position = 150
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/SqrtFunction.swift
+++ b/src/Catty/Functions/Math/SqrtFunction.swift
@@ -27,7 +27,7 @@ class SqrtFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 70
+    static let position = 140
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/TanFunction.swift
+++ b/src/Catty/Functions/Math/TanFunction.swift
@@ -27,7 +27,7 @@ class TanFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 30
+    static let position = 170
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Math/TrueFunction.swift
+++ b/src/Catty/Functions/Math/TrueFunction.swift
@@ -26,7 +26,7 @@ class TrueFunction: ZeroParameterDoubleFunction {
     static var defaultValue = 1.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 300
+    static let position = 20
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Text/JoinFunction.swift
+++ b/src/Catty/Functions/Text/JoinFunction.swift
@@ -26,7 +26,7 @@ class JoinFunction: DoubleParameterStringFunction {
     static var defaultValue = ""
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 230
+    static let position = 80
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Text/LengthFunction.swift
+++ b/src/Catty/Functions/Text/LengthFunction.swift
@@ -27,7 +27,7 @@ class LengthFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 210
+    static let position = 100
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Text/LetterFunction.swift
+++ b/src/Catty/Functions/Text/LetterFunction.swift
@@ -26,7 +26,7 @@ class LetterFunction: DoubleParameterStringFunction {
     static var defaultValue = ""
     static var requiredResource = ResourceType.noResources
     static var isIdempotent = true
-    static let position = 220
+    static let position = 90
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/Functions/Touch/MultiFingerTouchedFunction.swift
+++ b/src/Catty/Functions/Touch/MultiFingerTouchedFunction.swift
@@ -27,7 +27,7 @@ class MultiFingerTouchedFunction: SingleParameterDoubleFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.touchHandler
     static var isIdempotent = false
-    static let position = 180
+    static let position = 70
 
     let getTouchManager: () -> TouchManagerProtocol?
 

--- a/src/Catty/Functions/Touch/MultiFingerXFunction.swift
+++ b/src/Catty/Functions/Touch/MultiFingerXFunction.swift
@@ -27,7 +27,7 @@ class MultiFingerXFunction: SingleParameterDoubleObjectFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.touchHandler
     static var isIdempotent = false
-    static let position = 160
+    static let position = 80
 
     let getTouchManager: () -> TouchManagerProtocol?
 

--- a/src/Catty/Functions/Touch/MultiFingerYFunction.swift
+++ b/src/Catty/Functions/Touch/MultiFingerYFunction.swift
@@ -27,7 +27,7 @@ class MultiFingerYFunction: SingleParameterDoubleObjectFunction {
     static var defaultValue = 0.0
     static var requiredResource = ResourceType.touchHandler
     static var isIdempotent = false
-    static let position = 170
+    static let position = 90
 
     let getTouchManager: () -> TouchManagerProtocol?
 

--- a/src/Catty/Operators/Binary/EqualOperator.swift
+++ b/src/Catty/Operators/Binary/EqualOperator.swift
@@ -25,7 +25,7 @@
     @objc static var tag = "EQUAL"
     static var name = "="
     static var priority = 3
-    static var position = 2
+    static var position = 1
 
     func value(left: AnyObject, right: AnyObject) -> Bool {
         let leftDouble = doubleParameter(object: left)

--- a/src/Catty/Operators/Binary/NotEqualOperator.swift
+++ b/src/Catty/Operators/Binary/NotEqualOperator.swift
@@ -25,7 +25,7 @@
     @objc static var tag = "NOT_EQUAL"
     static var name = "≠"
     static var priority = 4
-    static var position = 1
+    static var position = 2
 
     func value(left: AnyObject, right: AnyObject) -> Bool {
         let leftDouble = doubleParameter(object: left)

--- a/src/Catty/PlayerEngine/Sensors/Audio/LoudnessSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Audio/LoudnessSensor.swift
@@ -24,7 +24,7 @@
     @objc static let tag = "LOUDNESS"
     static let name = kUIFESensorLoudness
     static let defaultRawValue = -160.0
-    static let position = 10
+    static let position = 170
     static let requiredResource = ResourceType.loudness
 
     let getAudioManager: () -> AudioManagerProtocol?

--- a/src/Catty/PlayerEngine/Sensors/Camera/FaceDetectedSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FaceDetectedSensor.swift
@@ -25,7 +25,7 @@ class FaceDetectedSensor: DeviceSensor {
     static let tag = "FACE_DETECTED"
     static let name = kUIFESensorFaceDetected
     static let defaultRawValue = 0.0
-    static let position = 190
+    static let position = 220
     static let requiredResource = ResourceType.faceDetection
 
     let getFaceDetectionManager: () -> FaceDetectionManagerProtocol?

--- a/src/Catty/PlayerEngine/Sensors/Camera/FacePositionXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FacePositionXSensor.swift
@@ -25,7 +25,7 @@ class FacePositionXSensor: DeviceSensor {
     static let tag = "FACE_X_POSITION"
     static let name = kUIFESensorFaceX
     static let defaultRawValue = 0.0
-    static let position = 210
+    static let position = 230
     static let requiredResource = ResourceType.faceDetection
 
     let getFaceDetectionManager: () -> FaceDetectionManagerProtocol?

--- a/src/Catty/PlayerEngine/Sensors/Camera/FacePositionYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FacePositionYSensor.swift
@@ -25,7 +25,7 @@ class FacePositionYSensor: DeviceSensor {
     static let tag = "FACE_Y_POSITION"
     static let name = kUIFESensorFaceY
     static let defaultRawValue = 0.0
-    static let position = 220
+    static let position = 240
     static let requiredResource = ResourceType.faceDetection
 
     let getFaceDetectionManager: () -> FaceDetectionManagerProtocol?

--- a/src/Catty/PlayerEngine/Sensors/Camera/FaceSizeSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FaceSizeSensor.swift
@@ -25,7 +25,7 @@ class FaceSizeSensor: DeviceSensor {
     static let tag = "FACE_SIZE"
     static let name = kUIFESensorFaceSize
     static let defaultRawValue = 0.0
-    static let position = 200
+    static let position = 250
     static let requiredResource = ResourceType.faceDetection
 
     let getFaceDetectionManager: () -> FaceDetectionManagerProtocol?

--- a/src/Catty/PlayerEngine/Sensors/Date/DateDaySensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/DateDaySensor.swift
@@ -25,7 +25,7 @@ class DateDaySensor: DateSensor {
     static let tag = "DATE_DAY"
     static let name = kUIFESensorDateDay
     static let defaultRawValue = 0.0
-    static let position = 250
+    static let position = 120
     static let requiredResource = ResourceType.noResources
 
     func date() -> Date {

--- a/src/Catty/PlayerEngine/Sensors/Date/DateMonthSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/DateMonthSensor.swift
@@ -25,7 +25,7 @@ class DateMonthSensor: DateSensor {
     static let tag = "DATE_MONTH"
     static let name = kUIFESensorDateMonth
     static let defaultRawValue = 0.0
-    static let position = 240
+    static let position = 110
     static let requiredResource = ResourceType.noResources
 
     func date() -> Date {

--- a/src/Catty/PlayerEngine/Sensors/Date/DateWeekdaySensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/DateWeekdaySensor.swift
@@ -25,7 +25,7 @@ class DateWeekdaySensor: DateSensor {
     static let tag = "DATE_WEEKDAY"
     static let name = kUIFESensorDateWeekday
     static let defaultRawValue = 0.0
-    static let position = 260
+    static let position = 130
     static let requiredResource = ResourceType.noResources
 
     func date() -> Date {

--- a/src/Catty/PlayerEngine/Sensors/Date/DateYearSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/DateYearSensor.swift
@@ -25,7 +25,7 @@ class DateYearSensor: DateSensor {
     static let tag = "DATE_YEAR"
     static let name = kUIFESensorDateYear
     static let defaultRawValue = 0.0
-    static let position = 230
+    static let position = 100
     static let requiredResource = ResourceType.noResources
 
     func date() -> Date {

--- a/src/Catty/PlayerEngine/Sensors/Date/TimeHourSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/TimeHourSensor.swift
@@ -25,7 +25,7 @@ class TimeHourSensor: DateSensor {
     static let tag = "TIME_HOUR"
     static let name = kUIFESensorTimeHour
     static let defaultRawValue = 0.0
-    static let position = 270
+    static let position = 140
     static let requiredResource = ResourceType.noResources
 
     func date() -> Date {

--- a/src/Catty/PlayerEngine/Sensors/Date/TimeMinuteSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/TimeMinuteSensor.swift
@@ -25,7 +25,7 @@ class TimeMinuteSensor: DateSensor {
     static let tag = "TIME_MINUTE"
     static let name = kUIFESensorTimeMinute
     static let defaultRawValue = 0.0
-    static let position = 280
+    static let position = 150
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Date/TimeSecondSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/TimeSecondSensor.swift
@@ -25,7 +25,7 @@ class TimeSecondSensor: DateSensor {
     static let tag = "TIME_SECOND"
     static let name = kUIFESensorTimeSecond
     static let defaultRawValue = 0.0
-    static let position = 290
+    static let position = 160
     static let requiredResource = ResourceType.noResources
 
     func date() -> Date {

--- a/src/Catty/PlayerEngine/Sensors/Heading/CompassDirectionSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Heading/CompassDirectionSensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "COMPASS_DIRECTION"
     static let name = kUIFESensorCompass
     static let defaultRawValue = 0.0
-    static let position = 70
+    static let position = 180
     static let requiredResource = ResourceType.compass
 
     let getLocationManager: () -> LocationManager?

--- a/src/Catty/PlayerEngine/Sensors/Location/AltitudeSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Location/AltitudeSensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "ALTITUDE"
     static let name = kUIFESensorAltitude
     static let defaultRawValue = 0.0
-    static let position = 110
+    static let position = 290
     static let requiredResource = ResourceType.location
 
     let getLocationManager: () -> LocationManager?

--- a/src/Catty/PlayerEngine/Sensors/Location/LatitudeSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Location/LatitudeSensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "LATITUDE"
     static let name = kUIFESensorLatitude
     static let defaultRawValue = 0.0
-    static let position = 80
+    static let position = 280
     static let requiredResource = ResourceType.location
 
     let getLocationManager: () -> LocationManager?

--- a/src/Catty/PlayerEngine/Sensors/Location/LocationAccuracySensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Location/LocationAccuracySensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "LOCATION_ACCURACY"
     static let name = kUIFESensorLocationAccuracy
     static let defaultRawValue = 0.0
-    static let position = 100
+    static let position = 260
     static let requiredResource = ResourceType.location
 
     let getLocationManager: () -> LocationManager?

--- a/src/Catty/PlayerEngine/Sensors/Location/LongitudeSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Location/LongitudeSensor.swift
@@ -25,7 +25,7 @@ class LongitudeSensor: NSObject, DeviceSensor {
     @objc static let tag = "LONGITUDE"
     static let name = kUIFESensorLongitude
     static let defaultRawValue = 0.0
-    static let position = 90
+    static let position = 270
     static let requiredResource = ResourceType.location
 
     let getLocationManager: () -> LocationManager?

--- a/src/Catty/PlayerEngine/Sensors/Motion/AccelerationXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/AccelerationXSensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "X_ACCELERATION"
     static let name = kUIFESensorAccelerationX
     static let defaultRawValue = 0.0
-    static let position = 20
+    static let position = 190
     static let requiredResource = ResourceType.deviceMotion
 
     let getMotionManager: () -> MotionManager?

--- a/src/Catty/PlayerEngine/Sensors/Motion/AccelerationYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/AccelerationYSensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "Y_ACCELERATION"
     static let name = kUIFESensorAccelerationY
     static let defaultRawValue = 0.0
-    static let position = 30
+    static let position = 200
     static let requiredResource = ResourceType.deviceMotion
 
     let getMotionManager: () -> MotionManager?

--- a/src/Catty/PlayerEngine/Sensors/Motion/AccelerationZSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/AccelerationZSensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "Z_ACCELERATION"
     static let name = kUIFESensorAccelerationZ
     static let defaultRawValue = 0.0
-    static let position = 40
+    static let position = 210
     static let requiredResource = ResourceType.deviceMotion
 
     let getMotionManager: () -> MotionManager?

--- a/src/Catty/PlayerEngine/Sensors/Object/BackgroundNameSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/BackgroundNameSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFEObjectBackgroundName
     static let defaultRawValue = 0.0
     static let defaultStringValue = ""
-    static let position = 50
+    static let position = 100
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Object/BackgroundNumberSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/BackgroundNumberSensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "OBJECT_BACKGROUND_NUMBER"
     static let name = kUIFEObjectBackgroundNumber
     static let defaultRawValue = 0.0
-    static let position = 40
+    static let position = 80
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Object/BrightnessSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/BrightnessSensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "OBJECT_BRIGHTNESS"
     static let name = kUIFEObjectBrightness
     @objc static let defaultRawValue = 0.0
-    static let position = 20
+    static let position = 90
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Object/ColorSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/ColorSensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "OBJECT_COLOR"
     static let name = kUIFEObjectColor
     @objc static let defaultRawValue = 0.0
-    static let position = 30
+    static let position = 110
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Object/LayerSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/LayerSensor.swift
@@ -25,7 +25,7 @@
     static let tag = "OBJECT_LAYER"
     static let name = kUIFEObjectLayer
     static let defaultRawValue = 0.0
-    static let position = 100
+    static let position = 120
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Object/LookNameSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/LookNameSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFEObjectLookName
     static let defaultRawValue = 0.0
     static let defaultStringValue = ""
-    static let position = 50
+    static let position = 40
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Object/LookNumberSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/LookNumberSensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "OBJECT_LOOK_NUMBER"
     static let name = kUIFEObjectLookNumber
     static let defaultRawValue = 0.0
-    static let position = 40
+    static let position = 30
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Object/PositionXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/PositionXSensor.swift
@@ -25,7 +25,7 @@ class PositionXSensor: ObjectDoubleSensor {
     static let tag = "OBJECT_X"
     static let name = kUIFEObjectPositionX
     static let defaultRawValue = 0.0
-    static let position = 60
+    static let position = 20
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Object/PositionYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/PositionYSensor.swift
@@ -25,7 +25,7 @@ class PositionYSensor: ObjectDoubleSensor {
     static let tag = "OBJECT_Y"
     static let name = kUIFEObjectPositionY
     static let defaultRawValue = 0.0
-    static let position = 70
+    static let position = 10
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Object/RotationSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/RotationSensor.swift
@@ -28,7 +28,7 @@
     static let requiredResource = ResourceType.noResources
     static let rotationDegreeOffset = 90.0
     static let circleMaxDegrees = 360.0
-    static let position = 90
+    static let position = 60
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/PlayerEngine/Sensors/Object/SizeSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/SizeSensor.swift
@@ -26,7 +26,7 @@ class SizeSensor: ObjectDoubleSensor {
     static let name = kUIFEObjectSize
     static let defaultRawValue = 1.0
     static let requiredResource = ResourceType.noResources
-    static let position = 80
+    static let position = 50
 
     func tag() -> String {
         return type(of: self).tag

--- a/src/Catty/PlayerEngine/Sensors/Object/TransparencySensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/TransparencySensor.swift
@@ -25,7 +25,7 @@
     @objc static let tag = "OBJECT_GHOSTEFFECT"
     static let name = kUIFEObjectTransparency
     @objc static let defaultRawValue = 1.0
-    static let position = 10
+    static let position = 70
     static let requiredResource = ResourceType.noResources
 
     func tag() -> String {

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomLeftSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomLeftSensor.swift
@@ -27,7 +27,7 @@
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
     static let pinNumber = 2
-    static let position = 340
+    static let position = 310
 
     let getBluetoothService: () -> BluetoothService?
 

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomRightSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomRightSensor.swift
@@ -27,7 +27,7 @@
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
     static let pinNumber = 3
-    static let position = 350
+    static let position = 300
 
     let getBluetoothService: () -> BluetoothService?
 

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontLeftSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontLeftSensor.swift
@@ -27,7 +27,7 @@
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
     static let pinNumber = 0
-    static let position = 300
+    static let position = 330
 
     let getBluetoothService: () -> BluetoothService?
 

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontRightSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontRightSensor.swift
@@ -27,7 +27,7 @@
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
     static let pinNumber = 1
-    static let position = 310
+    static let position = 350
 
     let getBluetoothService: () -> BluetoothService?
 

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideLeftSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideLeftSensor.swift
@@ -27,7 +27,7 @@
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
     static let pinNumber = 4
-    static let position = 320
+    static let position = 340
 
     let getBluetoothService: () -> BluetoothService?
 

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideRightSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideRightSensor.swift
@@ -27,7 +27,7 @@
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
     static let pinNumber = 5
-    static let position = 330
+    static let position = 320
 
     let getBluetoothService: () -> BluetoothService?
 

--- a/src/Catty/PlayerEngine/Sensors/Touch/FingerTouchedSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Touch/FingerTouchedSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorFingerTouched
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.touchHandler
-    static let position = 120
+    static let position = 10
 
     let getTouchManager: () -> TouchManagerProtocol?
 

--- a/src/Catty/PlayerEngine/Sensors/Touch/FingerXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Touch/FingerXSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorFingerX
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.touchHandler
-    static let position = 130
+    static let position = 20
 
     let getTouchManager: () -> TouchManagerProtocol?
 

--- a/src/Catty/PlayerEngine/Sensors/Touch/FingerYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Touch/FingerYSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorFingerY
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.touchHandler
-    static let position = 140
+    static let position = 30
 
     let getTouchManager: () -> TouchManagerProtocol?
 

--- a/src/Catty/PlayerEngine/Sensors/Touch/LastFingerIndexSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Touch/LastFingerIndexSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorLastFingerIndex
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.touchHandler
-    static let position = 150
+    static let position = 40
 
     let getTouchManager: () -> TouchManagerProtocol?
 

--- a/src/Catty/Resources/Localization/af.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/af.lproj/Localizable.strings
@@ -989,6 +989,9 @@
 "No description available" = "No description available";
 
 /* No comment provided by engineer. */
+"Please enter at least %lu character(s)." = "Please enter at least %lu character(s).";
+
+/* No comment provided by engineer. */
 "No or invalid image name entered, try again." = "No or invalid image name entered, try again.";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
The order of the keys in the central area in the formula editor for the subcategories for math, object, logic and sensors should be shown in a different order, by bringing them in the order in which they are used most.
@robertpainsi has analyzed the usage of formula elements in uploaded projects on http://robertpainsi.github.io/catrobat/statistics/?period=overall#Formula-usage.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
