### PR TITLE
CATTY-143 Change math function default values

### DIFF
--- a/src/Catty/Functions/Math/AbsFunction.swift
+++ b/src/Catty/Functions/Math/AbsFunction.swift
@@ -34,7 +34,7 @@ class AbsFunction: SingleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 1)
     }
 
     func value(parameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/AsinFunction.swift
+++ b/src/Catty/Functions/Math/AsinFunction.swift
@@ -34,7 +34,7 @@ class AsinFunction: SingleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 0.5)
     }
 
     func value(parameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/AtanFunction.swift
+++ b/src/Catty/Functions/Math/AtanFunction.swift
@@ -34,7 +34,7 @@ class AtanFunction: SingleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 1)
     }
 
     func value(parameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/CosFunction.swift
+++ b/src/Catty/Functions/Math/CosFunction.swift
@@ -34,7 +34,7 @@ class CosFunction: SingleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 360)
     }
 
     func value(parameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/LnFunction.swift
+++ b/src/Catty/Functions/Math/LnFunction.swift
@@ -34,7 +34,7 @@ class LnFunction: SingleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 2.718281828459)
     }
 
     func value(parameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/LogFunction.swift
+++ b/src/Catty/Functions/Math/LogFunction.swift
@@ -34,7 +34,7 @@ class LogFunction: SingleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 10)
     }
 
     func value(parameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/MaxFunction.swift
+++ b/src/Catty/Functions/Math/MaxFunction.swift
@@ -33,11 +33,11 @@ class MaxFunction: DoubleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 5)
     }
 
     func secondParameter() -> FunctionParameter {
-        return .number(defaultValue: 1)
+        return .number(defaultValue: 4)
     }
 
     func value(firstParameter: AnyObject?, secondParameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/MinFunction.swift
+++ b/src/Catty/Functions/Math/MinFunction.swift
@@ -33,11 +33,11 @@ class MinFunction: DoubleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 7)
     }
 
     func secondParameter() -> FunctionParameter {
-        return .number(defaultValue: 1)
+        return .number(defaultValue: 2)
     }
 
     func value(firstParameter: AnyObject?, secondParameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/ModFunction.swift
+++ b/src/Catty/Functions/Math/ModFunction.swift
@@ -33,11 +33,11 @@ class ModFunction: DoubleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 1)
+        return .number(defaultValue: 3)
     }
 
     func secondParameter() -> FunctionParameter {
-        return .number(defaultValue: 1)
+        return .number(defaultValue: 2)
     }
 
     func value(firstParameter: AnyObject?, secondParameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/RandFunction.swift
+++ b/src/Catty/Functions/Math/RandFunction.swift
@@ -33,11 +33,11 @@ class RandFunction: DoubleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 1)
     }
 
     func secondParameter() -> FunctionParameter {
-        return .number(defaultValue: 1)
+        return .number(defaultValue: 6)
     }
 
     func value(firstParameter: AnyObject?, secondParameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/RoundFunction.swift
+++ b/src/Catty/Functions/Math/RoundFunction.swift
@@ -34,7 +34,7 @@ class RoundFunction: SingleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 1.6)
     }
 
     func value(parameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/SinFunction.swift
+++ b/src/Catty/Functions/Math/SinFunction.swift
@@ -34,7 +34,7 @@ class SinFunction: SingleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 90)
     }
 
     func value(parameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/SqrtFunction.swift
+++ b/src/Catty/Functions/Math/SqrtFunction.swift
@@ -34,7 +34,7 @@ class SqrtFunction: SingleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 4)
     }
 
     func value(parameter: AnyObject?) -> Double {

--- a/src/Catty/Functions/Math/TanFunction.swift
+++ b/src/Catty/Functions/Math/TanFunction.swift
@@ -34,7 +34,7 @@ class TanFunction: SingleParameterDoubleFunction {
     }
 
     func firstParameter() -> FunctionParameter {
-        return .number(defaultValue: 0)
+        return .number(defaultValue: 45)
     }
 
     func value(parameter: AnyObject?) -> Double {

--- a/src/CattyTests/PlayerEngine/Functions/Math/AbsFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/AbsFunctionTest.swift
@@ -50,7 +50,7 @@ class AbsFunctionTest: XCTestCase {
     }
 
     func testParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 1), function.firstParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/AsinFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/AsinFunctionTest.swift
@@ -50,7 +50,7 @@ class AsinFunctionTest: XCTestCase {
     }
 
     func testParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 0.5), function.firstParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/AtanFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/AtanFunctionTest.swift
@@ -50,7 +50,7 @@ class AtanFunctionTest: XCTestCase {
     }
 
     func testParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 1), function.firstParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/CosFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/CosFunctionTest.swift
@@ -50,7 +50,7 @@ class CosFunctionTest: XCTestCase {
     }
 
     func testParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 360), function.firstParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/LnFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/LnFunctionTest.swift
@@ -50,7 +50,7 @@ class LnFunctionTest: XCTestCase {
     }
 
     func testParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 2.718281828459), function.firstParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/LogFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/LogFunctionTest.swift
@@ -50,7 +50,7 @@ class LogFunctionTest: XCTestCase {
     }
 
     func testParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 10), function.firstParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/MaxFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/MaxFunctionTest.swift
@@ -53,11 +53,11 @@ class MaxFunctionTest: XCTestCase {
     }
 
     func testFirstParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 5), function.firstParameter())
     }
 
     func testSecondParameter() {
-        XCTAssertEqual(.number(defaultValue: 1), function.secondParameter())
+        XCTAssertEqual(.number(defaultValue: 4), function.secondParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/MinFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/MinFunctionTest.swift
@@ -53,11 +53,11 @@ class MinFunctionTest: XCTestCase {
     }
 
     func testFirstParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 7), function.firstParameter())
     }
 
     func testSecondParameter() {
-        XCTAssertEqual(.number(defaultValue: 1), function.secondParameter())
+        XCTAssertEqual(.number(defaultValue: 2), function.secondParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/ModFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/ModFunctionTest.swift
@@ -71,11 +71,11 @@ class ModFunctionTest: XCTestCase {
     }
 
     func testFirstParameter() {
-        XCTAssertEqual(.number(defaultValue: 1), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 3), function.firstParameter())
     }
 
     func testSecondParameter() {
-        XCTAssertEqual(.number(defaultValue: 1), function.secondParameter())
+        XCTAssertEqual(.number(defaultValue: 2), function.secondParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/RandFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/RandFunctionTest.swift
@@ -118,11 +118,11 @@ class RandFunctionTest: XCTestCase {
     }
 
     func testFirstParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 1), function.firstParameter())
     }
 
     func testSecondParameter() {
-        XCTAssertEqual(.number(defaultValue: 1), function.secondParameter())
+        XCTAssertEqual(.number(defaultValue: 6), function.secondParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/RoundFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/RoundFunctionTest.swift
@@ -50,7 +50,7 @@ class RoundFunctionTest: XCTestCase {
     }
 
     func testParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 1.6), function.firstParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/SinFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/SinFunctionTest.swift
@@ -50,7 +50,7 @@ class SinFunctionTest: XCTestCase {
     }
 
     func testParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 90), function.firstParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/SqrtFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/SqrtFunctionTest.swift
@@ -50,7 +50,7 @@ class SqrtFunctionTest: XCTestCase {
     }
 
     func testParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 4), function.firstParameter())
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Functions/Math/TanFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Math/TanFunctionTest.swift
@@ -50,7 +50,7 @@ class TanFunctionTest: XCTestCase {
     }
 
     func testParameter() {
-        XCTAssertEqual(.number(defaultValue: 0), function.firstParameter())
+        XCTAssertEqual(.number(defaultValue: 45), function.firstParameter())
     }
 
     func testTag() {


### PR DESCRIPTION
Change default values of math functions like in catroid
e.g. sin(0) -> sin(90) 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
