### PR TITLE
CATTY-138 Remove warnings for Nimble

### DIFF
--- a/src/CattyTests/PlayerEngine/AudioEngine/UnitTests/AudioPlayerTests.swift
+++ b/src/CattyTests/PlayerEngine/AudioEngine/UnitTests/AudioPlayerTests.swift
@@ -59,7 +59,7 @@ final class AudioPlayerTests: XCTestCase {
     func testPlayDiscardedPlayerExpectPlayerNotToPlay() {
         player.isDiscarded = true
         player.play(expectation: nil)
-        expect(self.player.akPlayer.isPlaying).to(beFalse())
+        expect(self.player.akPlayer.isPlaying) == false
     }
 
     func testStopExpectWaitExpectationToBeFulfilled() {
@@ -70,26 +70,26 @@ final class AudioPlayerTests: XCTestCase {
         player.stop()
 
         expect(soundIsFinishedExpectation.isFulfilled).toEventually(beTrue(), timeout: 3)
-        expect(self.player.akPlayer.isPlaying).to(beFalse())
+        expect(self.player.akPlayer.isPlaying) == false
     }
 
     func testPause() {
         player.play(expectation: nil)
-        expect(self.player.akPlayer.isPlaying).to(beTrue())
+        expect(self.player.akPlayer.isPlaying) == true
         player.pause()
-        expect(self.player.akPlayer.isPaused).to(beTrue())
-        expect(self.player.isPaused).to(beTrue())
+        expect(self.player.akPlayer.isPaused) == true
+        expect(self.player.isPaused) == true
         player.stop()
     }
 
     func testResume() {
         player.play(expectation: nil)
-        expect(self.player.akPlayer.isPlaying).to(beTrue())
+        expect(self.player.akPlayer.isPlaying) == true
         player.pause()
-        expect(self.player.akPlayer.isPaused).to(beTrue())
-        expect(self.player.isPaused).to(beTrue())
+        expect(self.player.akPlayer.isPaused) == true
+        expect(self.player.isPaused) == true
         player.resume()
-        expect(self.player.akPlayer.isPlaying).to(beTrue())
+        expect(self.player.akPlayer.isPlaying) == true
         player.stop()
     }
 
@@ -98,10 +98,10 @@ final class AudioPlayerTests: XCTestCase {
 
         expect(self.player.akPlayer.connectionPoints.count) == 1
         player.play(expectation: soundIsFinishedExpectation)
-        expect(self.player.akPlayer.isPlaying).to(beTrue())
+        expect(self.player.akPlayer.isPlaying) == true
         player.remove()
         expect(soundIsFinishedExpectation.isFulfilled).toEventually(beTrue(), timeout: 3)
-        expect(self.player.akPlayer.isPlaying).to(beFalse())
+        expect(self.player.akPlayer.isPlaying) == false
         expect(self.player.akPlayer.connectionPoints.count) == 0
     }
 }

--- a/src/CattyTests/PlayerEngine/AudioEngine/UnitTests/SpeechSynthesizerTests.swift
+++ b/src/CattyTests/PlayerEngine/AudioEngine/UnitTests/SpeechSynthesizerTests.swift
@@ -63,7 +63,7 @@ final class SpeechSynthesizerTests: XCTestCase {
         speechSynth.finishedSpeakingExpectationTuple = previousExpectationTuple
 
         speechSynth.speak(newUtterance, expectation: nil)
-        expect(self.currentUtteranceExpectation.isFulfilled).to(beTrue())
+        expect(self.currentUtteranceExpectation.isFulfilled) == true
         XCTAssertNil(speechSynth.finishedSpeakingExpectationTuple)
     }
 
@@ -71,8 +71,8 @@ final class SpeechSynthesizerTests: XCTestCase {
         speechSynth.finishedSpeakingExpectationTuple = previousExpectationTuple
 
         speechSynth.speak(newUtterance, expectation: newUtteranceExpectation)
-        expect(self.currentUtteranceExpectation.isFulfilled).to(beTrue())
-        expect(self.newUtteranceExpectation.isFulfilled).to(beFalse())
+        expect(self.currentUtteranceExpectation.isFulfilled) == true
+        expect(self.newUtteranceExpectation.isFulfilled) == false
         expect(self.speechSynth.finishedSpeakingExpectationTuple?.0) === newUtterance
         expect(self.speechSynth.finishedSpeakingExpectationTuple?.1) === newUtteranceExpectation
     }


### PR DESCRIPTION
Removed the warnings for Nimble by replacing „free matcher functions“ by „operator overloads“.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
