### PR TITLE
CATTY-162 Remove "easter egg" for Crashlytics

### DIFF
--- a/src/Catty/ViewController/CatrobatTableViewController/AboutPocketCodeOptionTableViewController.m
+++ b/src/Catty/ViewController/CatrobatTableViewController/AboutPocketCodeOptionTableViewController.m
@@ -34,15 +34,9 @@
     self.view.tintColor = UIColor.globalTint;
     [self addSection:[BOTableViewSection sectionWithHeaderTitle:@"" handler:^(BOTableViewSection *section) {
         
-        BOTableViewCell *cell = [BOTableViewCell cellWithTitle:kLocalizedAboutPocketCodeDescription key:nil handler:^(BOButtonTableViewCell *cell) {
+        [section addCell:[BOTableViewCell cellWithTitle:kLocalizedAboutPocketCodeDescription key:nil handler:^(BOButtonTableViewCell *cell) {
             cell.backgroundColor = UIColor.background;
-        }];
-        
-        UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(aboutPocketCodeDescriptionTapped:)];
-        tapRecognizer.numberOfTapsRequired = 4;
-        [cell.contentView addGestureRecognizer:tapRecognizer];
-        
-        [section addCell:cell];
+        }]];
         
         __unsafe_unretained typeof(self) weakSelf = self;
         [section addCell:[BOButtonTableViewCell cellWithTitle:kLocalizedSourceCodeLicenseButtonLabel key:nil handler:^(BOButtonTableViewCell *cell) {
@@ -61,11 +55,6 @@
             };
         }]];
     }]];
-}
-
-- (void)aboutPocketCodeDescriptionTapped:(UITapGestureRecognizer*)recognizer {
-    [[FIRCrashlytics crashlytics] log:@"This is an easter egg for an workshop which needs to be removed with CATTY-162"];
-    assert(NO);
 }
 
 - (void)openAboutURL


### PR DESCRIPTION
Remove the "easter egg" which causes the app to crash (implemented in CATTY-161).

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
