### PR TITLE
CATTY-153 extend isVarOrListBeingUsed for lists

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -622,6 +622,7 @@
 		4CFAD3611CFAB9AA0019C636 /* transparency-rgba.png in Resources */ = {isa = PBXBuildFile; fileRef = 4CFAD3601CFAB9AA0019C636 /* transparency-rgba.png */; };
 		4CFD5C5B23C47E2100980CD0 /* GlideToBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD5C5823C47E2100980CD0 /* GlideToBrickTests.swift */; };
 		5912C21623C4EAC700B3D9C0 /* FormulaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5912C21523C4EAC700B3D9C0 /* FormulaTest.swift */; };
+		590200D223FC03A900F0978B /* BrickWithUserVariableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590200D123FC03A900F0978B /* BrickWithUserVariableTests.swift */; };
 		592EF6E62094B3D700BD6000 /* SpriteObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592EF6E52094B3D700BD6000 /* SpriteObjectProtocol.swift */; };
 		592EF6EA2094B84900BD6000 /* DeviceSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592EF6E92094B84900BD6000 /* DeviceSensor.swift */; };
 		593624C21F76F36F008A588D /* TTTAttributedLabel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59473A601F76F04B00BD634F /* TTTAttributedLabel.framework */; };
@@ -2174,6 +2175,7 @@
 		549E9AB2BAC4EDDB63F01654 /* tr */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		58272AE1A8D3A638A258B722 /* bs */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		5912C21523C4EAC700B3D9C0 /* FormulaTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FormulaTest.swift; path = Formula/FormulaTest.swift; sourceTree = "<group>"; };
+		590200D123FC03A900F0978B /* BrickWithUserVariableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrickWithUserVariableTests.swift; sourceTree = "<group>"; };
 		592EF6E52094B3D700BD6000 /* SpriteObjectProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteObjectProtocol.swift; sourceTree = "<group>"; };
 		592EF6E92094B84900BD6000 /* DeviceSensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceSensor.swift; sourceTree = "<group>"; };
 		5936893B2021979A00FC3115 /* SoundsTableViewController+MediaLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SoundsTableViewController+MediaLibrary.swift"; sourceTree = "<group>"; };
@@ -5295,6 +5297,7 @@
 				9E24D7062326EBC300608203 /* ShowBrickTests.swift */,
 				9E24D7022326E8E600608203 /* TurnLeftBrickTests.swift */,
 				9E2C2D9123258F3F004B66C6 /* TurnRightBrickTests.swift */,
+				590200D123FC03A900F0978B /* BrickWithUserVariableTests.swift */,
 				4C1D26641E84F12700BAA2D2 /* VibrationBrickTests.swift */,
 				AA3BD9081BBF4BFB002B34A0 /* WaitBrickTests.swift */,
 				BA584CB9219C8803002CC082 /* WaitUntilBrickTests.swift */,
@@ -9171,6 +9174,7 @@
 				4CEB22521B95E47500B3BE2F /* BrickMoveManagerTests.m in Sources */,
 				4CF429EA213A64B600B78897 /* InternFormulaKeyboardAdapterTests.swift in Sources */,
 				4C822681213FA7A400F3D750 /* TransparencySensorTest.swift in Sources */,
+				590200D223FC03A900F0978B /* BrickWithUserVariableTests.swift in Sources */,
 				4C822661213FA7A400F3D750 /* FaceSizeSensorTest.swift in Sources */,
 				4C6FE16E212D2D2E0067B7D5 /* AsinFunctionTest.swift in Sources */,
 				926197F01BF3249E006D1A61 /* ArduinoTests.swift in Sources */,

--- a/src/Catty/Catty-Bridging-Header.h
+++ b/src/Catty/Catty-Bridging-Header.h
@@ -39,6 +39,7 @@
 
 // Bricks
 #import "Brick.h"
+#import "Brick+UserVariable.h"
 #import "IfLogicBeginBrick.h"
 #import "IfThenLogicBeginBrick.h"
 #import "IfLogicElseBrick.h"

--- a/src/Catty/Extension&Delegate&Protocol/Protocols/Bricks/BrickData/BrickListProtocol.h
+++ b/src/Catty/Extension&Delegate&Protocol/Protocols/Bricks/BrickData/BrickListProtocol.h
@@ -27,6 +27,8 @@
 
 @protocol BrickListProtocol <BrickProtocol>
 
+@property (nonatomic, strong) UserVariable *userList;
+
 - (UserVariable*)listForLineNumber:(NSInteger)lineNumber andParameterNumber:(NSInteger)paramNumber;
 - (void)setList:(UserVariable*)list forLineNumber:(NSInteger)lineNumber andParameterNumber:(NSInteger)paramNumber;
 

--- a/src/Catty/FormulaEditor/Helper/Brick+UserVariable.m
+++ b/src/Catty/FormulaEditor/Helper/Brick+UserVariable.m
@@ -29,13 +29,9 @@
 #import "ShowTextBrick.h"
 #import "HideTextBrick.h"
 #import "AddItemToUserListBrick.h"
-
-// TODO: uncomment as soon as classes exist
-/*
 #import "ReplaceItemInUserListBrick.h"
 #import "DeleteItemOfUserListBrick.h"
 #import "InsertItemIntoUserListBrick.h"
-*/
 
 @implementation Brick (UserVariable)
 
@@ -43,7 +39,7 @@
 #define BRICK_MAX_PARAM_NUMBER 3
 - (BOOL)isVarOrListBeingUsed:(UserVariable*)varOrList
 {
-    if([self conformsToProtocol:@protocol(BrickVariableProtocol)]){
+    if ([self conformsToProtocol:@protocol(BrickVariableProtocol)]) {
         
         if ([self isKindOfClass:[SetVariableBrick class]]) {
             SetVariableBrick* varBrick = (SetVariableBrick*) self;
@@ -70,51 +66,24 @@
         }
     }
     
-    if([self conformsToProtocol:@protocol(BrickListProtocol)]){
-        
-        if ([self isKindOfClass:[AddItemToUserListBrick class]]) {
-            AddItemToUserListBrick* listBrick = (AddItemToUserListBrick*) self;
-            if ([varOrList isEqualToUserVariable:listBrick.userList]) {
-                return YES;
-            }
+    if ([self conformsToProtocol:@protocol(BrickListProtocol)]) {
+        Brick<BrickListProtocol>* listBrick = (Brick<BrickListProtocol>*) self;
+        if ([varOrList isEqualToUserVariable:listBrick.userList]) {
+            return YES;
         }
-        
-        
-        // TODO: Implement following bricks, uncomment afterwards
-        /*
-         else if ([self isKindOfClass:[ReplaceItemInUserListBrick class]]) {
-         ReplaceItemInUserListBrick* listBrick = (ReplaceItemInUserListBrick*) self;
-         if ([varOrList isEqualToUserVariable:listBrick.userList]) {
-         return YES;
-         }
-         }
-         else if ([self isKindOfClass:[DeleteItemOfUserListBrick class]]) {
-         DeleteItemOfUserListBrick* listBrick = (DeleteItemOfUserListBrick*) self;
-         if ([varOrList isEqualToUserVariable:listBrick.userList]) {
-         return YES;
-         }
-         }
-         else if ([self isKindOfClass:[InsertItemIntoUserListBrick class]]) {
-         InsertItemIntoUserListBrick* listBrick = (InsertItemIntoUserListBrick*) self;
-         if ([varOrList isEqualToUserVariable:listBrick.userList]) {
-         return YES;
-         }
-         }
-         */
     }
-
-    if(![self conformsToProtocol:@protocol(BrickFormulaProtocol)])
+    
+    if (![self conformsToProtocol:@protocol(BrickFormulaProtocol)])
         return NO;
     
-    for(int line = 0; line <= BRICK_MAX_LINE_NUMBER; line++) {
-        for(int param = 0; param <= BRICK_MAX_PARAM_NUMBER; param++) {
+    for (int line = 0; line <= BRICK_MAX_LINE_NUMBER; line++) {
+        for (int param = 0; param <= BRICK_MAX_PARAM_NUMBER; param++) {
             id<BrickFormulaProtocol> formulaBrick = (id<BrickFormulaProtocol>)self;
             Formula *formula = [formulaBrick formulaForLineNumber:line andParameterNumber:param];
-            if(formula && [formula.formulaTree isVarOrListBeingUsed:varOrList])
+            if (formula && [formula.formulaTree isVarOrListBeingUsed:varOrList])
                 return YES;
         }
     }
-    
     return NO;
 }
 

--- a/src/Catty/FormulaEditor/ViewController/FormulaEditorViewController.m
+++ b/src/Catty/FormulaEditor/ViewController/FormulaEditorViewController.m
@@ -1143,7 +1143,6 @@ NS_ENUM(NSInteger, ButtonIndex) {
 
 - (BOOL)isVarOrListBeingUsed:(UserVariable*)variable
 {
-    // TODO: Make it work for lists
     if([self.object.project.variables isProjectVariableOrList:variable]) {
         for(SpriteObject *spriteObject in self.object.project.objectList) {
             for(Script *script in spriteObject.scriptList) {

--- a/src/CattyTests/Bricks/BrickWithUserVariableTests.swift
+++ b/src/CattyTests/Bricks/BrickWithUserVariableTests.swift
@@ -1,0 +1,126 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+@testable import Pocket_Code
+
+final class BrickWithUserVariableTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+    }
+
+    func testUserVariableNoList() {
+        let userVariable = UserVariable()
+        userVariable.name = "test"
+        userVariable.isList = false
+        userVariable.value = "testValue"
+
+        let brick = SetVariableBrick()
+        brick.setVariable(userVariable, forLineNumber: 1, andParameterNumber: 1)
+
+        XCTAssertTrue(brick.isVarOrListBeingUsed(userVariable))
+    }
+
+    func testUserVariableList() {
+        let variablesContainer = VariablesContainer()
+        let userList = UserVariable()
+        userList.name = "test"
+        userList.isList = true
+
+        variablesContainer.programListOfLists = [userList]
+        variablesContainer.add(toUserList: userList, value: 4)
+        variablesContainer.add(toUserList: userList, value: "testValue")
+
+        let brick = SetVariableBrick()
+        brick.setVariable(userList, forLineNumber: 1, andParameterNumber: 1)
+
+        XCTAssertTrue(brick.isVarOrListBeingUsed(userList))
+    }
+
+    func testUserVariableListUsedReplaceItemInUserListBrick() {
+        let variablesContainer = VariablesContainer()
+        let userList = UserVariable()
+        userList.name = "test"
+        userList.isList = true
+
+        variablesContainer.programListOfLists = [userList]
+        variablesContainer.add(toUserList: userList, value: 4)
+        variablesContainer.add(toUserList: userList, value: "testValue")
+
+        let brick = ReplaceItemInUserListBrick()
+        brick.setList(userList, forLineNumber: 1, andParameterNumber: 1)
+
+        XCTAssertTrue(brick.isVarOrListBeingUsed(userList))
+    }
+
+    func testUserVariableListNotUsedReplaceItemInUserListBrick() {
+        let variablesContainer = VariablesContainer()
+        let userList = UserVariable()
+        let userList2 = UserVariable()
+        userList.name = "test"
+        userList.isList = true
+        userList2.name = "test2"
+        userList2.isList = true
+
+        variablesContainer.programListOfLists = [userList]
+        variablesContainer.add(toUserList: userList, value: 4)
+        variablesContainer.add(toUserList: userList, value: "testValue")
+
+        let brick = ReplaceItemInUserListBrick()
+        brick.setList(userList, forLineNumber: 1, andParameterNumber: 1)
+
+        XCTAssertTrue(brick.isVarOrListBeingUsed(userList))
+        XCTAssertFalse(brick.isVarOrListBeingUsed(userList2))
+    }
+
+    func testUserVariableListUsedMultipleBrick() {
+        let variablesContainer = VariablesContainer()
+        let userList = UserVariable()
+        userList.name = "test"
+        userList.isList = true
+
+        variablesContainer.programListOfLists = [userList]
+        variablesContainer.add(toUserList: userList, value: 4)
+        variablesContainer.add(toUserList: userList, value: "testValue")
+
+        let insertBrick = InsertItemIntoUserListBrick()
+        let addBrick = AddItemToUserListBrick()
+        let deleteBrick = DeleteItemOfUserListBrick()
+
+        insertBrick.setList(userList, forLineNumber: 1, andParameterNumber: 1)
+        XCTAssertTrue(insertBrick.isVarOrListBeingUsed(userList))
+        XCTAssertFalse(addBrick.isVarOrListBeingUsed(userList))
+        XCTAssertFalse(deleteBrick.isVarOrListBeingUsed(userList))
+
+        addBrick.setList(userList, forLineNumber: 1, andParameterNumber: 1)
+        XCTAssertTrue(insertBrick.isVarOrListBeingUsed(userList))
+        XCTAssertTrue(addBrick.isVarOrListBeingUsed(userList))
+        XCTAssertFalse(deleteBrick.isVarOrListBeingUsed(userList))
+
+        deleteBrick.setList(userList, forLineNumber: 1, andParameterNumber: 1)
+        XCTAssertTrue(insertBrick.isVarOrListBeingUsed(userList))
+        XCTAssertTrue(addBrick.isVarOrListBeingUsed(userList))
+        XCTAssertTrue(deleteBrick.isVarOrListBeingUsed(userList))
+    }
+}


### PR DESCRIPTION
In Brick+UserVariable.m, the method isVarOrListBeingUsed was extended for the ReplaceItemInUserListBrick, DeleteItemOfUserListBrick and InsertItemIntoUserListBrick.
A new test class for this method was added.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
