### PR TITLE
CATTY-126 add increasing number to downloaded projects with same name

### DIFF
--- a/src/Catty/ViewController/Download/ProjectDetailStoreViewController.m
+++ b/src/Catty/ViewController/Download/ProjectDetailStoreViewController.m
@@ -40,7 +40,6 @@
 @property (nonatomic, strong) Project *loadedProject;
 @property (strong, nonatomic) NSURLSession *session;
 @property (strong, nonatomic) NSURLSessionDataTask *dataTask;
-@property (nonatomic, strong) NSString *duplicateName;
 
 @end
 
@@ -81,7 +80,6 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    self.duplicateName = self.project.name;
     [self initNavigationBar];
     self.hidesBottomBarWhenPushed = YES;
     self.view.backgroundColor = UIColor.background;
@@ -309,7 +307,8 @@
     [self.projectView viewWithTag:kDownloadButtonTag].hidden = YES;
     button.hidden = NO;
     button.progress = 0;
-    [self downloadWithName:self.project.name];
+    NSString* duplicateName = [Util uniqueName:self.project.name existingNames:[Project allProjectNames]];
+    [self downloadWithName:duplicateName];
 }
 
 - (void)downloadButtonPressed:(id)sender
@@ -325,9 +324,9 @@
     downloadAgainButton.enabled = NO;
     button.hidden = NO;
     button.progress = 0;
-    self.duplicateName = [Util uniqueName:self.project.name existingNames:[Project allProjectNames]];
+    NSString* duplicateName = [Util uniqueName:self.project.name existingNames:[Project allProjectNames]];
     NSDebug(@"%@",[Project allProjectNames]);
-    [self downloadWithName:self.duplicateName];
+    [self downloadWithName:duplicateName];
 }
 
 -(void)downloadWithName:(NSString*)name

--- a/src/CattyTests/FileManager/CBFileManagerTests.swift
+++ b/src/CattyTests/FileManager/CBFileManagerTests.swift
@@ -27,16 +27,18 @@ import XCTest
 final class CBFileManagerTests: XCTestCase {
 
     var fileManager: CBFileManager!
+    var projectId: String!
+    var projectName: String!
 
     override func setUp() {
         super.setUp()
 
         fileManager = CBFileManager.shared()
+        projectId = "1234"
+        projectName = "testProject"
     }
 
     func testUnzipAndStore() {
-        let projectId = "1234"
-        let projectName = "testProject"
 
         Project.removeProjectFromDisk(withProjectName: projectName, projectID: projectId)
         XCTAssertFalse(Project.projectExists(withProjectID: projectId))
@@ -48,12 +50,69 @@ final class CBFileManagerTests: XCTestCase {
         XCTAssertTrue(Project.projectExists(withProjectID: projectId))
         XCTAssertTrue(Project.projectExists(withProjectName: projectName, projectID: projectId))
     }
+    
+    func testUnzipAndStoreWithSameName() {
+        
+        Project.removeProjectFromDisk(withProjectName: projectName, projectID: projectId)
+        XCTAssertFalse(Project.projectExists(withProjectID: projectId))
+        
+        let projectData = NSData(contentsOf: Bundle.main.url(forResource: "My first project", withExtension: "catrobat")!)! as Data
+        
+        let result = fileManager.unzipAndStore(projectData, withProjectID: projectId, withName: projectName)
+
+        let newProjectName = "testProject (1)"
+        XCTAssertTrue(result)
+        XCTAssertTrue(Project.projectExists(withProjectID: projectId))
+        XCTAssertTrue(Project.projectExists(withProjectName: newProjectName, projectID: projectId))
+        
+        let result_2 = fileManager.unzipAndStore(projectData, withProjectID: projectId, withName: projectName)
+
+        let newProjectName_2 = "testProject (2)"
+        XCTAssertTrue(result_2)
+        XCTAssertTrue(Project.projectExists(withProjectID: projectId))
+        XCTAssertTrue(Project.projectExists(withProjectName: newProjectName_2, projectID: projectId))
+    }
+    
+    func testUnzipAndStoreWithSameNameDifferentId() {
+        
+        Project.removeProjectFromDisk(withProjectName: projectName, projectID: projectId)
+        Project.removeProjectFromDisk(withProjectName: projectName + " (1)", projectID: projectId)
+        Project.removeProjectFromDisk(withProjectName: projectName + " (2)", projectID: projectId)
+        Project.removeProjectFromDisk(withProjectName: projectName, projectID: "4321")
+        Project.removeProjectFromDisk(withProjectName: projectName + " (1)", projectID: "4321")
+        Project.removeProjectFromDisk(withProjectName: projectName + " (2)", projectID: "4321")
+        XCTAssertFalse(Project.projectExists(withProjectID: projectId))
+        XCTAssertFalse(Project.projectExists(withProjectID: "4321"))
+        
+        let projectData = NSData(contentsOf: Bundle.main.url(forResource: "My first project", withExtension: "catrobat")!)! as Data
+        
+        let result = fileManager.unzipAndStore(projectData, withProjectID: projectId, withName: projectName)
+        XCTAssertTrue(result)
+        XCTAssertTrue(Project.projectExists(withProjectID: projectId))
+        XCTAssertTrue(Project.projectExists(withProjectName: projectName, projectID: projectId))
+        
+        let projectId_2 = "4321"
+        let result_2 = fileManager.unzipAndStore(projectData, withProjectID: projectId_2, withName: projectName)
+
+        let newProjectName = "testProject (1)"
+        XCTAssertTrue(result_2)
+        XCTAssertTrue(Project.projectExists(withProjectID: projectId_2))
+        XCTAssertTrue(Project.projectExists(withProjectName: newProjectName, projectID: projectId_2))
+        
+        let result_3 = fileManager.unzipAndStore(projectData, withProjectID: projectId_2, withName: projectName)
+
+        let newProjectName_2 = "testProject (2)"
+        XCTAssertTrue(result_3)
+        XCTAssertTrue(Project.projectExists(withProjectID: projectId_2))
+        XCTAssertTrue(Project.projectExists(withProjectName: newProjectName_2, projectID: projectId_2))
+    }
 
     func testUnzipAndStoreWithInvalidData() {
-        let projectId = "1234"
-        let projectName = "testProject"
 
         Project.removeProjectFromDisk(withProjectName: projectName, projectID: projectId)
+        Project.removeProjectFromDisk(withProjectName: projectName, projectID: projectId)
+        Project.removeProjectFromDisk(withProjectName: projectName + " (1)", projectID: "4321")
+        Project.removeProjectFromDisk(withProjectName: projectName + " (2)", projectID: "4321")
         XCTAssertFalse(Project.projectExists(withProjectID: projectId))
 
         let programData = NSData(contentsOf: Bundle.main.url(forResource: "Document-Icon", withExtension: "png")!)! as Data


### PR DESCRIPTION
Downloaded projects with the same name are now stored with an increasing number as if you create a project with the same name directly on your device.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
