### PR TITLE
CATTY-175 Login with non-existing user shows wrong error message

### DIFF
--- a/src/Catty UITests/Defines/LanguageTranslationDefinesUI.swift
+++ b/src/Catty UITests/Defines/LanguageTranslationDefinesUI.swift
@@ -746,6 +746,7 @@ let kLocalizedServerTimeoutIssueTitle = NSLocalizedString("Connection failed", b
 let kLocalizedServerTimeoutIssueMessage = NSLocalizedString("Server is taking to long to respond, please try again later.", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedUnexpectedErrorTitle = NSLocalizedString("Unexpected Error", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedUnexpectedErrorMessage = NSLocalizedString("Unexpected Error, please try again later.", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kLocalizedInvalidUser = NSLocalizedString("Invalid Credentials.", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 
 //************************************************************************************************************
 //****************************************       Debug        ************************************************

--- a/src/Catty/Defines/LanguageTranslationDefines.h
+++ b/src/Catty/Defines/LanguageTranslationDefines.h
@@ -746,6 +746,7 @@
 #define kLocalizedServerTimeoutIssueMessage NSLocalizedString(@"Server is taking to long to respond, please try again later.", nil)
 #define kLocalizedUnexpectedErrorTitle NSLocalizedString(@"Unexpected Error", nil)
 #define kLocalizedUnexpectedErrorMessage NSLocalizedString(@"Unexpected Error, please try again later.", nil)
+#define kLocalizedInvalidUser NSLocalizedString(@"Invalid Credentials.", nil)
 
 //************************************************************************************************************
 //****************************************       Debug        ************************************************

--- a/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
+++ b/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
@@ -746,6 +746,7 @@ let kLocalizedServerTimeoutIssueTitle = NSLocalizedString("Connection failed", c
 let kLocalizedServerTimeoutIssueMessage = NSLocalizedString("Server is taking to long to respond, please try again later.", comment: "")
 let kLocalizedUnexpectedErrorTitle = NSLocalizedString("Unexpected Error", comment: "")
 let kLocalizedUnexpectedErrorMessage = NSLocalizedString("Unexpected Error, please try again later.", comment: "")
+let kLocalizedInvalidUser = NSLocalizedString("Invalid Credentials.", comment: "")
 
 //************************************************************************************************************
 //****************************************       Debug        ************************************************

--- a/src/Catty/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en.lproj/Localizable.strings
@@ -728,6 +728,9 @@
 "into list" = "into list";
 
 /* No comment provided by engineer. */
+"Invalid Credentials." = "Invalid Credentials.";
+
+/* No comment provided by engineer. */
 "Invalid input entered, try again." = "Invalid input entered, try again.";
 
 /* No comment provided by engineer. */

--- a/src/Catty/ViewController/Upload/LoginViewController.m
+++ b/src/Catty/ViewController/Upload/LoginViewController.m
@@ -40,6 +40,7 @@
 #define statusCodeOK @"200"
 #define statusCodeRegistrationOK @"201"
 #define statusAuthenticationFailed @"601"
+#define statusInvalidUser @"803"
 
 //random boundary string
 #define httpBoundary @"---------------------------98598263596598246508247098291---------------------------"
@@ -368,6 +369,14 @@
         [self hideLoadingView];
         NSDebug(@"Error: %@", kLocalizedAuthenticationFailed);
         [self showError:kLocalizedAuthenticationFailed];
+    } else if([statusCode isEqualToString:statusInvalidUser]){
+        self.loginButton.enabled = YES;
+        [self hideLoadingView];
+        
+        NSString *serverResponse = [dictionary valueForKey:answerTag];
+        NSDebug(@"Error: %@", serverResponse);
+        [self showError:kLocalizedInvalidUser];
+
     } else {
         self.loginButton.enabled = YES;
         [self hideLoadingView];


### PR DESCRIPTION
When logging in with a user which does not exist, the App reports "Server is taking to long to respond, please try again later. The app should say "Invalid credentials".

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [X] Include the name of the Jira ticket in the PR’s title
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Stick to the project’s git workflow (rebase and squash your commits)
- [X] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
