### PR TITLE
CATTY-149 Page indicator missing for Brick selection

### DIFF
--- a/src/Catty/Extension&Delegate&Protocol/Extensions/UIColor+Extension/UIColor+CatrobatUIColorExtensions.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/UIColor+Extension/UIColor+CatrobatUIColorExtensions.swift
@@ -154,6 +154,10 @@ extension UIColor {
         return self.dark
     }
 
+    static var pageIndicator: UIColor {
+        return UIColor(hex: 0x3ab2c1)
+    }
+
     static var buttonHighlightedTint: UIColor {
         return self.background
     }

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryViewController.m
@@ -67,7 +67,7 @@
     }
     
     self.collectionView.backgroundColor = UIColor.clearColor;
-    self.view.backgroundColor = UIColor.clearColor;
+    self.view.backgroundColor = UIColor.whiteColor;
 }
 
 -(void)reloadData {

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickSelectionViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickSelectionViewController.m
@@ -47,7 +47,7 @@
     [super viewDidLoad];
     self.dataSource = self;
     self.delegate = self;
-    self.view.backgroundColor = UIColor.background;
+    self.view.backgroundColor = UIColor.pageIndicator;
     self.navigationController.toolbarHidden = YES;
     [self setupNavBar];
 }
@@ -114,14 +114,28 @@
     return self.categories.count;
 }
 
+- (NSInteger)presentationIndexForPageViewController:(UIPageViewController *)pageViewController
+{
+    BrickCategoryViewController *lastSelectedView = (BrickCategoryViewController*)self.viewControllers.firstObject;
+    NSInteger index = 0;
+    for (BrickCategory *category in self.categories)
+    {
+        if (category.type == lastSelectedView.category.type && index < [self.categories count])
+        {
+            return index;
+        }
+        index++;
+    }
+    return 0;
+}
+
 - (void)overwritePageControl
 {
     self.pageControl = [[self.view.subviews
                                    filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"class = %@", [UIPageControl class]]] lastObject];
-    self.pageControl.currentPageIndicatorTintColor = UIColor.background;
-    self.pageControl.pageIndicatorTintColor = UIColor.toolTint;
-    self.pageControl.backgroundColor = UIColor.toolBar;
-
+    self.pageControl.currentPageIndicatorTintColor = UIColor.whiteColor;
+    self.pageControl.pageIndicatorTintColor = UIColor.navTint;
+    self.pageControl.backgroundColor = UIColor.pageIndicator;
 }
 
 #pragma mark - Setup
@@ -131,6 +145,8 @@
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel
                                                                                            target:self
                                                                                            action:@selector(dismiss:)];
+    
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName : UIColor.navTint};
     
     self.navigationItem.leftBarButtonItem.tintColor = UIColor.navTint;
     


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

I change the color of the title in the Brick selection. It was white. Now it has the same color as everywhere.

One mainfunction for the page Indicator was missing. (presentationIndexForPageViewController)