### PR TITLE
CATTY-175 use error message authentication failed for non existing user

### DIFF
--- a/src/Catty/ViewController/Upload/LoginViewController.m
+++ b/src/Catty/ViewController/Upload/LoginViewController.m
@@ -40,6 +40,8 @@
 #define statusCodeOK @"200"
 #define statusCodeRegistrationOK @"201"
 #define statusAuthenticationFailed @"601"
+#define statusUserDoesNotExist @"803"
+
 
 //random boundary string
 #define httpBoundary @"---------------------------98598263596598246508247098291---------------------------"
@@ -363,7 +365,8 @@
         [self hideLoadingView];
         [self.navigationController popViewControllerAnimated:NO];
         
-    } else if ([statusCode isEqualToString:statusAuthenticationFailed]) {
+    } else if ([statusCode isEqualToString:statusAuthenticationFailed] ||
+               [statusCode isEqualToString:statusUserDoesNotExist]) {
         self.loginButton.enabled = YES;
         [self hideLoadingView];
         NSDebug(@"Error: %@", kLocalizedAuthenticationFailed);

--- a/src/CattyTests/Utils/LoginViewControllerTests.swift
+++ b/src/CattyTests/Utils/LoginViewControllerTests.swift
@@ -48,6 +48,12 @@ class LoginViewControllerTests: XCTestCase {
         loginViewController.handleLoginResponse(with: dataMock(status_code: statusAuthentificationFailed), andResponse: nil)
         XCTAssertEqual(kLocalizedAuthenticationFailed, loginViewController.errorMessage!)
     }
+    
+    func testServerForUserNotExistingStatusCode() {
+        let statusUserNotExisting = ["statusCode": "803"]
+        loginViewController.handleLoginResponse(with: dataMock(status_code: statusUserNotExisting), andResponse: nil)
+        XCTAssertEqual(kLocalizedAuthenticationFailed, loginViewController.errorMessage!)
+    }
 
     func testServerForStatusCodeOK() {
         let statusOk = ["statusCode": "200"]


### PR DESCRIPTION
For non-existing users the error message "Authentication failed" is now shown such as if you login with invalid credentials.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
