### PR TITLE
CATTY-120 Parameter fields for Bricks

### DIFF
--- a/src/Catty UITests/BrickCellTests.swift
+++ b/src/Catty UITests/BrickCellTests.swift
@@ -1,0 +1,81 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+class BrickCellTests: XCTestCase {
+
+    var app: XCUIApplication!
+
+    override func setUp() {
+        super.setUp()
+        app = launchAppWithDefaultProject()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testBrickParameterSpace() {
+
+        let brickWidth: CGFloat
+        let initialParameterTextViewWidth: CGFloat
+        let firstParameterTextView: XCUIElement
+        let secondParameterTextView: XCUIElement
+        let firstParameterTextViewWidth: CGFloat
+        let secondParameterTextViewWidth: CGFloat
+
+        createProject(name: "My Project", in: app)
+        app.tables.staticTexts[kLocalizedBackground].tap()
+        app.tables.staticTexts[kLocalizedScripts].tap()
+        addBrick(label: kLocalizedPlaceAt, section: kLocalizedCategoryMotion, in: app)
+
+        brickWidth = app.collectionViews.cells.otherElements.containing(.staticText, identifier: kLocalizedPlaceAt).firstMatch.frame.size.width
+        initialParameterTextViewWidth = app.collectionViews.cells.otherElements.containing(.staticText, identifier: kLocalizedPlaceAt)
+                                        .children(matching: .button).firstMatch.frame.size.width
+
+        firstParameterTextView = app.collectionViews.cells.otherElements.containing(.staticText, identifier: kLocalizedPlaceAt)
+                                 .children(matching: .button).element(boundBy: 0)
+        firstParameterTextView.tap()
+
+        for i in 1...8 {
+            app.buttons["\(String(i))"].staticTexts["\(String(i))"].doubleTap()
+        }
+        app.buttons[kLocalizedDone].tap()
+
+        firstParameterTextViewWidth = firstParameterTextView.frame.size.width
+
+        secondParameterTextView = app.collectionViews.cells.otherElements.containing(.staticText, identifier: kLocalizedPlaceAt)
+                                  .children(matching: .button).element(boundBy: 1)
+        secondParameterTextView.tap()
+
+        for i in 1...8 {
+            app.buttons["\(String(i))"].staticTexts["\(String(i))"].doubleTap()
+        }
+        app.buttons[kLocalizedDone].tap()
+        secondParameterTextViewWidth = secondParameterTextView.frame.size.width
+
+        XCTAssertTrue(firstParameterTextViewWidth > initialParameterTextViewWidth)
+        XCTAssertEqual(firstParameterTextViewWidth, secondParameterTextViewWidth, accuracy: 0.0001)
+        XCTAssertTrue(brickWidth - (firstParameterTextViewWidth + secondParameterTextViewWidth) < firstParameterTextViewWidth)
+    }
+}

--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		22524C38239FAFC500DD515E /* LoginViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22524C37239FAFC500DD515E /* LoginViewControllerTests.swift */; };
 		22524C3D23A2533F00DD515E /* LoginViewControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22524C3C23A2533F00DD515E /* LoginViewControllerMock.swift */; };
+		22C48768240FFAA3003CB222 /* BrickCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C48767240FFAA3003CB222 /* BrickCellTests.swift */; };
 		2D010F4822240C9F00CAAA06 /* XCUIElement+staticTexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D010F4722240C9F00CAAA06 /* XCUIElement+staticTexts.swift */; };
 		2D227D94220B38E0008A2BC9 /* ScenePresenterVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D227D93220B38E0008A2BC9 /* ScenePresenterVCTests.swift */; };
 		2D6E3F39210A0A9F00FB8139 /* ChartProjectStoreDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D6E3F38210A0A9F00FB8139 /* ChartProjectStoreDataSource.swift */; };
@@ -1489,6 +1490,7 @@
 		1C557E56F94895CB30ED2558 /* en-CA */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		22524C37239FAFC500DD515E /* LoginViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewControllerTests.swift; sourceTree = "<group>"; };
 		22524C3C23A2533F00DD515E /* LoginViewControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewControllerMock.swift; sourceTree = "<group>"; };
+		22C48767240FFAA3003CB222 /* BrickCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrickCellTests.swift; sourceTree = "<group>"; };
 		232DAAC73BFD01550ECFD889 /* sk */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2B9E6447F112720F0F74D139 /* tw */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = tw; path = tw.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -8181,6 +8183,7 @@
 				4CF8747221C8E7AB00C8143F /* SoundsTVCTests.swift */,
 				BA6805AD21303B48004F004F /* VariablesTests.swift */,
 				2D227D93220B38E0008A2BC9 /* ScenePresenterVCTests.swift */,
+				22C48767240FFAA3003CB222 /* BrickCellTests.swift */,
 			);
 			path = "Catty UITests";
 			sourceTree = "<group>";
@@ -9242,6 +9245,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				22C48768240FFAA3003CB222 /* BrickCellTests.swift in Sources */,
 				BCFED6F12111CA5D00BE57BF /* PocketCodeMainScreenTests.swift in Sources */,
 				4C1EDCAC218A080200B60464 /* ScriptCollectionVCTests.swift in Sources */,
 				4C48E5CE23FD7F4B004C6E6A /* SettingsTVCTests.swift in Sources */,

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellFormulaData.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellFormulaData.m
@@ -35,6 +35,8 @@
 
 @implementation BrickCellFormulaData
 
+#define SPACE_DISTRIBUTE_VALUE 3.1f
+
 - (instancetype)initWithFrame:(CGRect)frame andBrickCell:(BrickCell*)brickCell andLineNumber:(NSInteger)line andParameterNumber:(NSInteger)parameter
 {
     Brick<BrickFormulaProtocol> *formulaBrick = (Brick<BrickFormulaProtocol>*)brickCell.scriptOrBrick;
@@ -59,9 +61,9 @@
             self.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
             self.titleLabel.minimumScaleFactor = 10./self.titleLabel.font.pointSize;
         } else if ([brickCell isKindOfClass:[PlaceAtBrickCell class]] || [brickCell isKindOfClass:[GlideToBrickCell class]]) {
-            if (self.frame.size.width > [Util screenWidth]/4.0f ) {
+            if (self.frame.size.width > [Util screenWidth]/SPACE_DISTRIBUTE_VALUE) {
                 CGRect labelFrame = self.frame;
-                labelFrame.size.width = [Util screenWidth]/4.0f;
+                labelFrame.size.width = [Util screenWidth]/SPACE_DISTRIBUTE_VALUE;
                 self.frame = labelFrame;
             }
         } else {


### PR DESCRIPTION
CATTY-120 change name of test

Provided more space for Parameter fields for Bricks and added a UITest. The new provided space was checked on different iPhone sizes. (from 5s onwards)
https://jira.catrob.at/browse/CATTY-120

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
