### PR TITLE
CATTY-185 Implement GitHub Action for xcprojectlint

### DIFF
--- a/.github/workflows/validate-xcodeproj.yml
+++ b/.github/workflows/validate-xcodeproj.yml
@@ -1,0 +1,26 @@
+name: validate-xcodeproj
+
+on: 
+  pull_request:
+    types: [opened, reopened]
+    
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Catty
+        uses: actions/checkout@v2
+        with:
+          path: Catty
+      - name: Checkout xcprojectlint
+        uses: actions/checkout@v2
+        with:
+          repository: americanexpress/xcprojectlint
+          path: xcprojectlint
+      - name: Build xcodeprojlint
+        run: |
+          cd ${{ github.workspace }}/xcprojectlint
+          swift package update
+          make build
+      - name: Verify xcodeproj
+        run: xcprojectlint/.build/x86_64-apple-macosx/debug/xcprojectlint --report error --validations all --project Catty/src/Catty.xcodeproj


### PR DESCRIPTION
To ensure a valid xcodeproj file at in each PR, xcprojectlint should be integrated with a GitHub Action.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
