### PR TITLE
CATTY-172 Appearance of Privacy Policy

### DIFF
--- a/src/Catty/Storyboard+XIB/LaunchScreen.storyboard
+++ b/src/Catty/Storyboard+XIB/LaunchScreen.storyboard
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vwt-6C-EYF">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="vwt-6C-EYF">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Pocket Code-->
         <scene sceneID="mFP-py-AC1">
             <objects>
-                <navigationController title="Pocket Code" id="vwt-6C-EYF" sceneMemberID="viewController">
+                <navigationController title="Pocket Code" navigationBarHidden="YES" id="vwt-6C-EYF" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="Mk2-tc-ao1">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" red="0.094117647058823528" green="0.6470588235294118" blue="0.71764705882352942" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="tintColor" red="0.6588235294" green="0.87450980389999999" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
When starting Pocket Code for the first time, the privacy policy screen is shown (or if activated in the settings, then this screen is always shown).
This screen gets shown on the top of the usual Pocket Code interface (with the blueish "Pocket Code" bar at the top). Because of this there is a disturbing, non-smooth "blinking effect" when the policy is shown.
Privacy Policy should be shown before the bar at the top is shown.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
