### PR TITLE
CATTY-106 Margin for BrickSelectionViewController

### DIFF
--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryViewController.m
@@ -146,9 +146,17 @@ didSelectItemAtIndexPath:(NSIndexPath*)indexPath
                         layout:(UICollectionViewLayout*)collectionViewLayout
         insetForSectionAtIndex:(NSInteger)section
 {
-    return UIEdgeInsetsMake(CGRectGetHeight(self.navigationController.navigationBar.bounds) +
-                            CGRectGetHeight([UIApplication sharedApplication].statusBarFrame) +
-                            kScriptCollectionViewInset, 0.0f, kScriptCollectionViewInset, 0.0f);
+    if (@available(iOS 13, *))
+    {
+        return UIEdgeInsetsMake(CGRectGetHeight(self.navigationController.navigationBar.bounds) +
+        kScriptCollectionViewInset, 0.0f, kScriptCollectionViewInset, 0.0f);
+    } else
+    {
+        return UIEdgeInsetsMake(CGRectGetHeight(self.navigationController.navigationBar.bounds) +
+        CGRectGetHeight([UIApplication sharedApplication].statusBarFrame) +
+        kScriptCollectionViewInset, 0.0f, kScriptCollectionViewInset, 0.0f);
+    }
+    
 }
 
 - (CGFloat)collectionView:(UICollectionView*)collectionView


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

Since iOS13 the boundaries of the viewcontroller have changed because of it, the fault occurred