### PR TITLE
Catty-188: Refactor Brick tests

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		187A3F202434BC4300EF1B02 /* PlaySoundAndWaitBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187A3F1F2434BC4300EF1B02 /* PlaySoundAndWaitBrickTests.swift */; };
+		187CECAB24314F1600C3EDCA /* SetLookBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 187CECAA24314F1600C3EDCA /* SetLookBrickTests.swift */; };
+		18A9DBA92434C7F400F4C390 /* IfLogicBeginBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A9DBA82434C7F400F4C390 /* IfLogicBeginBrickTests.swift */; };
 		22524C38239FAFC500DD515E /* LoginViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22524C37239FAFC500DD515E /* LoginViewControllerTests.swift */; };
 		22524C3D23A2533F00DD515E /* LoginViewControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22524C3C23A2533F00DD515E /* LoginViewControllerMock.swift */; };
 		22C48768240FFAA3003CB222 /* BrickCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C48767240FFAA3003CB222 /* BrickCellTests.swift */; };
@@ -1484,6 +1487,9 @@
 		0C64E34E5347DA71ECB56DE6 /* pt */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		113CDA22CF21176FFA49E694 /* sd */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = sd; path = sd.lproj/Localizable.strings; sourceTree = "<group>"; };
 		13B5EB79EDA9CF73908FF75C /* no */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = no; path = no.lproj/Localizable.strings; sourceTree = "<group>"; };
+		187A3F1F2434BC4300EF1B02 /* PlaySoundAndWaitBrickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaySoundAndWaitBrickTests.swift; sourceTree = "<group>"; };
+		187CECAA24314F1600C3EDCA /* SetLookBrickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetLookBrickTests.swift; sourceTree = "<group>"; };
+		18A9DBA82434C7F400F4C390 /* IfLogicBeginBrickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IfLogicBeginBrickTests.swift; sourceTree = "<group>"; };
 		18EF8F4D5C0ED599CBA2B488 /* vi */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1B5E0F4EFA8B76CD707F0556 /* ur */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ur; path = ur.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1C035A070A526C061039C146 /* ha */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ha; path = ha.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -5814,10 +5820,12 @@
 				9ECDCB122328578F00EBDA63 /* HideBrickTests.swift */,
 				4CAB10081ECF1A9A0019A67B /* HideTextBrickTests.swift */,
 				9E3AF7992326F4D100AB16F1 /* IfOnEdgeBounceBrickTests.swift */,
+				18A9DBA82434C7F400F4C390 /* IfLogicBeginBrickTests.swift */,
 				4CF4CB7221E64BEE009D6DD9 /* InsertItemIntoUserListBrickTests.swift */,
 				9EA6DCAF2329A9E1007E837A /* MoveNStepsBrickTests.swift */,
 				9EBCBD822329B44E0074C2D9 /* NextLookBrickTests.swift */,
 				9EBCBD842329B73D0074C2D9 /* PlaceAtBrickTests.swift */,
+				187A3F1F2434BC4300EF1B02 /* PlaySoundAndWaitBrickTests.swift */,
 				9EBCBD862329BD700074C2D9 /* PointInDirectionBrickTests.swift */,
 				9EBCBD882329BF5F0074C2D9 /* PointToBrickTests.swift */,
 				9EBCBD8A2329C3BF0074C2D9 /* PreviousLookBrickTests.swift */,
@@ -5825,6 +5833,7 @@
 				4C0F9FD8204BD3D500E71B2D /* RepeatUntilBrickTests.swift */,
 				4CF4CB7621E65A9B009D6DD9 /* ReplaceItemInUserListBrickTests.swift */,
 				9ECDCB102328548800EBDA63 /* SetBackgroundBrickTests.swift */,
+				187CECAA24314F1600C3EDCA /* SetLookBrickTests.swift */,
 				9E4D2389232AF24B009D0C3C /* SetBrightnessBrickTests.swift */,
 				9E4D238B232AF688009D0C3C /* SetColorBrickTests.swift */,
 				9EBCBD8C2329C56F0074C2D9 /* SetSizeToBrickTests.swift */,
@@ -9292,6 +9301,7 @@
 				9E2C2D9223258F3F004B66C6 /* TurnRightBrickTests.swift in Sources */,
 				4C28D78B2132A83D00870CE2 /* FormulaMock.swift in Sources */,
 				4C6FE163212D2D2E0067B7D5 /* ModFunctionTest.swift in Sources */,
+				187A3F202434BC4300EF1B02 /* PlaySoundAndWaitBrickTests.swift in Sources */,
 				4C1A596823FE9997001A78D2 /* CrashlyticsMock.swift in Sources */,
 				4C82265A213FA7A400F3D750 /* TouchManagerMock.swift in Sources */,
 				4CBF96BF2351B3EC0063D5FC /* ProjectTests.swift in Sources */,
@@ -9323,6 +9333,7 @@
 				4CFAD35E1CFAB3EC0019C636 /* CustomExtensionsTests.m in Sources */,
 				4C1A597323FEAC10001A78D2 /* AppDelegateMock.swift in Sources */,
 				9E2C2D9023257704004B66C6 /* ChangeBrightnessByNBrickTests.swift in Sources */,
+				18A9DBA92434C7F400F4C390 /* IfLogicBeginBrickTests.swift in Sources */,
 				4CC50A5E213BE036004BC914 /* ZeroParameterDoubleFunctionMock.swift in Sources */,
 				4CEB22521B95E47500B3BE2F /* BrickMoveManagerTests.m in Sources */,
 				4CF429EA213A64B600B78897 /* InternFormulaKeyboardAdapterTests.swift in Sources */,
@@ -9548,6 +9559,7 @@
 				4C82265E213FA7A400F3D750 /* LastFingerIndexSensorTest.swift in Sources */,
 				4C6FE168212D2D2E0067B7D5 /* TanFunctionTest.swift in Sources */,
 				4C7182E123EEF47500195BC7 /* UICollectionViewMock.swift in Sources */,
+				187CECAB24314F1600C3EDCA /* SetLookBrickTests.swift in Sources */,
 				2ED418BB2411213E00AFE2FD /* XMLParserBlackBoxTests095.swift in Sources */,
 				4CD0BA9921467C5A00BF17A4 /* HeaderTests.swift in Sources */,
 				4C3A5CA721D3B687008FD83F /* EqualOperatorTest.swift in Sources */,

--- a/src/Catty/DataModel/Bricks/Control/RepeatBrick.m
+++ b/src/Catty/DataModel/Bricks/Control/RepeatBrick.m
@@ -76,8 +76,8 @@
 - (id)mutableCopyWithContext:(CBMutableCopyContext*)context
 {
     RepeatBrick *brick = [self mutableCopyWithContext:context AndErrorReporting:NO];
-    brick.repetitions = self.repetitions;
-    brick.maxRepetitions = self.maxRepetitions;
+    brick.repetitions = 0;
+    brick.maxRepetitions = nil;
     return brick;
 }
 

--- a/src/Catty/DataModel/Bricks/Control/RepeatUntilBrick.m
+++ b/src/Catty/DataModel/Bricks/Control/RepeatUntilBrick.m
@@ -69,13 +69,6 @@
     return [NSString stringWithFormat:@"RepeatLoop"];
 }
 
-#pragma mark - Copy
-- (id)mutableCopyWithContext:(CBMutableCopyContext*)context
-{
-    RepeatUntilBrick *brick = [self mutableCopyWithContext:context AndErrorReporting:NO];
-    return brick;
-}
-
 #pragma mark - Resources
 - (NSInteger)getRequiredResources
 {

--- a/src/Catty/DataModel/Bricks/Look/SetBackgroundBrick.m
+++ b/src/Catty/DataModel/Bricks/Look/SetBackgroundBrick.m
@@ -78,7 +78,6 @@
     return kNoResources;
 }
 
-
 - (id)mutableCopyWithContext:(CBMutableCopyContext*)context
 {
     if (! context) NSError(@"%@ must not be nil!", [CBMutableCopyContext class]);

--- a/src/Catty/DataModel/Bricks/Look/SetLookBrick.m
+++ b/src/Catty/DataModel/Bricks/Look/SetLookBrick.m
@@ -83,7 +83,6 @@
     return kNoResources;
 }
 
-
 - (id)mutableCopyWithContext:(CBMutableCopyContext*)context
 {
     if (! context) NSError(@"%@ must not be nil!", [CBMutableCopyContext class]);

--- a/src/Catty/DataModel/Bricks/Motion/GlideToBrick.m
+++ b/src/Catty/DataModel/Bricks/Motion/GlideToBrick.m
@@ -103,13 +103,6 @@
     return YES;
 }
 
-#pragma mark - Copy
-- (id)mutableCopyWithContext:(CBMutableCopyContext*)context
-{
-    return [self mutableCopyWithContext:context AndErrorReporting:NO];
-    
-}
-
 #pragma mark - Resources
 - (NSInteger)getRequiredResources
 {

--- a/src/Catty/DataModel/Bricks/Motion/PointToBrick.m
+++ b/src/Catty/DataModel/Bricks/Motion/PointToBrick.m
@@ -84,6 +84,14 @@
     return copy;
 }
 
+- (id)mutableCopyWithContext:(CBMutableCopyContext*)context AndErrorReporting:(BOOL)reportError
+{
+    PointToBrick *copy = [super mutableCopyWithContext:context AndErrorReporting:reportError];
+    if(self.pointedObject)
+        copy.pointedObject = self.pointedObject;
+    return copy;
+}
+
 #pragma mark - Resources
 - (NSInteger)getRequiredResources
 {

--- a/src/CattyTests/Bricks/BrickMutableCopyTests.swift
+++ b/src/CattyTests/Bricks/BrickMutableCopyTests.swift
@@ -33,9 +33,13 @@
         let copiedBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as AnyObject
 
         XCTAssertTrue(brick.isEqual(to: copiedBrick as? Brick))
+        XCTAssertFalse(brick === (copiedBrick as? Brick))
+
         XCTAssertFalse(brick.xPosition.isEqual(to: brick.yPosition))
         XCTAssertTrue(brick.xPosition.isEqual(to: copiedBrick.xPosition))
+        XCTAssertFalse(brick.xPosition === copiedBrick.xPosition)
         XCTAssertTrue(brick.yPosition.isEqual(to: copiedBrick.yPosition))
+        XCTAssertFalse(brick.yPosition === copiedBrick.yPosition)
     }
 
      func testMutableCopyForBool() {
@@ -46,6 +50,7 @@
         let copiedBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as AnyObject
 
         XCTAssertTrue(brick.isEqual(to: copiedBrick as? Brick))
+        XCTAssertFalse(brick === copiedBrick as? Brick)
         XCTAssertEqual(brick.isAnimated, copiedBrick.isAnimated)
         XCTAssertEqual(brick.isAnimatedInsertBrick, copiedBrick.isAnimatedInsertBrick)
 

--- a/src/CattyTests/Bricks/BrickTests.swift
+++ b/src/CattyTests/Bricks/BrickTests.swift
@@ -67,4 +67,5 @@ final class BrickTests: XCTestCase {
                        formulaManager.interpretDouble(brick.variableFormula, for: SpriteObject()),
                        "Invalid formula")
     }
+
 }

--- a/src/CattyTests/Bricks/GlideToBrickTests.swift
+++ b/src/CattyTests/Bricks/GlideToBrickTests.swift
@@ -37,4 +37,27 @@ final class GlideToBrickTests: XCTestCase {
         XCTAssertEqual(brick.xDestination, brick.formula(forLineNumber: 1, andParameterNumber: 0))
         XCTAssertEqual(brick.yDestination, brick.formula(forLineNumber: 1, andParameterNumber: 1))
     }
+
+    func testMutableCopy() {
+        let brick = GlideToBrick()
+
+        brick.durationInSeconds = Formula(double: 1)
+        brick.xDestination = Formula(double: 1)
+        brick.yDestination = Formula(double: 1)
+
+        let copiedBrick: GlideToBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! GlideToBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+
+        XCTAssertTrue(brick.durationInSeconds.isEqual(to: copiedBrick.durationInSeconds))
+        XCTAssertFalse(brick.durationInSeconds === copiedBrick.durationInSeconds)
+
+        XCTAssertTrue(brick.xDestination.isEqual(to: copiedBrick.xDestination))
+        XCTAssertFalse(brick.xDestination === copiedBrick.xDestination)
+
+        XCTAssertTrue(brick.yDestination.isEqual(to: copiedBrick.yDestination))
+        XCTAssertFalse(brick.yDestination === copiedBrick.yDestination)
+    }
+
 }

--- a/src/CattyTests/Bricks/IfLogicBeginBrickTests.swift
+++ b/src/CattyTests/Bricks/IfLogicBeginBrickTests.swift
@@ -1,0 +1,42 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+@testable import Pocket_Code
+
+final class IfLogicBeginBrickTests: XCTestCase {
+
+    func testMutableCopy() {
+        let brick = IfLogicBeginBrick()
+        brick.ifCondition = Formula(float: 1)
+
+        let copiedBrick: IfLogicBeginBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! IfLogicBeginBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.ifCondition.isEqual(to: copiedBrick.ifCondition))
+        XCTAssertFalse(copiedBrick.ifCondition.isEqual(to: Formula(float: 0)))
+        XCTAssertFalse(brick.ifCondition === copiedBrick.ifCondition)
+    }
+
+}

--- a/src/CattyTests/Bricks/PlaySoundAndWaitBrickTests.swift
+++ b/src/CattyTests/Bricks/PlaySoundAndWaitBrickTests.swift
@@ -1,0 +1,42 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+@testable import Pocket_Code
+
+final class PlaySoundAndWaitBrickTests: XCTestCase {
+
+    func testMutableCopy() {
+        let brick = PlaySoundAndWaitBrick()
+        let sound = Sound(name: "soundToCopy", fileName: "sound")
+        brick.sound = sound
+
+        let copiedBrick: PlaySoundAndWaitBrick = brick.mutableCopy(with: CBMutableCopyContext()) as! PlaySoundAndWaitBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.sound.isEqual(to: copiedBrick.sound))
+        XCTAssertTrue(brick.sound === copiedBrick.sound)
+    }
+
+}

--- a/src/CattyTests/Bricks/PointToBrickTests.swift
+++ b/src/CattyTests/Bricks/PointToBrickTests.swift
@@ -82,4 +82,14 @@ final class PointToBrickTests: AbstractBrickTest {
         XCTAssertEqual(45.0, firstSpriteNode.catrobatRotation, accuracy: 0.1, "PointToBrick not correct")
     }
 
+    func testMutableCopy() {
+        secondSpriteNode.spriteObject.name = "second object"
+        let copiedBrick: PointToBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! PointToBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.pointedObject.isEqual(to: copiedBrick.pointedObject))
+        XCTAssertTrue(brick.pointedObject === copiedBrick.pointedObject)
+    }
+
 }

--- a/src/CattyTests/Bricks/RepeatBrickTests.swift
+++ b/src/CattyTests/Bricks/RepeatBrickTests.swift
@@ -73,4 +73,26 @@ final class RepeatBrickTests: XCTestCase {
         XCTAssertEqual(0, repeatBrick.repetitions)
         XCTAssertNil(repeatBrick.maxRepetitions)
     }
+
+    func testMutableCopy() {
+        let interpreter = FormulaManager(sceneSize: CGSize.zero)
+
+        let brick = RepeatBrick()
+        let script = Script()
+        let object = SpriteObject()
+
+        script.object = object
+        brick.script = script
+        brick.timesToRepeat = Formula(double: 2)
+
+        XCTAssertTrue(brick.checkCondition(formulaInterpreter: interpreter))
+
+        let copiedBrick: RepeatBrick = brick.mutableCopy(with: CBMutableCopyContext()) as! RepeatBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.timesToRepeat.isEqual(to: copiedBrick.timesToRepeat))
+        XCTAssertFalse(brick.timesToRepeat === copiedBrick.timesToRepeat)
+    }
+
 }

--- a/src/CattyTests/Bricks/RepeatUntilBrickTests.swift
+++ b/src/CattyTests/Bricks/RepeatUntilBrickTests.swift
@@ -49,4 +49,25 @@ final class RepeatUntilBrickTests: XCTestCase {
         brick.repeatCondition = Formula(double: 1)
         XCTAssertFalse(brick.checkCondition(formulaInterpreter: formulaInterpreter))
     }
+
+    func testMutableCopy() {
+        brick.repeatCondition = Formula.init(double: 0)
+
+        var copiedBrick: RepeatUntilBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! RepeatUntilBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.repeatCondition.isEqual(to: copiedBrick.repeatCondition))
+        XCTAssertFalse(brick.repeatCondition === copiedBrick.repeatCondition)
+
+        brick.repeatCondition = Formula.init(double: 1)
+        copiedBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! RepeatUntilBrick
+
+        XCTAssertTrue(brick.repeatCondition.isEqual(to: copiedBrick.repeatCondition))
+
+        brick.repeatCondition = Formula.init(double: 0)
+
+        XCTAssertFalse(brick.repeatCondition.isEqual(to: copiedBrick.repeatCondition))
+    }
+
 }

--- a/src/CattyTests/Bricks/SetBackgroundBrickTests.swift
+++ b/src/CattyTests/Bricks/SetBackgroundBrickTests.swift
@@ -26,12 +26,25 @@ import XCTest
 
 final class SetBackgroundBrickTests: AbstractBrickTest {
 
-    func testSetBackgroundBrick() {
-        let object = SpriteObject()
-        let project = Project.defaultProject(withName: "a", projectID: "1")
-        let spriteNode = CBSpriteNode(spriteObject: object)
+    var object: SpriteObject!
+    var project: Project!
+    var spriteNode: CBSpriteNode!
+    var script: Script!
+
+    override func setUp() {
+
+        object = SpriteObject()
+        project = Project.defaultProject(withName: "a", projectID: "1")
+        spriteNode = CBSpriteNode(spriteObject: object)
         object.spriteNode = spriteNode
         object.project = project
+
+        script = WhenScript()
+        script.object = object
+
+    }
+
+    func testSetBackgroundBrick() {
 
         let backgroundObject = project.objectList.firstObject as! SpriteObject
         XCTAssertNotNil(backgroundObject)
@@ -54,8 +67,6 @@ final class SetBackgroundBrickTests: AbstractBrickTest {
             XCTFail("Error when writing image data")
         }
 
-        let script = WhenScript()
-        script.object = object
         let brick = SetBackgroundBrick()
         brick.script = script
         brick.look = look1
@@ -69,4 +80,19 @@ final class SetBackgroundBrickTests: AbstractBrickTest {
         XCTAssertEqual(backgroundObject.spriteNode.currentLook, look1, "SetBackgroundBrick not correct")
         Project.removeProjectFromDisk(withProjectName: project.header.programName, projectID: project.header.programID)
     }
+
+    func testMutableCopy() {
+
+        let brick = SetBackgroundBrick()
+        let look = Look(name: "backgroundToCopy", andPath: "background")
+        brick.look = look
+
+        let copiedBrick: SetBackgroundBrick = brick.mutableCopy(with: CBMutableCopyContext()) as! SetBackgroundBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertTrue(brick.look.isEqual(to: copiedBrick.look))
+        XCTAssertTrue(copiedBrick.look.isEqual(to: look))
+        XCTAssertTrue(copiedBrick.look === brick.look)
+    }
+
 }

--- a/src/CattyTests/Bricks/SetLookBrickTests.swift
+++ b/src/CattyTests/Bricks/SetLookBrickTests.swift
@@ -20,59 +20,36 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-#import "WaitUntilBrick.h"
-#import "Script.h"
+import XCTest
 
-@interface WaitUntilBrick()
-@end
+@testable import Pocket_Code
 
-@implementation WaitUntilBrick
+final class SetLookBrickTests: XCTestCase {
 
-- (kBrickCategoryType)category
-{
-    return kControlBrick;
+    var object: SpriteObject!
+    var project: Project!
+    var spriteNode: CBSpriteNode!
+
+    override func setUp() {
+
+        object = SpriteObject()
+        project = Project.defaultProject(withName: "a", projectID: "1")
+        spriteNode = CBSpriteNode(spriteObject: object)
+        object.spriteNode = spriteNode
+        object.project = project
+
+    }
+
+    func testMutableCopy() {
+        let brick = SetLookBrick()
+        let look = Look(name: "lookToCopy", andPath: "look")
+        brick.look = look
+
+        let copiedBrick: SetLookBrick = brick.mutableCopy(with: CBMutableCopyContext()) as! SetLookBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertTrue(brick.look.isEqual(to: copiedBrick.look))
+        XCTAssertTrue(copiedBrick.look === brick.look)
+    }
+
 }
-
-- (BOOL)isAnimateable
-{
-    return YES;
-}
-
-- (Formula*)formulaForLineNumber:(NSInteger)lineNumber andParameterNumber:(NSInteger)paramNumber
-{
-    return self.waitCondition;
-}
-
-- (void)setFormula:(Formula*)formula forLineNumber:(NSInteger)lineNumber andParameterNumber:(NSInteger)paramNumber
-{
-    self.waitCondition = formula;
-}
-
-- (BOOL)allowsStringFormula
-{
-    return NO;
-}
-
-- (NSArray*)getFormulas
-{
-    return @[self.waitCondition];
-}
-
-- (void)setDefaultValuesForObject:(SpriteObject*)spriteObject
-{
-    self.waitCondition = [[Formula alloc] initWithInteger:1];
-}
-
-#pragma mark - Description
-- (NSString*)description
-{
-    return [NSString stringWithFormat:@"WaitForCondition"];
-}
-
-#pragma mark - Resources
-- (NSInteger)getRequiredResources
-{
-    return [self.waitCondition getRequiredResources];
-}
-
-@end

--- a/src/CattyTests/Bricks/WaitUntilBrickTests.swift
+++ b/src/CattyTests/Bricks/WaitUntilBrickTests.swift
@@ -80,6 +80,27 @@ final class WaitUntilBrickTests: XMLAbstractTest {
         XCTAssertFalse(conditionResult, "Condition should have returned false.")
     }
 
+    func testMutableCopy() {
+        var brick = WaitUntilBrick()
+        brick.waitCondition = Formula(float: 0)
+
+        var copiedBrick: WaitUntilBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! WaitUntilBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.waitCondition.isEqual(to: copiedBrick.waitCondition))
+        XCTAssertFalse(brick.waitCondition === copiedBrick.waitCondition)
+
+        brick = WaitUntilBrick()
+        brick.waitCondition = Formula(float: 1)
+
+        copiedBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! WaitUntilBrick
+
+        XCTAssertTrue(brick.waitCondition.isEqual(to: copiedBrick.waitCondition))
+        XCTAssertFalse(brick.waitCondition === copiedBrick.waitCondition)
+
+    }
+
     private func createPredicate(variable: UserVariable, shouldNotBeEqual: NSNumber, forSeconds: Double) -> NSPredicate {
         let stopTime = Date().addingTimeInterval(TimeInterval(forSeconds))
         return NSPredicate(block: { _, _ in


### PR DESCRIPTION
Added new tests to test 'mutable copy' functionality for various bricks. Removed unnecessary overriding 'mutableCopy' methods and added it where required in various subclasses of Brick. 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
