### PR TITLE
Catty-200 Remove deprecated properties of GlideToBrick

### DIFF
--- a/src/Catty/DataModel/Bricks/Motion/GlideToBrick.h
+++ b/src/Catty/DataModel/Bricks/Motion/GlideToBrick.h
@@ -31,10 +31,5 @@
 @property (nonatomic, strong) Formula *xDestination;
 @property (nonatomic, strong) Formula *yDestination;
 
-@property (nonatomic, assign) BOOL isInitialized;
-@property (nonatomic, assign) CGPoint currentPoint;
-@property (nonatomic, assign) CGPoint startingPoint;
-@property (nonatomic) float deltaX;
-@property (nonatomic) float deltaY;
 
 @end

--- a/src/Catty/DataModel/Bricks/Motion/GlideToBrick.m
+++ b/src/Catty/DataModel/Bricks/Motion/GlideToBrick.m
@@ -80,9 +80,6 @@
 
 - (id)init
 {
-    if(self = [super init]) {
-        self.isInitialized = NO;
-    }
     return self;
 }
 


### PR DESCRIPTION
The following properties have been removed from `GlideToBrick` since they are on longer required

isInitialized
currentPoint
startingPoint
deltaX
deltaY

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
