### PR TITLE
CATTY-199: Move BrickCellTests

### DIFF
--- a/src/Catty UITests/ScriptCollectionView/BrickCellTests.swift
+++ b/src/Catty UITests/ScriptCollectionView/BrickCellTests.swift
@@ -35,7 +35,7 @@ class BrickCellTests: XCTestCase {
         super.tearDown()
     }
 
-    func testBrickParameterSpace() {
+    func testVariableBrickParameterSpace() {
 
         let brickWidth: CGFloat
         let initialParameterTextViewWidth: CGFloat

--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -6076,6 +6076,7 @@
 		59DC626D23FAF7A6009C28E3 /* ScriptCollectionView */ = {
 			isa = PBXGroup;
 			children = (
+				22C48767240FFAA3003CB222 /* BrickCellTests.swift */,
 				59F5C2AE23F2E36D00D95016 /* BrickCellPickerViewerTest.swift */,
 				4C1EDCA9218A080200B60464 /* ScriptCollectionVCTests.swift */,
 			);
@@ -8194,7 +8195,6 @@
 				4CF8747221C8E7AB00C8143F /* SoundsTVCTests.swift */,
 				BA6805AD21303B48004F004F /* VariablesTests.swift */,
 				2D227D93220B38E0008A2BC9 /* ScenePresenterVCTests.swift */,
-				22C48767240FFAA3003CB222 /* BrickCellTests.swift */,
 			);
 			path = "Catty UITests";
 			sourceTree = "<group>";


### PR DESCRIPTION
Moved UI test named BrickCellTests to ScriptCollectionView subfolder.

Renamed function testBrickParameterSpace to testVariableBrickParameterSpace

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
