### PR TITLE
CATTY-195 Add non-fatal reports for Crashlytics (projects fetch)

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 		4C1EDCAC218A080200B60464 /* ScriptCollectionVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1EDCA9218A080200B60464 /* ScriptCollectionVCTests.swift */; };
 		4C1F6FA5213CF6BE00C20BEB /* SingleParameterStringFunctionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1F6FA4213CF6BE00C20BEB /* SingleParameterStringFunctionMock.swift */; };
 		4C1F6FA7213CFB5800C20BEB /* FunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1F6FA6213CFB5800C20BEB /* FunctionTests.swift */; };
+		4C245CAC244481F3004C941C /* NimbleMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C245CA9244481F3004C941C /* NimbleMatcher.swift */; };
 		4C26506A1A6538710050775B /* CBMutableCopyContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C2650691A6538710050775B /* CBMutableCopyContext.m */; };
 		4C2732A91CE4F30F00CA61AC /* CBSpriteNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2732A81CE4F30F00CA61AC /* CBSpriteNodeTests.swift */; };
 		4C28D78B2132A83D00870CE2 /* FormulaMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C28D78A2132A83D00870CE2 /* FormulaMock.swift */; };
@@ -1913,6 +1914,7 @@
 		4C1EDCA9218A080200B60464 /* ScriptCollectionVCTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScriptCollectionVCTests.swift; sourceTree = "<group>"; };
 		4C1F6FA4213CF6BE00C20BEB /* SingleParameterStringFunctionMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleParameterStringFunctionMock.swift; sourceTree = "<group>"; };
 		4C1F6FA6213CFB5800C20BEB /* FunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionTests.swift; sourceTree = "<group>"; };
+		4C245CA9244481F3004C941C /* NimbleMatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NimbleMatcher.swift; sourceTree = "<group>"; };
 		4C2650681A6538710050775B /* CBMutableCopyContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CBMutableCopyContext.h; path = CBCopyContext/CBMutableCopyContext.h; sourceTree = "<group>"; };
 		4C2650691A6538710050775B /* CBMutableCopyContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CBMutableCopyContext.m; path = CBCopyContext/CBMutableCopyContext.m; sourceTree = "<group>"; };
 		4C26506C1A653A5A0050775B /* CBMutableCopying.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CBMutableCopying.h; path = Copying/CBMutableCopying.h; sourceTree = "<group>"; };
@@ -5669,9 +5671,10 @@
 		4CD0BA92214678D500BF17A4 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				22524C37239FAFC500DD515E /* LoginViewControllerTests.swift */,
-				4CD0BA952146791D00BF17A4 /* UtilTests.swift */,
 				9E1444F5228B531400104F77 /* ExtendedTimerTests.swift */,
+				22524C37239FAFC500DD515E /* LoginViewControllerTests.swift */,
+				4C245CA9244481F3004C941C /* NimbleMatcher.swift */,
+				4CD0BA952146791D00BF17A4 /* UtilTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -9258,7 +9261,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/usr/libexec/PlistBuddy \"$SRCROOT/Catty/Settings.bundle/Root.plist\" -c \"set PreferenceSpecifiers:3:DefaultValue $MARKETING_VERSION\"\n";
-
 		};
 		CADBD6D619B0E8C200C62836 /* Catty Precompile Tests */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -9592,6 +9594,7 @@
 				4CC50A53213AE386004BC914 /* FormulaManagerIdempotenceTests.swift in Sources */,
 				4C822666213FA7A400F3D750 /* LongitudeSensorTest.swift in Sources */,
 				4C822665213FA7A400F3D750 /* AltitudeSensorTest.swift in Sources */,
+				4C245CAC244481F3004C941C /* NimbleMatcher.swift in Sources */,
 				4CB73A9023FC1F0400D5E9A7 /* CatrobatTableViewControllerMock.swift in Sources */,
 				9E445888230A021100222B14 /* ChromaprintFingerprinter.swift in Sources */,
 				4C7182E323EF0AEB00195BC7 /* FormulaEditorViewControllerTests.swift in Sources */,

--- a/src/Catty/Extension&Delegate&Protocol/Extensions/Notification/NotificationExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/Notification/NotificationExtension.swift
@@ -31,6 +31,7 @@ extension Notification.Name {
     static var brickSelected: Notification.Name { .init(rawValue: NotificationName.brickSelected) }
     static var projectInvalidVersion: Notification.Name { .init(rawValue: NotificationName.projectInvalidVersion) }
     static var projectInvalidXml: Notification.Name { .init(rawValue: NotificationName.projectInvalidXml) }
+    static var projectFetchFailure: Notification.Name { .init(rawValue: NotificationName.projectFetchFailure) }
     static var projectFetchDetailsFailure: Notification.Name { .init(rawValue: NotificationName.projectFetchDetailsFailure) }
     static var settingsCrashReportingChanged: Notification.Name { .init(rawValue: NotificationName.settingsCrashReportingChanged) }
 }
@@ -47,6 +48,7 @@ public class NotificationName: NSObject {
     public static let brickSelected = "BrickCategoryViewController.brickSelected"
     public static let projectInvalidVersion = "Project.invalidVersion"
     public static let projectInvalidXml = "Project.invalidXml"
+    public static let projectFetchFailure = "Project.fetchFailure"
     public static let projectFetchDetailsFailure = "Project.fetchDetailsFailure"
     public static let settingsCrashReportingChanged = "SettingsTableViewController.crashReportingChanged"
 }

--- a/src/Catty/Setup/Firebase/AppDelegateFirebaseExtension.swift
+++ b/src/Catty/Setup/Firebase/AppDelegateFirebaseExtension.swift
@@ -55,6 +55,7 @@ extension AppDelegate {
             addObserver(selector: #selector(self.brickSelected(notification:)), name: .brickSelected)
             addObserver(selector: #selector(self.projectInvalidVersion(notification:)), name: .projectInvalidVersion)
             addObserver(selector: #selector(self.projectInvalidXml(notification:)), name: .projectInvalidXml)
+            addObserver(selector: #selector(self.projectFetchFailure(notification:)), name: .projectFetchFailure)
             addObserver(selector: #selector(self.projectFetchDetailsFailure(notification:)), name: .projectFetchDetailsFailure)
         }
 
@@ -121,6 +122,20 @@ extension AppDelegate {
                         "projectName": projectName]
 
         let error = NSError(domain: "ProjectParserError", code: 501, userInfo: userInfo)
+        crashlytics.record(error: error)
+    }
+
+    @objc func projectFetchFailure(notification: Notification) {
+        var info: [String: Any] = [:]
+
+        if let errorInfo = notification.object as? ProjectFetchFailureInfo {
+            info["type"] = errorInfo.type ?? type(of: self).logNoValue
+            info["url"] = errorInfo.url
+            info["statusCode"] = errorInfo.type ?? type(of: self).logNoValue
+            info["description"] = errorInfo.description
+        }
+
+        let error = NSError(domain: "ProjectFetchError", code: 410, userInfo: info)
         crashlytics.record(error: error)
     }
 

--- a/src/CattyTests/Setup/Firebase/FirebaseCrashlyticsSetupTests.swift
+++ b/src/CattyTests/Setup/Firebase/FirebaseCrashlyticsSetupTests.swift
@@ -136,6 +136,28 @@ final class FirebaseCrashlyticsSetupTests: XCTestCase {
         XCTAssertEqual(1, crashlytics!.records.count)
     }
 
+    func testProjectFetchFailureNotification() {
+        UserDefaults.standard.set(true, forKey: kFirebaseSendCrashReports)
+        app?.setupCrashlytics()
+
+        let errorInfo = ProjectFetchFailureInfo(type: nil, url: "testurl", statusCode: nil, description: "Invalid API response while fetching project")
+
+        let expectedErrorValue: String = "No value"
+        let info: [String: Any] = ["type": expectedErrorValue,
+                                   "url": errorInfo.url,
+                                   "statusCode": expectedErrorValue,
+                                   "description": errorInfo.description]
+
+        let error = NSError(domain: "ProjectFetchError", code: 410, userInfo: info)
+
+        NotificationCenter.default.post(name: .projectFetchFailure, object: errorInfo)
+
+        XCTAssertEqual(0, crashlytics!.logs.count)
+        XCTAssertEqual(1, crashlytics!.records.count)
+        XCTAssertEqual(error.domain, (crashlytics!.records.first as NSError?)?.domain)
+        XCTAssertEqual(error.userInfo as NSDictionary, (crashlytics!.records.first! as NSError).userInfo as NSDictionary)
+    }
+
     func testProjectFetchDetailsFailureNotification() {
         UserDefaults.standard.set(true, forKey: kFirebaseSendCrashReports)
         app?.setupCrashlytics()

--- a/src/CattyTests/Utils/NimbleMatcher.swift
+++ b/src/CattyTests/Utils/NimbleMatcher.swift
@@ -1,0 +1,34 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import Nimble
+
+public func contain<T: Equatable>(_ expectedNotificationName: Notification.Name, expectedObject: T) -> Predicate<[Notification]> {
+    Predicate.define("contain " + stringify(expectedNotificationName) + " with object " + stringify(expectedObject)) { actualExpression, msg in
+        guard let actualNotifications = try actualExpression.evaluate() else {
+            return PredicateResult(status: .fail, message: msg)
+        }
+
+        let matches = actualNotifications.filter { $0.name == expectedNotificationName && ($0.object as? T) == expectedObject }
+        return PredicateResult(bool: !matches.isEmpty, message: msg)
+    }
+}


### PR DESCRIPTION
Added non-fatal reports for Crashlytics when fetching projects for different possible failures. Included Unit tests for different project types (featured, most downloaded, most recent, most viewed). Added new Observer and Notification projectFetchFailure.


- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline]
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
