### PR TITLE
CATTY-222 set stroke color of brick cell to strokeColorDisabled of category

### DIFF
--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/BrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/BrickCell.m
@@ -399,18 +399,19 @@
     UIColor *fillColor = category.color;
     UIColor *strokeColor = category.strokeColor;
     UIColor *grayColor = [category colorDisabled];
+    UIColor *grayStrokeColor = [category strokeColorDisabled];
         
     if ([self isScriptBrick]) {
         Script *script = (Script*)[self scriptOrBrick];
         if (script.isDisabled) {
             fillColor = grayColor;
-            strokeColor = [fillColor colorWithAlphaComponent:0.5];
+            strokeColor = grayStrokeColor;
         }
     } else {
         Brick *brick = (Brick*)[self scriptOrBrick];
         if (brick.isDisabled) {
             fillColor = grayColor;
-            strokeColor = [fillColor colorWithAlphaComponent:0.5];
+            strokeColor = grayStrokeColor;
         }
     }
     kBrickShapeType shapeType = [self brickShapeType];


### PR DESCRIPTION
Make sure, that the stripes are still visible when a brick is disabled. Use the disabled stroke color of the bricks category.

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
