### PR TITLE
CATTY-225 Change license

### DIFF
--- a/src/Catty/Supporting Files/App-Info.plist
+++ b/src/Catty/Supporting Files/App-Info.plist
@@ -54,7 +54,7 @@
 	<key>CatrobatPlatformName</key>
 	<string>iOS</string>
 	<key>CatrobatProgramLicense</key>
-	<string>http://developer.catrobat.org/agpl_v3</string>
+	<string>https://developer.catrobat.org/agpl_v3</string>
 	<key>FIREBASE_ANALYTICS_COLLECTION_ENABLED</key>
 	<false/>
 	<key>FirebaseCrashlyticsCollectionEnabled</key>


### PR DESCRIPTION
The URL for the media license is changed from `http://developer.catrobat.org/agpl_v3` to `https://developer.catrobat.org/agpl_v3` in `App-Info.plist`.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
