### PR TITLE
CATTY-228 Fix crash in Settings for older iOS versions

### DIFF
--- a/src/Catty/ViewController/CatrobatTableViewController/SettingsTableViewController.swift
+++ b/src/Catty/ViewController/CatrobatTableViewController/SettingsTableViewController.swift
@@ -24,6 +24,11 @@ import Foundation
 
 class SettingsTableViewController: BOTableViewController {
 
+    static let unusedKey = "unused"
+
+    let aboutPocketCodeViewController = AboutPocketCodeOptionTableViewController()
+    let termsOfUseViewController = TermsOfUseOptionTableViewController()
+
     override func setup() {
 
         title = kLocalizedSettings
@@ -76,7 +81,7 @@ class SettingsTableViewController: BOTableViewController {
         if Util.isPhiroActivated() || Util.isArduinoActivated() {
             addSection(BOTableViewSection(headerTitle: "", handler: { section in
                 if service.phiro != nil || service.arduino != nil {
-                    section?.addCell(BOButtonTableViewCell(title: kLocalizedDisconnectAllDevices, key: nil, handler: { cell in
+                    section?.addCell(BOButtonTableViewCell(title: kLocalizedDisconnectAllDevices, key: type(of: self).unusedKey, handler: { cell in
                         if let disconnectAllDevicesCellButton = cell as? BOButtonTableViewCell {
                             disconnectAllDevicesCellButton.backgroundColor = UIColor.background
                             disconnectAllDevicesCellButton.mainColor = UIColor.globalTint
@@ -88,7 +93,7 @@ class SettingsTableViewController: BOTableViewController {
                 }
                 let tempArray = UserDefaults.standard.array(forKey: "KnownBluetoothDevices")
                 if tempArray?.count != nil {
-                    section?.addCell(BOButtonTableViewCell(title: kLocalizedRemoveKnownDevices, key: nil, handler: { cell in
+                    section?.addCell(BOButtonTableViewCell(title: kLocalizedRemoveKnownDevices, key: type(of: self).unusedKey, handler: { cell in
                         if let removeKnownDevicesCellButton = cell as? BOButtonTableViewCell {
                             removeKnownDevicesCellButton.backgroundColor = UIColor.background
                             removeKnownDevicesCellButton.mainColor = UIColor.globalTint
@@ -103,7 +108,7 @@ class SettingsTableViewController: BOTableViewController {
 
         if (UserDefaults.standard.value(forKey: kUserIsLoggedIn) as? NSNumber)?.boolValue ?? false {
             addSection(BOTableViewSection(headerTitle: "", handler: { section in
-                section?.addCell(BOButtonTableViewCell(title: kLocalizedLogout, key: nil, handler: { cell in
+                section?.addCell(BOButtonTableViewCell(title: kLocalizedLogout, key: type(of: self).unusedKey, handler: { cell in
                     if let userIsLoggedInCellButton = cell as? BOButtonTableViewCell {
                         userIsLoggedInCellButton.backgroundColor = UIColor.background
                         userIsLoggedInCellButton.mainColor = UIColor.variableBrickRed
@@ -117,17 +122,17 @@ class SettingsTableViewController: BOTableViewController {
         }
 
         addSection(BOTableViewSection(headerTitle: "", handler: { section in
-            section?.addCell(BOChoiceTableViewCell(title: kLocalizedAboutPocketCode, key: nil, handler: { cell in
+            section?.addCell(BOChoiceTableViewCell(title: kLocalizedAboutPocketCode, key: type(of: self).unusedKey, handler: { cell in
                 if let aboutPocketCodeCellChoice = cell as? BOChoiceTableViewCell {
-                    aboutPocketCodeCellChoice.destinationViewController = AboutPocketCodeOptionTableViewController()
+                    aboutPocketCodeCellChoice.destinationViewController = self.aboutPocketCodeViewController
                     aboutPocketCodeCellChoice.backgroundColor = UIColor.background
                     aboutPocketCodeCellChoice.mainColor = UIColor.globalTint
                 }
             }))
 
-            section?.addCell(BOChoiceTableViewCell(title: kLocalizedTermsOfUse, key: nil, handler: { cell in
+            section?.addCell(BOChoiceTableViewCell(title: kLocalizedTermsOfUse, key: type(of: self).unusedKey, handler: { cell in
                 if let termsOfUseCellChoice = cell as? BOChoiceTableViewCell {
-                    termsOfUseCellChoice.destinationViewController = TermsOfUseOptionTableViewController()
+                    termsOfUseCellChoice.destinationViewController = self.termsOfUseViewController
                     termsOfUseCellChoice.backgroundColor = UIColor.background
                     termsOfUseCellChoice.mainColor = UIColor.globalTint
                 }
@@ -135,7 +140,7 @@ class SettingsTableViewController: BOTableViewController {
         }))
 
         addSection(BOTableViewSection(headerTitle: "", handler: { section in
-            section?.addCell(BOButtonTableViewCell(title: kLocalizedPrivacySettings, key: nil, handler: { cell in
+            section?.addCell(BOButtonTableViewCell(title: kLocalizedPrivacySettings, key: type(of: self).unusedKey, handler: { cell in
                 if let privacyCellButton = cell as? BOButtonTableViewCell {
                     privacyCellButton.backgroundColor = UIColor.background
                     privacyCellButton.mainColor = UIColor.globalTint
@@ -145,7 +150,7 @@ class SettingsTableViewController: BOTableViewController {
                 }
             }))
 
-            section?.addCell(BOButtonTableViewCell(title: kLocalizedRateUs, key: nil, handler: { cell in
+            section?.addCell(BOButtonTableViewCell(title: kLocalizedRateUs, key: type(of: self).unusedKey, handler: { cell in
                 if let rateUsCellButton = cell as? BOButtonTableViewCell {
                     rateUsCellButton.backgroundColor = UIColor.background
                     rateUsCellButton.mainColor = UIColor.globalTint


### PR DESCRIPTION
Fix crash in Settings for older iOS versions. This crash occurred for iOS 10, 11 and 12, not for the most recent iOS 13.

Reason for this crash is that the outdated Bohr dependency holds an weak reference to the `destinationViewController` (https://github.com/davdroman/Bohr/blob/883ac77d59e1612e2ab549261657a6f01d42720d/Bohr/BOTableViewCell.h#L39).

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
