### PR TITLE
CATTY-196 Add non-fatal reports for Crashlytics (media library)

### DIFF
--- a/src/Catty/Extension&Delegate&Protocol/Extensions/Notification/NotificationExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/Notification/NotificationExtension.swift
@@ -35,6 +35,8 @@ extension Notification.Name {
     static var projectFetchDetailsFailure: Notification.Name { .init(rawValue: NotificationName.projectFetchDetailsFailure) }
     static var projectSearchFailure: Notification.Name { .init(rawValue: NotificationName.projectSearchFailure) }
     static var settingsCrashReportingChanged: Notification.Name { .init(rawValue: NotificationName.settingsCrashReportingChanged) }
+    static var mediaLibraryDownloadIndexFailure: Notification.Name { .init(rawValue: NotificationName.mediaLibraryDownloadIndexFailure) }
+    static var mediaLibraryDownloadDataFailure: Notification.Name { .init(rawValue: NotificationName.mediaLibraryDownloadDataFailure) }
 }
 
 @objcMembers
@@ -53,4 +55,6 @@ public class NotificationName: NSObject {
     public static let projectFetchDetailsFailure = "Project.fetchDetailsFailure"
     public static let projectSearchFailure = "Project.searchFailure"
     public static let settingsCrashReportingChanged = "SettingsTableViewController.crashReportingChanged"
+    public static let mediaLibraryDownloadIndexFailure = "MediaLibrary.DownloadIndexFailure"
+    public static let mediaLibraryDownloadDataFailure = "MediaLibrary.DownloadDataFailure"
 }

--- a/src/Catty/Setup/Firebase/AppDelegateFirebaseExtension.swift
+++ b/src/Catty/Setup/Firebase/AppDelegateFirebaseExtension.swift
@@ -58,6 +58,8 @@ extension AppDelegate {
             addObserver(selector: #selector(self.projectFetchFailure(notification:)), name: .projectFetchFailure)
             addObserver(selector: #selector(self.projectFetchDetailsFailure(notification:)), name: .projectFetchDetailsFailure)
             addObserver(selector: #selector(self.projectSearchFailure(notification:)), name: .projectSearchFailure)
+            addObserver(selector: #selector(self.mediaLibraryDownloadIndexFailure(notification:)), name: .mediaLibraryDownloadIndexFailure)
+            addObserver(selector: #selector(self.mediaLibraryDownloadDataFailure(notification:)), name: .mediaLibraryDownloadDataFailure)
         }
 
         addObserver(selector: #selector(self.settingsCrashReportingChanged(notification:)), name: .settingsCrashReportingChanged)
@@ -142,6 +144,32 @@ extension AppDelegate {
 
     @objc func projectFetchDetailsFailure(notification: Notification) {
         let error = NSError(domain: "ProjectFetchDetailsError", code: 400, userInfo: notification.userInfo as? [String: Any] ?? [:])
+        crashlytics.record(error: error)
+    }
+
+    @objc func mediaLibraryDownloadIndexFailure(notification: Notification) {
+        var info: [String: Any] = [:]
+
+        if let errorInfo = notification.object as? MediaLibraryDownloadFailureInfo {
+            info["url"] = errorInfo.url
+            info["statusCode"] = errorInfo.statusCode
+            info["description"] = errorInfo.description
+        }
+
+        let error = NSError(domain: "MediaLibraryDownloadIndexError", code: 420, userInfo: info)
+        crashlytics.record(error: error)
+    }
+
+    @objc func mediaLibraryDownloadDataFailure(notification: Notification) {
+        var info: [String: Any] = [:]
+
+        if let errorInfo = notification.object as? MediaLibraryDownloadFailureInfo {
+            info["url"] = errorInfo.url
+            info["statusCode"] = errorInfo.statusCode
+            info["description"] = errorInfo.description
+        }
+
+        let error = NSError(domain: "MediaLibraryDownloadDataError", code: 430, userInfo: info)
         crashlytics.record(error: error)
     }
 

--- a/src/CattyTests/Setup/Firebase/FirebaseCrashlyticsSetupTests.swift
+++ b/src/CattyTests/Setup/Firebase/FirebaseCrashlyticsSetupTests.swift
@@ -204,4 +204,43 @@ final class FirebaseCrashlyticsSetupTests: XCTestCase {
         XCTAssertEqual(error.userInfo as NSDictionary, (crashlytics!.records.last! as NSError).userInfo as NSDictionary)
     }
 
+    func testMediaLibraryDownloadIndexFailureNotification() {
+        UserDefaults.standard.set(true, forKey: kFirebaseSendCrashReports)
+        app?.setupCrashlytics()
+
+        let errorInfo = MediaLibraryDownloadFailureInfo(url: "testUrl", statusCode: 404, description: "Invalid Response while downloading media library index")
+
+        let info: [String: Any] = ["url": errorInfo.url,
+                                   "statusCode": errorInfo.statusCode as Any,
+                                   "description": errorInfo.description]
+
+        let error = NSError(domain: "MediaLibraryDownloadIndexError", code: 420, userInfo: info)
+
+        NotificationCenter.default.post(name: .mediaLibraryDownloadIndexFailure, object: errorInfo)
+
+        XCTAssertEqual(0, crashlytics!.logs.count)
+        XCTAssertEqual(1, crashlytics!.records.count)
+        XCTAssertEqual(error.domain, (crashlytics!.records.first as NSError?)?.domain)
+        XCTAssertEqual(error.userInfo as NSDictionary, (crashlytics!.records.first! as NSError).userInfo as NSDictionary)
+    }
+
+    func testMediaLibraryDownloadDataFailureNotification() {
+        UserDefaults.standard.set(true, forKey: kFirebaseSendCrashReports)
+        app?.setupCrashlytics()
+
+        let errorInfo = MediaLibraryDownloadFailureInfo(url: "testUrl", statusCode: 404, description: "Invalid Response while downloading media library data")
+
+        let info: [String: Any] = ["url": errorInfo.url,
+                                   "statusCode": errorInfo.statusCode as Any,
+                                   "description": errorInfo.description]
+
+        let error = NSError(domain: "MediaLibraryDownloadDataError", code: 430, userInfo: info)
+
+        NotificationCenter.default.post(name: .mediaLibraryDownloadDataFailure, object: errorInfo)
+
+        XCTAssertEqual(0, crashlytics!.logs.count)
+        XCTAssertEqual(1, crashlytics!.records.count)
+        XCTAssertEqual(error.domain, (crashlytics!.records.first as NSError?)?.domain)
+        XCTAssertEqual(error.userInfo as NSDictionary, (crashlytics!.records.first! as NSError).userInfo as NSDictionary)
+    }
 }


### PR DESCRIPTION
Added non-fatal reports for Crashlytics when downloading media library index or data for possible failures. Included Unit tests for different errors. Added new Observer and Notification mediaLibraryDownloadIndex and mediaLibraryDownloadData. Added FirebaseCrashlyticsSetup test.

https://jira.catrob.at/browse/CATTY-196

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
