### PR TITLE
CATTY-244 Modify StoreProjectDownloaderProtocol

### DIFF
--- a/src/Catty/ViewController/Download/ChartProjects/ChartProjectStoreDataSource.swift
+++ b/src/Catty/ViewController/Download/ChartProjects/ChartProjectStoreDataSource.swift
@@ -194,7 +194,7 @@ class ChartProjectStoreDataSource: NSObject, UITableViewDataSource, UITableViewD
         }
         self.delegate?.showLoadingIndicator(false)
 
-        self.downloader.fetchProjectDetails(for: cellProject) { project, error in
+        self.downloader.fetchProjectDetails(for: cellProject.projectId) { project, error in
             guard timer.isValid else { return }
             guard let StoreProject = project, error == nil else { return }
             cell.project = StoreProject

--- a/src/Catty/ViewController/Download/FeaturedProjects/FeaturedProjectsStoreTableDataSource.swift
+++ b/src/Catty/ViewController/Download/FeaturedProjects/FeaturedProjectsStoreTableDataSource.swift
@@ -82,7 +82,7 @@ class FeaturedProjectsStoreTableDataSource: NSObject, UITableViewDataSource, UIT
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cell: FeaturedProjectsCell? = tableView.cellForRow(at: indexPath) as? FeaturedProjectsCell
 
-        self.downloader.fetchProjectDetails(for: (cell?.project)!) { project, error in
+        self.downloader.fetchProjectDetails(for: (cell?.project)!.projectId) { project, error in
             guard let StoreProject = project, error == nil else { return }
             cell?.project = StoreProject
             self.delegate?.selectedCell(dataSource: self, didSelectCellWith: cell!)

--- a/src/Catty/ViewController/Download/SearchStore/SearchStoreDataSource.swift
+++ b/src/Catty/ViewController/Download/SearchStore/SearchStoreDataSource.swift
@@ -135,7 +135,7 @@ class SearchStoreDataSource: NSObject, UITableViewDataSource, UITableViewDelegat
         self.delegate?.showLoadingIndicator()
 
         guard let cellProject = cell?.project else { return }
-        self.downloader.fetchProjectDetails(for: cellProject) { project, error in
+        self.downloader.fetchProjectDetails(for: cellProject.projectId) { project, error in
             guard timer.isValid else { return }
             guard let StoreProject = project, error == nil else { return }
             guard let cell = cell else { return }

--- a/src/Catty/ViewController/Download/StoreProjectDownloader.swift
+++ b/src/Catty/ViewController/Download/StoreProjectDownloader.swift
@@ -23,7 +23,7 @@
 protocol StoreProjectDownloaderProtocol {
     func fetchProjects(forType: ProjectType, offset: Int, completion: @escaping (StoreProjectCollection.StoreProjectCollectionText?, StoreProjectDownloaderError?) -> Void)
     func fetchSearchQuery(searchTerm: String, completion: @escaping (StoreProjectCollection.StoreProjectCollectionNumber?, StoreProjectDownloaderError?) -> Void)
-    func fetchProjectDetails(for project: StoreProject, completion: @escaping (StoreProject?, StoreProjectDownloaderError?) -> Void)
+    func fetchProjectDetails(for projectId: String, completion: @escaping (StoreProject?, StoreProjectDownloaderError?) -> Void)
     func download(projectId: String, completion: @escaping (Data?, StoreProjectDownloaderError?) -> Void, progression: ((Float) -> Void)?)
 }
 
@@ -162,8 +162,8 @@ final class StoreProjectDownloader: StoreProjectDownloaderProtocol {
         }.resume()
     }
 
-    func fetchProjectDetails(for project: StoreProject, completion: @escaping (StoreProject?, StoreProjectDownloaderError?) -> Void) {
-        guard let indexURL = URL(string: "\(NetworkDefines.connectionHost)/\(NetworkDefines.connectionIDQuery)?id=\(project.projectId)") else { return }
+    func fetchProjectDetails(for projectId: String, completion: @escaping (StoreProject?, StoreProjectDownloaderError?) -> Void) {
+        guard let indexURL = URL(string: "\(NetworkDefines.connectionHost)/\(NetworkDefines.connectionIDQuery)?id=\(projectId)") else { return }
 
         self.session.dataTask(with: URLRequest(url: indexURL)) { data, response, error in
             let handleDataTaskCompletion: (Data?, URLResponse?, Error?) -> (project: StoreProject?, error: StoreProjectDownloaderError?)
@@ -171,7 +171,7 @@ final class StoreProjectDownloader: StoreProjectDownloaderProtocol {
                 guard let response = response as? HTTPURLResponse else { return (nil, .unexpectedError) }
 
                 guard let data = data, response.statusCode == 200, error == nil else {
-                    let userInfo = ["projectId": project.projectId,
+                    let userInfo = ["projectId": projectId,
                                     "url": indexURL.absoluteString,
                                     "statusCode": response.statusCode,
                                     "error": error?.localizedDescription ?? ""] as [String: Any]

--- a/src/CattyTests/Download/StoreProjectsDownloaderTests.swift
+++ b/src/CattyTests/Download/StoreProjectsDownloaderTests.swift
@@ -754,10 +754,10 @@ class StoreProjectsDownloaderTests: XCTestCase {
     func testFetchProjectDetailsSucceeds() {
         let dvrSession = Session(cassetteName: "StoreProjectDownloader.fetchProjectDetails.success")
         let downloader = StoreProjectDownloader(session: dvrSession)
-        let project = getStoreProjectMock()
+        let projectId = "821"
         let expectation = XCTestExpectation(description: "Download Featured Project")
 
-        downloader.fetchProjectDetails(for: project) { data, error in
+        downloader.fetchProjectDetails(for: projectId) { data, error in
             XCTAssertNil(error, "request failed")
             guard data != nil else { XCTFail("no data received"); return }
             expectation.fulfill()
@@ -769,10 +769,10 @@ class StoreProjectsDownloaderTests: XCTestCase {
     func testFetchProjectDetailsSucceedsWithIntegerId() {
         let dvrSession = Session(cassetteName: "StoreProjectDownloader.fetchProjectDetails.IntegerId.success")
         let downloader = StoreProjectDownloader(session: dvrSession)
-        let project = getStoreProjectMock()
+        let projectId = "821"
         let expectation = XCTestExpectation(description: "Download Featured Project")
 
-        downloader.fetchProjectDetails(for: project) { data, error in
+        downloader.fetchProjectDetails(for: projectId) { data, error in
             XCTAssertNil(error, "request failed")
             guard data != nil else { XCTFail("no data received"); return }
             expectation.fulfill()
@@ -785,9 +785,9 @@ class StoreProjectsDownloaderTests: XCTestCase {
         let mockSession = URLSessionMock()
         let downloader = StoreProjectDownloader(session: mockSession)
         let expectation = XCTestExpectation(description: "Fetch Featured Projects")
-        let project = getStoreProjectMock()
+        let projectId = "821"
 
-        downloader.fetchProjectDetails(for: project) { _, error in
+        downloader.fetchProjectDetails(for: projectId) { _, error in
             guard let error = error else { XCTFail("no error returned"); return }
             XCTAssertEqual(error, .unexpectedError)
             expectation.fulfill()
@@ -800,9 +800,9 @@ class StoreProjectsDownloaderTests: XCTestCase {
         let dvrSession = Session(cassetteName: "StoreProjectDownloader.fetchProjectDetails.fail.request")
         let downloader = StoreProjectDownloader(session: dvrSession)
         let expectation = XCTestExpectation(description: "Fetch Featured Projects")
-        let project = getStoreProjectMock()
+        let projectId = "821"
 
-        downloader.fetchProjectDetails(for: project) { _, error in
+        downloader.fetchProjectDetails(for: projectId) { _, error in
             guard let error = error else { XCTFail("no error received"); return }
             switch error {
             case let .request(error: _, statusCode: statusCode):
@@ -816,20 +816,20 @@ class StoreProjectsDownloaderTests: XCTestCase {
     }
 
     func testFetchProjectDetailsNotFoundNotification() {
-        let project = getStoreProjectMock()
-        let url = URL(string: "\(NetworkDefines.connectionHost)/\(NetworkDefines.connectionIDQuery)?id=\(project.projectId)")!
+        let projectId = "821"
+        let url = URL(string: "\(NetworkDefines.connectionHost)/\(NetworkDefines.connectionIDQuery)?id=\(projectId)")!
         let response = HTTPURLResponse(url: url, statusCode: 404, httpVersion: nil, headerFields: nil)
         let error = ErrorMock("errorDescription")
         let session = URLSessionMock(response: response, error: error)
         let downloader = StoreProjectDownloader(session: session)
-        let userInfo = ["projectId": project.projectId,
+        let userInfo = ["projectId": projectId,
                         "url": url.absoluteString,
                         "statusCode": 404,
                         "error": error.localizedDescription] as [String: Any]
 
         let expectedNotification = Notification(name: .projectFetchDetailsFailure, object: downloader, userInfo: userInfo)
 
-        expect(downloader.fetchProjectDetails(for: project) { _, _ in }).toEventually(postNotifications(contain(expectedNotification)))
+        expect(downloader.fetchProjectDetails(for: projectId) { _, _ in }).toEventually(postNotifications(contain(expectedNotification)))
     }
 
     // MARK: - Download project
@@ -898,25 +898,6 @@ class StoreProjectsDownloaderTests: XCTestCase {
             expectation.fulfill()
         })
         wait(for: [expectation], timeout: 1)
-    }
-
-    private func getStoreProjectMock() -> StoreProject {
-        StoreProject(projectId: "821",
-                     projectName: "Whack A Mole",
-                     projectNameShort: "",
-                     author: "VesnaK",
-                     description: "",
-                     version: "",
-                     views: 0,
-                     downloads: 0,
-                     uploaded: 0,
-                     uploadedString: "",
-                     screenshotBig: "",
-                     screenshotSmall: "",
-                     projectUrl: "",
-                     downloadUrl: "",
-                     fileSize: 1.0,
-                     featuredImage: "")
     }
 }
 

--- a/src/CattyTests/Mocks/StoreProjectDownloaderMock.swift
+++ b/src/CattyTests/Mocks/StoreProjectDownloaderMock.swift
@@ -50,7 +50,7 @@ final class StoreProjectDownloaderMock: StoreProjectDownloaderProtocol {
         }
     }
 
-    func fetchProjectDetails(for project: StoreProject, completion: @escaping (StoreProject?, StoreProjectDownloaderError?) -> Void) {
+    func fetchProjectDetails(for projectId: String, completion: @escaping (StoreProject?, StoreProjectDownloaderError?) -> Void) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
             completion(self.project, nil)
         }


### PR DESCRIPTION
StoreProjectDownloaderProtocol is modified so that fetchProjectDetails gets a string projectId as the first parameter.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
