### PR TITLE
Catty-163: New value overwrites most recent value for Broadcast

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		44B76EC72476C19600DC30E2 /* FirebaseCrashlyticsReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B76EC52476C19500DC30E2 /* FirebaseCrashlyticsReporter.swift */; };
 		44B76EC82476C19600DC30E2 /* FirebaseAnalyticsReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44B76EC62476C19500DC30E2 /* FirebaseAnalyticsReporter.swift */; };
 		4647D55A23D8AF9F001A67F6 /* PrivacyPolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647D55923D8AF9F001A67F6 /* PrivacyPolicyViewController.swift */; };
+		46F1754E24C46837006B2ACA /* ScriptCollectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F1754D24C46837006B2ACA /* ScriptCollectionViewControllerTests.swift */; };
 		4C03A4BE2133FD05007BFFD2 /* FormulaManager+Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C03A4BD2133FD05007BFFD2 /* FormulaManager+Resources.swift */; };
 		4C03A4C22133FDE7007BFFD2 /* FormulaManager+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C03A4C12133FDE7007BFFD2 /* FormulaManager+Editor.swift */; };
 		4C03A4C42133FF4B007BFFD2 /* FormulaManager+Interpreter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C03A4C32133FF4B007BFFD2 /* FormulaManager+Interpreter.swift */; };
@@ -1936,6 +1937,7 @@
 		44B76EC52476C19500DC30E2 /* FirebaseCrashlyticsReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseCrashlyticsReporter.swift; sourceTree = "<group>"; };
 		44B76EC62476C19500DC30E2 /* FirebaseAnalyticsReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirebaseAnalyticsReporter.swift; sourceTree = "<group>"; };
 		4647D55923D8AF9F001A67F6 /* PrivacyPolicyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyViewController.swift; sourceTree = "<group>"; };
+		46F1754D24C46837006B2ACA /* ScriptCollectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptCollectionViewControllerTests.swift; sourceTree = "<group>"; };
 		481639B0D938C88A5E2E6963 /* ms */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4997640FD2AB79927E45C4EF /* ca */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4C03A4BD2133FD05007BFFD2 /* FormulaManager+Resources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormulaManager+Resources.swift"; sourceTree = "<group>"; };
@@ -4966,6 +4968,7 @@
 				D3CF986123FD23E40076F366 /* ScriptCollectionViewControllerDisableTests.swift */,
 				4C7182D723EEAFF600195BC7 /* BaseCollectionViewControllerTests.swift */,
 				4C4B4CE523EEA6BF0054C861 /* BaseTableViewControllerTests.swift */,
+				46F1754D24C46837006B2ACA /* ScriptCollectionViewControllerTests.swift */,
 				4C7182DE23EEF21800195BC7 /* BrickCategoryViewControllerTests.swift */,
 				4CAEB26B23F3F8BC00DB31BB /* CatrobatTableViewControllerTests.swift */,
 				4C4B4CDE23EE98C80054C861 /* CustomAlertControllerTests.swift */,
@@ -9888,6 +9891,7 @@
 				4C822667213FA7A400F3D750 /* LocationAccuracySensorTest.swift in Sources */,
 				4C822677213FA7A400F3D750 /* RotationSensorTest.swift in Sources */,
 				9E0F740E22B53C9F0030CD89 /* AudioPlayerMock.swift in Sources */,
+				46F1754E24C46837006B2ACA /* ScriptCollectionViewControllerTests.swift in Sources */,
 				4C82265B213FA7A400F3D750 /* ObjectStringSensorMock.swift in Sources */,
 				9E4D2386232AE9E5009D0C3C /* GoNStepsBackBrickTests.swift in Sources */,
 				4CEB22751B95E4BC00B3BE2F /* BrickInsertManagerLogicTests.m in Sources */,

--- a/src/Catty/DataModel/Bricks/Control/BroadcastBrick.m
+++ b/src/Catty/DataModel/Bricks/Control/BroadcastBrick.m
@@ -43,9 +43,9 @@
 - (void)setDefaultValuesForObject:(SpriteObject*)spriteObject
 {
     if(spriteObject) {
-        NSArray *messages = [Util allMessagesForProject:spriteObject.project];
+        NSOrderedSet *messages = [Util allMessagesForProject:spriteObject.project];
         if([messages count] > 0)
-            self.broadcastMessage = [messages objectAtIndex:0];
+            self.broadcastMessage = [messages firstObject];
         else
             self.broadcastMessage = @"";
     }

--- a/src/Catty/DataModel/Bricks/Control/BroadcastWaitBrick.m
+++ b/src/Catty/DataModel/Bricks/Control/BroadcastWaitBrick.m
@@ -45,9 +45,9 @@
 - (void)setDefaultValuesForObject:(SpriteObject*)spriteObject
 {
     if(spriteObject) {
-        NSArray *messages = [Util allMessagesForProject:spriteObject.project];
+        NSOrderedSet *messages = [Util allMessagesForProject:spriteObject.project];
         if([messages count] > 0)
-            self.broadcastMessage = [messages objectAtIndex:0];
+            self.broadcastMessage = [messages firstObject];
         else
             self.broadcastMessage = @"";
     }

--- a/src/Catty/DataModel/Project/Project.h
+++ b/src/Catty/DataModel/Project/Project.h
@@ -34,7 +34,9 @@
 @property (nonatomic, strong, nonnull) UserDataContainer *userData;
 @property (nonatomic, strong, nonnull) NSMutableSet<NSString*> *unsupportedElements;
 @property (nonatomic) BOOL requiresBluetooth;
+@property (nonatomic, strong, nullable) NSMutableOrderedSet *allBroadcastMessages;
 
+- (instancetype _Nonnull)init;
 - (NSInteger)numberOfTotalObjects;
 - (NSInteger)numberOfBackgroundObjects;
 - (NSInteger)numberOfNormalObjects;

--- a/src/Catty/DataModel/Project/Project.m
+++ b/src/Catty/DataModel/Project/Project.m
@@ -37,6 +37,15 @@
 
 @synthesize objectList = _objectList;
 
+- (instancetype)init
+{
+    if (self = [super init])
+    {
+        _allBroadcastMessages = [[NSMutableOrderedSet alloc] init];
+    }
+    return self;
+}
+
 - (NSInteger)numberOfTotalObjects
 {
     return [self.objectList count];
@@ -446,8 +455,8 @@
 
 + (instancetype)defaultProjectWithName:(NSString*)projectName projectID:(NSString*)projectID
 {
-    projectName = [Util uniqueName:projectName existingNames:[[self class] allProjectNames]];
     Project *project = [[Project alloc] init];
+    projectName = [Util uniqueName:projectName existingNames:[[self class] allProjectNames]];
     project.header = [Header defaultHeader];
     project.header.programName = projectName;
     project.header.programID = projectID;

--- a/src/Catty/DataModel/Scripts/BroadcastScript.m
+++ b/src/Catty/DataModel/Scripts/BroadcastScript.m
@@ -34,9 +34,9 @@
 - (void)setDefaultValuesForObject:(SpriteObject*)spriteObject
 {
     if(spriteObject) {
-        NSArray *messages = [Util allMessagesForProject:spriteObject.project];
+        NSOrderedSet *messages = [Util allMessagesForProject:spriteObject.project];
         if([messages count] > 0)
-            self.receivedMessage = [messages objectAtIndex:0];
+            self.receivedMessage = [messages firstObject];
         else
             self.receivedMessage = nil;
     }

--- a/src/Catty/Helpers/Util/Util.h
+++ b/src/Catty/Helpers/Util/Util.h
@@ -153,7 +153,7 @@ if (__functor) __functor(__VA_ARGS__);  \
 
 + (Look* _Nullable)lookWithName:(NSString* _Nullable)objectName forObject:(SpriteObject* _Nullable)object;
 
-+ (NSArray* _Nullable)allMessagesForProject:(Project* _Nullable)project;
++ (NSMutableOrderedSet* _Nullable)allMessagesForProject:(Project* _Nonnull)project;
 
 + (BOOL)isNetworkError:(NSError* _Nullable)error;
 

--- a/src/Catty/Helpers/Util/Util.m
+++ b/src/Catty/Helpers/Util/Util.m
@@ -222,7 +222,7 @@
                               minInputLength:(NSUInteger)minInputLength
                               maxInputLength:(NSUInteger)maxInputLength
                     invalidInputAlertMessage:(NSString*)invalidInputAlertMessage
-                               existingNames:(NSArray*)existingNames {
+                               existingNames:(NSOrderedSet*)existingNames {
     [[[[[[[[AlertControllerBuilder textFieldAlertWithTitle:title message:message]
      placeholder:placeholder]
      initialText:value]
@@ -559,9 +559,10 @@
     return nil;
 }
 
-+ (NSArray*)allMessagesForProject:(Project*)project
++ (NSMutableOrderedSet*)allMessagesForProject:(Project*)project
 {
-    NSMutableArray *messages = [[NSMutableArray alloc] init];
+    NSMutableOrderedSet* messages = [[NSMutableOrderedSet alloc] init];
+    [messages addObjectsFromArray:project.allBroadcastMessages.array];
     for(SpriteObject *object in project.allObjects) {
         for(Script *script in object.scriptList) {
             if([script isKindOfClass:[BroadcastScript class]]) {

--- a/src/Catty/Helpers/Util/Util.m
+++ b/src/Catty/Helpers/Util/Util.m
@@ -222,7 +222,7 @@
                               minInputLength:(NSUInteger)minInputLength
                               maxInputLength:(NSUInteger)maxInputLength
                     invalidInputAlertMessage:(NSString*)invalidInputAlertMessage
-                               existingNames:(NSOrderedSet*)existingNames {
+                               existingNames:(NSArray*)existingNames {
     [[[[[[[[AlertControllerBuilder textFieldAlertWithTitle:title message:message]
      placeholder:placeholder]
      initialText:value]

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
@@ -1082,6 +1082,7 @@ willBeginDraggingItemAtIndexPath:(NSIndexPath*)indexPath
     }
     [self.object.project saveToDiskWithNotification:YES];
     [self enableUserInteractionAndResetHighlight];
+    [self.object.project.allBroadcastMessages addObject:messageName];
 }
 
 - (void)addVariableWithName:(NSString*)variableName andCompletion:(id)completion
@@ -1164,6 +1165,7 @@ willBeginDraggingItemAtIndexPath:(NSIndexPath*)indexPath
             [(Brick<BrickStaticChoiceProtocol>*)brick setChoice:(NSString*)value forLineNumber:line andParameterNumber:parameter];
     }else
     if ([brickCellData isKindOfClass:[BrickCellMessageData class]] && [brick conformsToProtocol:@protocol(BrickMessageProtocol)]) {
+        [self.object.project.allBroadcastMessages addObject:value];
         Brick<BrickMessageProtocol> *messageBrick = (Brick<BrickMessageProtocol>*)brick;
         if([(NSString*)value isEqualToString:kLocalizedNewElement]) {
             [Util askUserForUniqueNameAndPerformAction:@selector(addMessageWithName:andCompletion:)
@@ -1179,7 +1181,7 @@ willBeginDraggingItemAtIndexPath:(NSIndexPath*)indexPath
                                         minInputLength:kMinNumOfMessageNameCharacters
                                         maxInputLength:kMaxNumOfMessageNameCharacters
                               invalidInputAlertMessage:kLocalizedMessageAlreadyExistsDescription
-                                         existingNames:[Util allMessagesForProject:self.object.project]];
+                                         existingNames:[Util allMessagesForProject:self.object.project].array];
             [self enableUserInteractionAndResetHighlight];
             return;
         } else {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellMessageData.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellMessageData.m
@@ -48,11 +48,11 @@ static NSMutableArray *messages = nil;
             if ([brickCell.scriptOrBrick conformsToProtocol:@protocol(BrickMessageProtocol)]) {
                 Brick<BrickMessageProtocol> *messageBrick = (Brick<BrickMessageProtocol>*)brickCell.scriptOrBrick;
                 NSString *currentMessage = [messageBrick messageForLineNumber:line andParameterNumber:parameter];
-                NSArray *messages;
+                NSMutableOrderedSet *messages;
                 if ([brickCell.scriptOrBrick isKindOfClass:[Script class]]) {
-                    messages = [Util allMessagesForProject:((Script*)brickCell.scriptOrBrick).object.project];
+                    messages = [Util allMessagesForProject: ((Script*)brickCell.scriptOrBrick).object.project];
                 } else {
-                    messages = [Util allMessagesForProject:messageBrick.script.object.project];
+                    messages = [Util allMessagesForProject: messageBrick.script.object.project];
                 }
                 for (NSString *message in messages) {
                     if (! [options containsObject:message]) {
@@ -68,7 +68,6 @@ static NSMutableArray *messages = nil;
                     currentOptionIndex = optionIndex;
                 }
             }
-
         }
         [self setValues:options];
         [self setCurrentValue:options[currentOptionIndex]];

--- a/src/CattyTests/CattyTests-Bridging-Header.h
+++ b/src/CattyTests/CattyTests-Bridging-Header.h
@@ -33,3 +33,5 @@
 #import "ScriptCollectionViewController.h"
 #import "FormulaEditorViewController.h"
 #import "PaintViewController.h"
+#import "BrickCellMessageData.h"
+#import "BroadcastBrickCell.h"

--- a/src/CattyTests/Utils/UtilTests.swift
+++ b/src/CattyTests/Utils/UtilTests.swift
@@ -26,7 +26,17 @@ import XCTest
 
 final class UtilTests: XCTestCase {
 
+    var project: Project!
+    var spriteObject: SpriteObject!
+    var script: Script!
+    var broadcastScript: BroadcastScript!
+    var broadcastBrick: BroadcastBrick!
+    var broadcastWaitBrick: BroadcastWaitBrick!
+
     override func setUp() {
+
+        project = Project()
+
         super.setUp()
     }
 
@@ -151,5 +161,38 @@ final class UtilTests: XCTestCase {
         let utilPlatformVersion = Util.platformVersionWithoutPatch()
         let devicePlatformVersion = UIDevice.current.systemVersion
         XCTAssertEqual(utilPlatformVersion, devicePlatformVersion)
+    }
+
+    func testAllMessagesForProjectIsEmptyAtInit() {
+
+        let messages = Util.allMessages(for: project)
+
+        XCTAssertEqual(messages?.count, 0)
+    }
+
+    func testAllMessagesForProjectWithValues() {
+
+        project.allBroadcastMessages?.add("firstValue")
+
+        spriteObject = SpriteObject()
+        project.objectList.add(spriteObject!)
+        broadcastScript = BroadcastScript()
+        spriteObject.scriptList.add(broadcastScript!)
+        broadcastScript.receivedMessage = "secondValue"
+
+        script = Script()
+        spriteObject.scriptList.add(script!)
+
+        broadcastBrick = BroadcastBrick()
+        script.brickList.add(broadcastBrick!)
+        broadcastBrick.broadcastMessage = "thirdValue"
+
+        broadcastWaitBrick = BroadcastWaitBrick()
+        script.brickList.add(broadcastWaitBrick!)
+        broadcastWaitBrick.broadcastMessage = "fourthValue"
+
+        let messages = Util.allMessages(for: project)
+
+        XCTAssertEqual(messages?.count, 4)
     }
 }

--- a/src/CattyTests/Utils/UtilTests.swift
+++ b/src/CattyTests/Utils/UtilTests.swift
@@ -195,4 +195,13 @@ final class UtilTests: XCTestCase {
 
         XCTAssertEqual(messages?.count, 4)
     }
+
+    func testAllMessagesForProjectWithDuplicatedValues() {
+
+        project.allBroadcastMessages?.add("duplicate")
+        project.allBroadcastMessages?.add("duplicate")
+        project.allBroadcastMessages?.add("duplicate")
+
+        XCTAssertEqual(project.allBroadcastMessages?.count, 1)
+    }
 }

--- a/src/CattyTests/ViewController/ScriptCollectionViewControllerDisableTests.swift
+++ b/src/CattyTests/ViewController/ScriptCollectionViewControllerDisableTests.swift
@@ -543,4 +543,6 @@ final class ScriptCollectionViewControllerDisableTests: XCTestCase {
         XCTAssertTrue(viewController.isInsideDisabledLoopOrIf(brick: changeVariableBrick))
         XCTAssertFalse(viewController.isInsideDisabledLoopOrIf(brick: ifThenLogicEndBrick))
     }
+    
+    FUNC
 }

--- a/src/CattyTests/ViewController/ScriptCollectionViewControllerDisableTests.swift
+++ b/src/CattyTests/ViewController/ScriptCollectionViewControllerDisableTests.swift
@@ -543,6 +543,4 @@ final class ScriptCollectionViewControllerDisableTests: XCTestCase {
         XCTAssertTrue(viewController.isInsideDisabledLoopOrIf(brick: changeVariableBrick))
         XCTAssertFalse(viewController.isInsideDisabledLoopOrIf(brick: ifThenLogicEndBrick))
     }
-    
-    FUNC
 }

--- a/src/CattyTests/ViewController/ScriptCollectionViewControllerTests.swift
+++ b/src/CattyTests/ViewController/ScriptCollectionViewControllerTests.swift
@@ -1,0 +1,62 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+@testable import Pocket_Code
+
+final class ScriptCollectionViewControllerTests: XCTestCase {
+
+    var layout: UICollectionViewFlowLayout!
+    var viewController: ScriptCollectionViewController!
+    var project: Project!
+    var broadcastBrick: BroadcastBrick!
+    var spriteObject: SpriteObject!
+    var broadcastBrickCell: BroadcastBrickCell!
+    var brickCellMessageData: BrickCellMessageData!
+
+    override func setUp() {
+        super.setUp()
+
+        project = Project()
+        layout = UICollectionViewFlowLayout()
+        layout.itemSize = CGSize(width: 100, height: 100)
+        viewController = ScriptCollectionViewController(collectionViewLayout: layout)
+        XCTAssertNotNil(viewController, "ScriptCollectionViewController must not be nil")
+    }
+
+    func testUpdateBrickCellDataSavesBroadcastMessage() {
+        spriteObject = SpriteObject()
+        broadcastBrick = BroadcastBrick()
+        broadcastBrickCell = BroadcastBrickCell()
+        brickCellMessageData = BrickCellMessageData()
+        viewController.object = spriteObject
+        spriteObject.project = project
+        broadcastBrickCell.scriptOrBrick = broadcastBrick
+        broadcastBrickCell.dataDelegate = viewController as? BrickCellDataDelegate
+        brickCellMessageData.brickCell = broadcastBrickCell
+
+        broadcastBrickCell.dataDelegate.updateBrickCellData(brickCellMessageData, withValue: "Message1")
+
+        XCTAssertTrue((project.allBroadcastMessages?.contains("Message1"))!)
+    }
+}


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

A project variable is created, which stores all recently created messages until the project is closed, i.e. the user goes back to the main screen or the project listing screen. Once the project is reopened, only the used messages are shown.