### PR TITLE
CATTY-246 Remove deprecated methods for VariablesContainer

### DIFF
--- a/src/Catty/DataModel/VariablesContainer/VariablesContainer.h
+++ b/src/Catty/DataModel/VariablesContainer/VariablesContainer.h
@@ -65,8 +65,6 @@
 - (NSMutableArray*)allVariables;
 // Array of Lists
 - (NSMutableArray*)allLists;
-// Array of Variables and Lists
-- (NSMutableArray*)allVariablesAndLists;
 
 // Array of UserVariable
 - (NSArray*)objectVariablesForObject:(SpriteObject*)spriteObject;
@@ -76,8 +74,6 @@
 - (BOOL)addObjectList:(UserVariable*)userList forObject:(SpriteObject*)spriteObject;
 
 - (SpriteObject*)spriteObjectForObjectVariable:(UserVariable*)userVariable;
-
-- (BOOL)isVariableOfSpriteObject:(SpriteObject*)spriteObject userVariable:(UserVariable*)userVariable;
 
 - (BOOL)isProjectVariableOrList:(UserVariable*)userVariable;
 

--- a/src/Catty/DataModel/VariablesContainer/VariablesContainer.m
+++ b/src/Catty/DataModel/VariablesContainer/VariablesContainer.m
@@ -390,17 +390,6 @@ static pthread_mutex_t variablesLock;
     return vars;
 }
 
-- (NSMutableArray*)allVariablesAndLists
-{
-    NSMutableArray *vars = [self allVariables ];
-    NSMutableArray *lists = [self allLists ];
-    if([vars count] > 0){
-        [vars addObjectsFromArray:lists];
-    }
-    
-    return vars;
-}
-
 - (NSArray*)objectVariablesForObject:(SpriteObject*)spriteObject
 {
     NSMutableArray *vars = [NSMutableArray new];
@@ -450,24 +439,6 @@ static pthread_mutex_t variablesLock;
         }
     }
     return nil;
-}
-
-- (BOOL)isVariableOfSpriteObject:(SpriteObject*)spriteObject userVariable:(UserVariable*)userVariable
-{
-    for (NSUInteger index = 0; index < [self.objectVariableList count]; ++index) {
-        SpriteObject *spriteObjectToCompare = [self.objectVariableList keyAtIndex:index];
-        if (spriteObjectToCompare != spriteObject) {
-            continue;
-        }
-
-        NSMutableArray *userVariableList = [self.objectVariableList objectAtIndex:index];
-        for (UserVariable *userVariableToCompare in userVariableList) {
-            if ([userVariableToCompare.name isEqualToString:userVariable.name]) {
-                return YES;
-            }
-        }
-    }
-    return NO;
 }
 
 - (BOOL)isProjectVariableOrList:(UserVariable*)userVarOrList

--- a/src/CattyTests/DataModel/VariablesContainerTest.swift
+++ b/src/CattyTests/DataModel/VariablesContainerTest.swift
@@ -146,33 +146,6 @@ final class VariablesContainerTest: XCTestCase {
         XCTAssertEqual(allList[1].name, list2.name)
     }
 
-    func testAllVariableAndAllList() {
-        let objectA = SpriteObject()
-        objectA.name = "testObjectA"
-
-        let userVariable = UserVariable(name: "testVariable", isList: false)
-
-        let list = UserVariable(name: "testList", isList: true)
-
-        let container = VariablesContainer()
-
-        container.addObjectVariable(userVariable, for: objectA)
-        var allListAndALlVariable = container.allVariablesAndLists() as! [UserVariable]
-
-        XCTAssertEqual(1, allListAndALlVariable.count)
-        XCTAssertEqual(allListAndALlVariable[0].name, userVariable.name)
-        XCTAssertFalse(allListAndALlVariable[0].isList)
-
-        container.addObjectList(list, for: objectA)
-        allListAndALlVariable = container.allVariablesAndLists() as! [UserVariable]
-
-        XCTAssertEqual(2, allListAndALlVariable.count)
-        XCTAssertEqual(allListAndALlVariable[0].name, userVariable.name)
-        XCTAssertEqual(allListAndALlVariable[1].name, list.name)
-        XCTAssertFalse(allListAndALlVariable[0].isList)
-        XCTAssertTrue(allListAndALlVariable[1].isList)
-    }
-
     func testObjectVariablesForObject() {
         let objectA = SpriteObject()
         objectA.name = "testObjectA"


### PR DESCRIPTION
## Removed the deprecated methods:

- isVariableOfSpriteObject
- allVariablesAndLists

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
