### PR TITLE
CATTY-281 Make UserDataProtocol available for ObjC and use it in VariableContainer

### DIFF
--- a/src/Catty/DataModel/UserData/UserDataProtocol.swift
+++ b/src/Catty/DataModel/UserData/UserDataProtocol.swift
@@ -20,9 +20,14 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-protocol UserDataProtocol: CBMutableCopying {
-    associatedtype DataType
-
+@objc protocol UserDataProtocol: CBMutableCopying {
     var name: String { get set }
-    var value: DataType { get set }
+}
+
+protocol UserVariableProtocol: UserDataProtocol {
+    var value: Any? { get set }
+}
+
+protocol UserListProtocol: UserDataProtocol {
+    var value: NSMutableArray { get set }
 }

--- a/src/Catty/DataModel/UserData/UserList.swift
+++ b/src/Catty/DataModel/UserData/UserList.swift
@@ -20,7 +20,7 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-@objcMembers class UserList: NSObject, UserDataProtocol {
+@objcMembers class UserList: NSObject, UserListProtocol {
     typealias DataType = NSMutableArray
 
     var name: String

--- a/src/Catty/DataModel/UserData/UserVariable.swift
+++ b/src/Catty/DataModel/UserData/UserVariable.swift
@@ -21,7 +21,7 @@
  */
 
 @objc(UserVariable)
-@objcMembers class UserVariable: NSObject, UserDataProtocol {
+@objcMembers class UserVariable: NSObject, UserVariableProtocol {
 
     typealias DataType = Any?
 

--- a/src/Catty/DataModel/VariablesContainer/VariablesContainer.h
+++ b/src/Catty/DataModel/VariablesContainer/VariablesContainer.h
@@ -26,6 +26,7 @@
 @class SpriteObject;
 @class UserVariable;
 @class OrderedMapTable;
+@protocol UserDataProtocol;
 
 @interface VariablesContainer : NSObject
 
@@ -73,9 +74,9 @@
 - (BOOL)addObjectVariable:(UserVariable*)userVariable forObject:(SpriteObject*)spriteObject;
 - (BOOL)addObjectList:(UserVariable*)userList forObject:(SpriteObject*)spriteObject;
 
-- (SpriteObject*)spriteObjectForObjectVariable:(UserVariable*)userVariable;
+- (SpriteObject*)spriteObjectForObjectData:(id<UserDataProtocol>)userData;
 
-- (BOOL)isProjectList: (UserVariable*)userList;
+- (BOOL)isProjectList: (id<UserDataProtocol>)userList;
 - (BOOL)isProjectVariable: (UserVariable*)userVariable;
 
 - (void)removeObjectVariablesForSpriteObject:(SpriteObject*)object;

--- a/src/Catty/DataModel/VariablesContainer/VariablesContainer.m
+++ b/src/Catty/DataModel/VariablesContainer/VariablesContainer.m
@@ -412,32 +412,29 @@ static pthread_mutex_t variablesLock;
     return lists;
 }
 
-- (SpriteObject*)spriteObjectForObjectVariable:(UserVariable*)userVariable
+- (SpriteObject*)spriteObjectForObjectData:(id<UserDataProtocol>)userData
 {
-    if (!userVariable.isList)
-    {
-        for (NSUInteger index = 0; index < [self.objectVariableList count]; ++index) {
-            SpriteObject *spriteObject = [self.objectVariableList keyAtIndex:index];
-            NSMutableArray *userVariableList = [self.objectVariableList objectAtIndex:index];
-            for (UserVariable *userVariableToCompare in userVariableList) {
-                if (userVariableToCompare == userVariable) {
-                    return spriteObject;
-                }
+    
+    for (NSUInteger index = 0; index < [self.objectVariableList count]; ++index) {
+        SpriteObject *spriteObject = [self.objectVariableList keyAtIndex:index];
+        NSMutableArray *userVariableList = [self.objectVariableList objectAtIndex:index];
+        for (UserVariable *userVariableToCompare in userVariableList) {
+            if (userVariableToCompare == userData) {
+                return spriteObject;
             }
         }
     }
-    if (userVariable.isList)
-    {
-        for (NSUInteger index = 0; index < [self.objectListOfLists count]; ++index) {
-            SpriteObject *spriteObject = [self.objectListOfLists keyAtIndex:index];
-            NSMutableArray *userListOfLists = [self.objectListOfLists objectAtIndex:index];
-            for (UserVariable *userListToCompare in userListOfLists) {
-                if (userListToCompare == userVariable) {
-                    return spriteObject;
-                }
+    
+    for (NSUInteger index = 0; index < [self.objectListOfLists count]; ++index) {
+        SpriteObject *spriteObject = [self.objectListOfLists keyAtIndex:index];
+        NSMutableArray *userListOfLists = [self.objectListOfLists objectAtIndex:index];
+        for (UserList *userListToCompare in userListOfLists) {
+            if (userListToCompare == userData) {
+                return spriteObject;
             }
         }
     }
+    
     return nil;
 }
 
@@ -451,7 +448,7 @@ static pthread_mutex_t variablesLock;
     return NO;
 }
 
-- (BOOL)isProjectList: (UserVariable*)userList
+- (BOOL)isProjectList: (id<UserDataProtocol>)userList
 {
     for (UserVariable *userListToCompare in self.programListOfLists) {
         if ([userListToCompare.name isEqualToString:userList.name]) {

--- a/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/UserVariable/UserVariable+CBXMLHandler.m
+++ b/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/UserVariable/UserVariable+CBXMLHandler.m
@@ -146,7 +146,7 @@
     CBXMLPositionStack *positionStackOfUserVariable = nil;
 
     // check whether object variable/list or project variable/list
-    SpriteObject *spriteObject = [context.variables spriteObjectForObjectVariable:self];
+    SpriteObject *spriteObject = [context.variables spriteObjectForObjectData:self];
     if (spriteObject) {
         // it is an object variable/list!
         NSMutableDictionary *alreadySerializedVarsOrLists = self.isList ? [context.spriteObjectNameUserListOfListsPositions objectForKey:spriteObject.name] :

--- a/src/CattyTests/DataModel/VariablesContainerTest.swift
+++ b/src/CattyTests/DataModel/VariablesContainerTest.swift
@@ -397,7 +397,7 @@ final class VariablesContainerTest: XCTestCase {
         XCTAssertNotEqual(itemInList[0], 30)
     }
 
-    func testSpriteObjectForObjectVariableWhenNotList() {
+    func testSpriteObjectForObjectDataNotList() {
         let objectA = SpriteObject()
         objectA.name = "testObjectA"
 
@@ -415,11 +415,11 @@ final class VariablesContainerTest: XCTestCase {
         result = container.addObjectVariable(userVariable2, for: objectB)
         XCTAssertTrue(result)
 
-        XCTAssertTrue(container.spriteObject(forObjectVariable: userVariable1)?.isEqual(to: objectA) == true)
-        XCTAssertTrue(container.spriteObject(forObjectVariable: userVariable2)?.isEqual(to: objectB) == true)
+        XCTAssertTrue(container.spriteObject(forObjectData: userVariable1)?.isEqual(to: objectA) == true)
+        XCTAssertTrue(container.spriteObject(forObjectData: userVariable2)?.isEqual(to: objectB) == true)
     }
 
-    func testSpriteObjectForObjectVariableWhenList() {
+    func testSpriteObjectForObjectDataWhenList() {
         let objectA = SpriteObject()
         objectA.name = "testObjectA"
 
@@ -437,8 +437,8 @@ final class VariablesContainerTest: XCTestCase {
         result = container.addObjectList(list2, for: objectB)
         XCTAssertTrue(result)
 
-        XCTAssertTrue(container.spriteObject(forObjectVariable: list1)?.isEqual(to: objectA) == true)
-        XCTAssertTrue(container.spriteObject(forObjectVariable: list2)?.isEqual(to: objectB) == true)
+        XCTAssertTrue(container.spriteObject(forObjectData: list1)?.isEqual(to: objectA) == true)
+        XCTAssertTrue(container.spriteObject(forObjectData: list2)?.isEqual(to: objectB) == true)
     }
 
     func testIsProjectVariable() {
@@ -471,6 +471,22 @@ final class VariablesContainerTest: XCTestCase {
 
         XCTAssertTrue(container.isProjectList(list1))
         XCTAssertFalse(container.isProjectList(list2))
+    }
+
+    func testIsProjectDataForListAndObjectWithSameName() {
+        let object = SpriteObject()
+        object.name = "testObject"
+
+       let projectList = UserVariable(name: "name", isList: true)
+       let objectVariable = UserVariable(name: "name", isList: false)
+
+        let container = VariablesContainer()
+
+        container.programListOfLists.add(projectList)
+        container.addObjectVariable(objectVariable, for: object)
+
+        XCTAssertTrue(container.isProjectList(projectList))
+        XCTAssertFalse(container.isProjectVariable(objectVariable))
     }
 
     func testRemoveObjectVariablesForSpriteObject() {


### PR DESCRIPTION
- Made UserDataProtocol available for ObjC classes.
- Used of UserDataProtocol protocol in the VariableContainer.
- Combined the isProjectVariable and `isProjectList` again by naming it `isProjectData`.

*Please enter a short description of your pull request and add a reference to the Jira ticket.*

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
