### PR TITLE
CATTY-49 Project can't be closed

### DIFF
--- a/src/Catty/Helpers/BrickHelpers/CameraPreviewHandler.h
+++ b/src/Catty/Helpers/BrickHelpers/CameraPreviewHandler.h
@@ -28,7 +28,6 @@
 + (instancetype)shared;
 
 @property (readonly, nonatomic) UIView* camView;
-@property (readonly, nonatomic) AVCaptureDevicePosition cameraPosition;
 
 - (void)setCamView:(UIView *)camView;
 - (void)startCameraPreview;
@@ -36,5 +35,6 @@
 - (void)switchCameraPositionTo:(AVCaptureDevicePosition)position;
 - (void)reset;
 - (AVCaptureSession*)getSession;
+- (AVCaptureDevicePosition) getCameraPosition;
 
 @end

--- a/src/Catty/PlayerEngine/Sensors/Camera/FaceDetectionManager.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FaceDetectionManager.swift
@@ -157,7 +157,7 @@ class FaceDetectionManager: NSObject, FaceDetectionManagerProtocol, AVCaptureVid
     }
 
     func cameraPosition() -> AVCaptureDevice.Position {
-        CameraPreviewHandler.shared().cameraPosition
+        (CameraPreviewHandler.shared()?.getCameraPosition())!
     }
 
     private func camera(for cameraPosition: AVCaptureDevice.Position) -> AVCaptureDevice? {

--- a/src/CattyTests/Bricks/ChooseCameraBrickTests.swift
+++ b/src/CattyTests/Bricks/ChooseCameraBrickTests.swift
@@ -57,7 +57,7 @@ final class ChooseCameraBrickTests: XCTestCase {
     func testDefaultCameraPosition() {
         // front camera should be default
         CameraPreviewHandler.shared().reset()
-        XCTAssertEqual(AVCaptureDevice.Position.front, CameraPreviewHandler.shared().cameraPosition)
+        XCTAssertEqual(AVCaptureDevice.Position.front, CameraPreviewHandler.shared().getCameraPosition())
     }
 
     func testChooseCameraBrick() {
@@ -73,7 +73,7 @@ final class ChooseCameraBrickTests: XCTestCase {
             break
         }
 
-        XCTAssertEqual(AVCaptureDevice.Position.back, CameraPreviewHandler.shared().cameraPosition)
+        XCTAssertEqual(AVCaptureDevice.Position.back, CameraPreviewHandler.shared().getCameraPosition())
     }
 
     func testChooseCameraBrickInitWithZero() {
@@ -89,7 +89,7 @@ final class ChooseCameraBrickTests: XCTestCase {
             break
         }
 
-        XCTAssertEqual(AVCaptureDevice.Position.back, CameraPreviewHandler.shared().cameraPosition)
+        XCTAssertEqual(AVCaptureDevice.Position.back, CameraPreviewHandler.shared().getCameraPosition())
     }
 
     func testChooseCameraBrickInitWithOne() {
@@ -105,7 +105,7 @@ final class ChooseCameraBrickTests: XCTestCase {
             break
         }
 
-        XCTAssertEqual(AVCaptureDevice.Position.front, CameraPreviewHandler.shared().cameraPosition)
+        XCTAssertEqual(AVCaptureDevice.Position.front, CameraPreviewHandler.shared().getCameraPosition())
     }
 
     func testMutableCopy() {


### PR DESCRIPTION
When the `ChooseCameraBrick` is used inside the `WhenTouchDownScript` it becomes impossible to open the menu and therefore to close the game. (See [CATTY-49](https://jira.catrob.at/browse/CATTY-49) )
Turns out this was due to the camera setup being executed on (and therefore blocking) the UI Thread. This PR changes this behaviour.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
