### PR TITLE
CATTY-310 Remove the deprecated typealias in UserList and UserVariable

### DIFF
--- a/src/Catty/DataModel/UserData/UserList.swift
+++ b/src/Catty/DataModel/UserData/UserList.swift
@@ -21,7 +21,6 @@
  */
 
 @objcMembers class UserList: NSObject, UserListProtocol {
-    typealias DataType = NSMutableArray
 
     var name: String
     var value: NSMutableArray

--- a/src/Catty/DataModel/UserData/UserVariable.swift
+++ b/src/Catty/DataModel/UserData/UserVariable.swift
@@ -23,8 +23,6 @@
 @objc(UserVariable)
 @objcMembers class UserVariable: NSObject, UserVariableProtocol {
 
-    typealias DataType = Any?
-
     var name: String
     var value: Any?
     var textLabel: SKLabelNode?


### PR DESCRIPTION
Removed the deprecated `typealias` from UserList and UserVariable class.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
