### PR TITLE
CATTY-311 Add setter and isEqual method for SynchronizedArray

### DIFF
--- a/src/CattyTests/DataModel/SynchronizedArrayTests.swift
+++ b/src/CattyTests/DataModel/SynchronizedArrayTests.swift
@@ -187,6 +187,49 @@ final class SynchronizedArrayTests: XCTestCase {
         XCTAssertTrue(doesContain)
     }
 
+    func testIsEqual() {
+        let array1 = SynchronizedArray<Int>()
+        let array2 = SynchronizedArray<Int>()
+
+        array1.append(6)
+        XCTAssertFalse(array1.isEqual(array2))
+
+        array2.append(6)
+        XCTAssertTrue(array1.isEqual(array2))
+    }
+
+    func testIsEqualForArrayWithDifferentOrder() {
+        let array1 = SynchronizedArray<AnyObject>()
+        let array2 = SynchronizedArray<AnyObject>()
+
+        let formula1 = Formula(double: 1)!
+        let formula2 = Formula(double: 2)!
+
+        array1.append(formula1)
+        array1.append(formula2)
+        XCTAssertFalse(array1.isEqual(array2))
+
+        array2.append(formula2)
+        array2.append(formula1)
+        XCTAssertFalse(array1.isEqual(array2))
+    }
+
+    func testIsEqualWithMultipleDataType() {
+        let array1 = SynchronizedArray<Any>()
+        let array2 = SynchronizedArray<Any>()
+
+        let formula1 = Formula(double: 1)!
+
+        array1.append(formula1)
+        array1.append("2")
+        XCTAssertFalse(array1.isEqual(array2))
+
+        array2.append(formula1)
+        array2.append("2")
+        XCTAssertTrue(array1.isEqual(array2))
+
+    }
+
     func testThreadSafeArray() {
         let array = SynchronizedArray<Int>()
 


### PR DESCRIPTION
Added setter and isEqual method for SynchronizedArray.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
