### PR TITLE
CATTY-314 Move variable functions from UserDataContainer to UserVariable

### DIFF
--- a/src/Catty/DataModel/UserData/UserVariable.swift
+++ b/src/Catty/DataModel/UserData/UserVariable.swift
@@ -24,8 +24,26 @@
 @objcMembers class UserVariable: NSObject, UserVariableProtocol {
 
     var name: String
-    var value: Any?
     var textLabel: SKLabelNode?
+    private let variableLocker = NSLock()
+    private var _value: Any?
+
+    var value: Any? {
+        get {
+          _value
+        }
+        set {
+            variableLocker.lock()
+            if let value = newValue as? NSString {
+                _value = value
+            } else if let value = newValue as? NSNumber {
+                _value = value
+            } else {
+                _value = NSNumber(value: 0)
+            }
+            variableLocker.unlock()
+        }
+    }
 
     init(name: String) {
         self.name = name
@@ -59,4 +77,11 @@
         return self
     }
 
+    func change(by value: Double) {
+        variableLocker.lock()
+        if let valueAsDouble = _value as? NSNumber {
+         _value = NSNumber(value: valueAsDouble.doubleValue + value)
+        }
+        variableLocker.unlock()
+    }
 }

--- a/src/Catty/DataModel/VariablesContainer/UserDataContainer.h
+++ b/src/Catty/DataModel/VariablesContainer/UserDataContainer.h
@@ -46,11 +46,6 @@
 - (BOOL)removeUserVariableNamed:(NSString*)name forSpriteObject:(SpriteObject*)sprite;
 - (BOOL)removeUserListNamed:(NSString*)name forSpriteObject:(SpriteObject*)sprite;
 
-
-- (void)setUserVariable:(UserVariable*)userVariable toValue:(id)value;
-
-- (void)changeVariable:(UserVariable*)userVariable byValue:(double)value;
-
 // Array of UserVariable
 - (NSArray<UserVariable*>*)allVariablesForObject:(SpriteObject*)spriteObject;
 - (NSArray<UserList*>*)allListsForObject:(SpriteObject*)spriteObject;

--- a/src/Catty/DataModel/VariablesContainer/UserDataContainer.m
+++ b/src/Catty/DataModel/VariablesContainer/UserDataContainer.m
@@ -228,30 +228,6 @@ static pthread_mutex_t variablesLock;
     pthread_mutex_unlock(&variablesLock);
 }
 
-- (void)setUserVariable:(UserVariable*)userVariable toValue:(id)value
-{
-    pthread_mutex_lock(&variablesLock);
-    if([value isKindOfClass:[NSString class]]){
-        NSString *stringValue = (NSString*)value;
-        userVariable.value = stringValue;
-    } else if([value isKindOfClass:[NSNumber class]]){
-        NSNumber *numberValue = (NSNumber*)value;
-        userVariable.value = numberValue;
-    } else {
-        userVariable.value = [NSNumber numberWithInt:0];
-    }
-    pthread_mutex_unlock(&variablesLock);
-}
-
-- (void)changeVariable:(UserVariable*)userVariable byValue:(double)value
-{
-    pthread_mutex_lock(&variablesLock);
-    if ([userVariable.value isKindOfClass:[NSNumber class]]){
-        userVariable.value = [NSNumber numberWithFloat:(CGFloat)(([userVariable.value doubleValue] + value))];
-    }
-    pthread_mutex_unlock(&variablesLock);
-}
-
 - (NSArray*)allVariablesForObject:(SpriteObject*)spriteObject
 {
     NSMutableArray *vars = [NSMutableArray arrayWithArray:self.programVariableList];

--- a/src/Catty/PlayerEngine/Instructions/Data/ChangeVariableBrick+Instruction.swift
+++ b/src/Catty/PlayerEngine/Instructions/Data/ChangeVariableBrick+Instruction.swift
@@ -24,8 +24,7 @@
 
     @nonobjc func instruction() -> CBInstruction {
 
-        guard let spriteObject = self.script?.object,
-            let userData = spriteObject.project?.userData
+        guard let spriteObject = self.script?.object
             else { fatalError("This should never happen!") }
 
         let userVariable = self.userVariable
@@ -43,7 +42,7 @@
                 }
                 if let _ = (userVariable.value as? NSNumber)?.doubleValue,
                     let numberDoubleValue = (result as? NSNumber)?.doubleValue {
-                    userData.change(userVariable, byValue: numberDoubleValue)
+                    userVariable.change(by: numberDoubleValue)
                     //update active UserVariable
                     userVariable.textLabel?.text = (userVariable.value as? NSNumber)?.stringValue
                 } else if userVariable.value is NSString {

--- a/src/Catty/PlayerEngine/Instructions/Data/SetVariableBrick+Instruction.swift
+++ b/src/Catty/PlayerEngine/Instructions/Data/SetVariableBrick+Instruction.swift
@@ -24,9 +24,7 @@
 
     @nonobjc func instruction() -> CBInstruction {
 
-        guard let spriteObject = self.script?.object,
-            let userData = spriteObject.project?.userData
-            else { fatalError("This should never happen!") }
+        guard let spriteObject = self.script?.object else { fatalError("This should never happen!") }
 
         let userVariable = self.userVariable
         let variableFormula = self.variableFormula
@@ -34,7 +32,7 @@
         return CBInstruction.execClosure { context, _ in
             guard let formula = variableFormula else { return }
             let result = context.formulaInterpreter.interpret(formula, for: spriteObject)
-            userData.setUserVariable(userVariable, toValue: result)
+            userVariable?.value = result
 
             //update visible userVariable
             var value = ""

--- a/src/CattyTests/Bricks/WaitUntilBrickTests.swift
+++ b/src/CattyTests/Bricks/WaitUntilBrickTests.swift
@@ -34,7 +34,7 @@ final class WaitUntilBrickTests: XMLAbstractTest {
         let scene = createScene(project: project)
         let started = scene.startProject()
         XCTAssertTrue(started)
-        project.userData.setUserVariable(testVar, toValue: NSNumber(value: 1))
+        testVar?.value = NSNumber(value: 1)
 
         let conditionMetPredicate = NSPredicate(block: { variable, _ in
             let hasFinishedWaiting = (variable as? UserVariable)!.value as! NSNumber

--- a/src/CattyTests/DataModel/UserDataContainerTest.swift
+++ b/src/CattyTests/DataModel/UserDataContainerTest.swift
@@ -204,48 +204,6 @@ final class UserDataContainerTest: XCTestCase {
         XCTAssertEqual(lists?[1].name, list2.name)
     }
 
-    func testSetUserVariable() {
-        let objectA = SpriteObject()
-        objectA.name = "testObjectA"
-
-        let userVariable1 = UserVariable(name: "testName1")
-
-        let container = UserDataContainer()
-
-        container.addObjectVariable(userVariable1, for: objectA)
-        container.setUserVariable(userVariable1, toValue: 10)
-
-        let variables = container.objectVariables(for: objectA)
-
-        XCTAssertEqual(1, variables?.count)
-        XCTAssertEqual(variables?[0].value as! Int, 10)
-    }
-
-    func testChangeVariable() {
-        let objectA = SpriteObject()
-        objectA.name = "testObjectA"
-
-        let userVariable1 = UserVariable(name: "testName1")
-
-        let container = UserDataContainer()
-
-        container.addObjectVariable(userVariable1, for: objectA)
-        container.setUserVariable(userVariable1, toValue: 10)
-        container.change(userVariable1, byValue: 10)
-
-        var variables = container.objectVariables(for: objectA)
-
-        XCTAssertEqual(1, variables?.count)
-        XCTAssertEqual(variables?[0].value as! Int, 20)
-
-        container.change(userVariable1, byValue: 10)
-
-        variables = container.objectVariables(for: objectA)
-
-        XCTAssertEqual(1, variables?.count)
-        XCTAssertEqual(variables?[0].value as! Int, 30)
-    }
-
     func testIsProjectVariable() {
         let objectA = SpriteObject()
         objectA.name = "testObjectA"
@@ -504,7 +462,7 @@ final class UserDataContainerTest: XCTestCase {
 
         container.addObjectList(list, for: objectA)
         container.addObjectVariable(variable, for: objectA)
-        container.setUserVariable(variable, toValue: 10)
+        variable.value = 10
 
         let copyContainer = container.mutableCopy() as! UserDataContainer
 

--- a/src/CattyTests/DataModel/UserVariableTests.swift
+++ b/src/CattyTests/DataModel/UserVariableTests.swift
@@ -98,4 +98,62 @@ final class UserVariableTests: XCTestCase {
         XCTAssertFalse(userVariableB.isEqual(userVariableA))
         XCTAssertTrue(userVariableC.isEqual(userVariableA))
     }
+
+    func testSet() {
+        let userVariable1 = UserVariable(name: "testName1")
+
+        XCTAssertNil(userVariable1.value)
+
+        userVariable1.value = 10
+        XCTAssertEqual(10, userVariable1.value as! Int)
+
+        userVariable1.value = "testValue"
+        XCTAssertEqual("testValue", userVariable1.value as! String)
+    }
+
+    func testSetWithInvalidDataType() {
+        let userVariable1 = UserVariable(name: "testName1")
+
+        XCTAssertNil(userVariable1.value)
+
+        let formula = Formula(double: 50.50)!
+        userVariable1.value = formula
+        XCTAssertEqual(0, userVariable1.value as! Int)
+    }
+
+    func testChange() {
+        let userVariable1 = UserVariable(name: "testName1")
+
+        XCTAssertNil(userVariable1.value)
+
+        userVariable1.value = 10
+        XCTAssertEqual(10, userVariable1.value as! Int)
+
+        userVariable1.change(by: 10)
+        XCTAssertEqual(20, userVariable1.value as! Int)
+    }
+
+    func testChangeToInvalidDataType() {
+        let userVariable1 = UserVariable(name: "testName1")
+
+        XCTAssertNil(userVariable1.value)
+
+        userVariable1.value = "10"
+        XCTAssertEqual("10", userVariable1.value as! String)
+
+        userVariable1.change(by: 10)
+        XCTAssertEqual("10", userVariable1.value as! String)
+    }
+
+    func testThreadSafety() {
+        let iterations = 1000
+
+        let userVariable = UserVariable(name: "name")
+        userVariable.value = NSNumber(0)
+
+        DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+            userVariable.change(by: 1)
+        }
+        XCTAssertEqual(iterations, userVariable.value as! Int)
+    }
 }


### PR DESCRIPTION
Moved the following functions from the UserDataContainer to UserVariable:

- setUserVariable
- changeVariable

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
