### PR TITLE
CATTY-217 Disable loops and nested Bricks

### DIFF
--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController+Disable.swift
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController+Disable.swift
@@ -134,4 +134,33 @@ extension ScriptCollectionViewController {
             logicBrick = brickList[logicIndex]
         }
     }
+
+    @objc func isInsideDisabledLoopOrIf(brick: Brick) -> Bool {
+        if let brickList = brick.script.brickList as? [Brick] {
+            for b in brickList where b != brick {
+                if let begin = b as? LoopBeginBrick, begin.isDisabled, let end = begin.loopEndBrick, brick != end {
+                    if isInsideScope(brick: brick, begin: begin, end: end) {
+                        return true
+                    }
+                } else if let begin = b as? IfLogicBeginBrick, begin.isDisabled, let end = begin.ifEndBrick, brick != end {
+                    if isInsideScope(brick: brick, begin: begin, end: end) {
+                        return true
+                    }
+                } else if let begin = b as? IfThenLogicBeginBrick, begin.isDisabled, let end = begin.ifEndBrick, brick != end {
+                    if isInsideScope(brick: brick, begin: begin, end: end) {
+                        return true
+                    }
+                }
+            }
+        }
+
+        return false
+    }
+
+    fileprivate func isInsideScope(brick: Brick, begin: Brick, end: Brick) -> Bool {
+        let startIdx = begin.script.brickList.index(of: begin)
+        let endIdx = end.script.brickList.index(of: end)
+
+        return (startIdx...endIdx).contains(brick.script.brickList.index(of: brick))
+    }
 }

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
@@ -282,28 +282,34 @@ minimumLineSpacingForSectionAtIndex:(NSInteger)section
         NSString *disableTitle = ([brick isIfLogicBrick] ? (brick.isDisabled ? kLocalizedEnableCondition : kLocalizedDisableCondition)
                                   : ([brick isLoopBrick]) ? (brick.isDisabled ? kLocalizedEnableLoop : kLocalizedDisableLoop)
                                   : (brick.isDisabled ? kLocalizedEnableBrick : kLocalizedDisableBrick));
-        
-        actionSheet = [[[[[[AlertControllerBuilder actionSheetWithTitle:kLocalizedEditBrick]
-                       addCancelActionWithTitle:kLocalizedCancel handler:nil]
-                       addDestructiveActionWithTitle:destructiveTitle handler:^{
-                           [self removeBrickOrScript:scriptOrBrick atIndexPath:indexPath];
-                       }]
-                      addDefaultActionWithTitle:disableTitle handler:^{
-                           [self disableOrEnableWithBrick:brick];
-                           [self reloadData];
-                           [self.object.project saveToDiskWithNotification:YES];
-                       }]
-                       addDefaultActionWithTitle:kLocalizedCopyBrick handler:^{
-                           [self copyBrick:brick atIndexPath:indexPath];
-                       }]
-                       addDefaultActionWithTitle:kLocalizedMoveBrick handler:^{
-                           brick.animateInsertBrick = YES;
-                           brick.animateMoveBrick = YES;
-                           [[BrickInsertManager sharedInstance] setBrickMoveMode:YES];
-                           [self turnOnInsertingBrickMode];
-                           [self reloadData];
-                       }];
-        
+
+        actionSheet = [[AlertControllerBuilder actionSheetWithTitle:kLocalizedEditBrick]
+            addCancelActionWithTitle:kLocalizedCancel handler:nil];
+
+        [actionSheet addDestructiveActionWithTitle:destructiveTitle handler:^{
+            [self removeBrickOrScript:scriptOrBrick atIndexPath:indexPath];
+        }];
+
+        if (![self isInsideDisabledLoopOrIfWithBrick:brick]) {
+            [actionSheet addDefaultActionWithTitle:disableTitle handler:^{
+                [self disableOrEnableWithBrick:brick];
+                [self reloadData];
+                [self.object.project saveToDiskWithNotification:YES];
+            }];
+        }
+
+        [actionSheet addDefaultActionWithTitle:kLocalizedCopyBrick handler:^{
+            [self copyBrick:brick atIndexPath:indexPath];
+        }];
+
+        [actionSheet addDefaultActionWithTitle:kLocalizedMoveBrick handler:^{
+            brick.animateInsertBrick = YES;
+            brick.animateMoveBrick = YES;
+            [[BrickInsertManager sharedInstance] setBrickMoveMode:YES];
+            [self turnOnInsertingBrickMode];
+            [self reloadData];
+        }];
+
         if (brick.isAnimateable) {
             [actionSheet addDefaultActionWithTitle:kLocalizedAnimateBrick handler:^{
                 [self animate:indexPath brickCell:brickCell];

--- a/src/CattyTests/ViewController/ScriptCollectionViewControllerDisableTests.swift
+++ b/src/CattyTests/ViewController/ScriptCollectionViewControllerDisableTests.swift
@@ -475,4 +475,72 @@ final class ScriptCollectionViewControllerDisableTests: XCTestCase {
         //after loop
         XCTAssertFalse(showTextBrick.isDisabled)
     }
+
+    func testBrickIsDisabledInsideLoopBrick() {
+        let startScript = StartScript()
+        let loopBeginBrick = LoopBeginBrick()
+        let changeVariableBrick = ChangeVariableBrick()
+        let loopEndBrick = LoopEndBrick()
+        loopBeginBrick.loopEndBrick = loopEndBrick
+
+        let scriptBrickList = [loopBeginBrick, changeVariableBrick, loopEndBrick]
+        startScript.brickList = NSMutableArray(array: scriptBrickList)
+
+        scriptBrickList.forEach({ $0.script = startScript })
+
+        viewController.disableOrEnable(brick: loopBeginBrick)
+        XCTAssertTrue(loopBeginBrick.isDisabled)
+        XCTAssertTrue(changeVariableBrick.isDisabled)
+        XCTAssertTrue(loopEndBrick.isDisabled)
+
+        XCTAssertFalse(viewController.isInsideDisabledLoopOrIf(brick: loopBeginBrick))
+        XCTAssertTrue(viewController.isInsideDisabledLoopOrIf(brick: changeVariableBrick))
+        XCTAssertFalse(viewController.isInsideDisabledLoopOrIf(brick: loopEndBrick))
+    }
+
+    func testBrickIsDisabledInsideIfLogicBeginBrick() {
+        let startScript = StartScript()
+        let ifLogicBeginBrick = IfLogicBeginBrick()
+        let changeVariableBrick = ChangeVariableBrick()
+        let ifLogicEndBrick = IfLogicEndBrick()
+        ifLogicBeginBrick.ifEndBrick = ifLogicEndBrick
+        ifLogicEndBrick.ifBeginBrick = ifLogicBeginBrick
+
+        let scriptBrickList = [ifLogicBeginBrick, changeVariableBrick, ifLogicEndBrick]
+        startScript.brickList = NSMutableArray(array: scriptBrickList)
+
+        scriptBrickList.forEach({ $0.script = startScript })
+
+        viewController.disableOrEnable(brick: ifLogicBeginBrick)
+        XCTAssertTrue(ifLogicBeginBrick.isDisabled)
+        XCTAssertTrue(changeVariableBrick.isDisabled)
+        XCTAssertTrue(ifLogicEndBrick.isDisabled)
+
+        XCTAssertFalse(viewController.isInsideDisabledLoopOrIf(brick: ifLogicBeginBrick))
+        XCTAssertTrue(viewController.isInsideDisabledLoopOrIf(brick: changeVariableBrick))
+        XCTAssertFalse(viewController.isInsideDisabledLoopOrIf(brick: ifLogicEndBrick))
+    }
+
+    func testBrickIsDisabledInsideIfThenLogicBrick() {
+        let startScript = StartScript()
+        let ifThenLogicBeginBrick = IfThenLogicBeginBrick()
+        let changeVariableBrick = ChangeVariableBrick()
+        let ifThenLogicEndBrick = IfThenLogicEndBrick()
+        ifThenLogicBeginBrick.ifEndBrick = ifThenLogicEndBrick
+        ifThenLogicEndBrick.ifBeginBrick = ifThenLogicBeginBrick
+
+        let scriptBrickList = [ifThenLogicBeginBrick, changeVariableBrick, ifThenLogicEndBrick]
+        startScript.brickList = NSMutableArray(array: scriptBrickList)
+
+        scriptBrickList.forEach({ $0.script = startScript })
+
+        viewController.disableOrEnable(brick: ifThenLogicBeginBrick)
+        XCTAssertTrue(ifThenLogicBeginBrick.isDisabled)
+        XCTAssertTrue(changeVariableBrick.isDisabled)
+        XCTAssertTrue(ifThenLogicEndBrick.isDisabled)
+
+        XCTAssertFalse(viewController.isInsideDisabledLoopOrIf(brick: ifThenLogicBeginBrick))
+        XCTAssertTrue(viewController.isInsideDisabledLoopOrIf(brick: changeVariableBrick))
+        XCTAssertFalse(viewController.isInsideDisabledLoopOrIf(brick: ifThenLogicEndBrick))
+    }
 }


### PR DESCRIPTION
Bricks inside a nested Brick which is disabled should not be executed nor allowed to be re-enabled in the UI. This applies for:
- Repeat
- Repeat Until
- IfThen
- IfThenElse
- Forever

This PR solves the re-enabling issue not exactly like Catroid because bricks which should not be allowed to be re-enabled are and stay grey in contrast to Catroid where these bricks return to the default color but without interfering the execution (dummy bricks)

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
