### PR TITLE
CATTY-322 Add remove methods for SynchronizedArray when initialized with UserData

### DIFF
--- a/src/Catty/DataModel/Array/SynchronizedArray.swift
+++ b/src/Catty/DataModel/Array/SynchronizedArray.swift
@@ -137,3 +137,14 @@ public extension SynchronizedArray where Element: Equatable {
         return result
     }
 }
+
+extension SynchronizedArray where Element: UserDataProtocol {
+    func remove(name: String) {
+        queue.async(flags: .barrier) {
+            for index in 0..<self.array.count where name == self.array[index].name {
+                self.array.remove(at: index)
+                break
+            }
+        }
+    }
+}

--- a/src/CattyTests/DataModel/SynchronizedArrayTests.swift
+++ b/src/CattyTests/DataModel/SynchronizedArrayTests.swift
@@ -230,6 +230,64 @@ final class SynchronizedArrayTests: XCTestCase {
 
     }
 
+    func testRemoveWhenInitializedWithUserList() {
+        let array = SynchronizedArray<UserList>()
+
+        XCTAssertEqual(0, array.count)
+
+        let userList1 = UserList(name: "userList1")
+        let userList2 = UserList(name: "userList2")
+
+        array.append(userList1)
+        array.append(userList2)
+        XCTAssertEqual(2, array.count)
+
+        array.remove(name: "testList")
+        XCTAssertEqual(2, array.count)
+
+        array.remove(name: "userList1")
+        XCTAssertEqual(1, array.count)
+        XCTAssertEqual(userList2, array[0])
+    }
+
+    func testRemoveWhenInitializedWithUserVariable() {
+        let array = SynchronizedArray<UserVariable>()
+
+        XCTAssertEqual(0, array.count)
+
+        let userVariable1 = UserVariable(name: "userVariable1")
+        let userVariable2 = UserVariable(name: "userVariable2")
+
+        array.append(userVariable1)
+        array.append(userVariable2)
+        XCTAssertEqual(2, array.count)
+
+        array.remove(name: "testVariable")
+        XCTAssertEqual(2, array.count)
+
+        array.remove(name: "userVariable1")
+        XCTAssertEqual(1, array.count)
+        XCTAssertEqual(userVariable2, array[0])
+    }
+
+    func testRemoveWhenInitializedWithUserDataProtocol() {
+        let array = SynchronizedArray<UserDataProtocol>()
+
+        let variable = UserVariable(name: "userVariable")
+        let list = UserList(name: "userList")
+
+        array.append(variable)
+        array.append(list)
+        XCTAssertEqual(2, array.count)
+
+        array.remove(name: "testUserData")
+        XCTAssertEqual(2, array.count)
+
+        array.remove(name: "userVariable")
+        XCTAssertEqual(1, array.count)
+        XCTAssertEqual(list, array[0] as! UserList)
+    }
+
     func testThreadSafeArray() {
         let array = SynchronizedArray<Int>()
 


### PR DESCRIPTION
Added a new extension for the SynchronizedArray.
Added remove for name function for SynchronizedArray when initialized with UserData.


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
