### PR TITLE
CATTY-331 Initial constuction of possible parameterization

### DIFF
--- a/src/Catty/Parser&Serialializer/New Parser & Serializer/Helper/CBXMLSerializerHelper.h
+++ b/src/Catty/Parser&Serialializer/New Parser & Serializer/Helper/CBXMLSerializerHelper.h
@@ -25,13 +25,16 @@
 @class Sound;
 @class Look;
 @class CBXMLPositionStack;
+@class SpriteObject;
+@protocol BrickProtocol;
 
 @interface CBXMLSerializerHelper : NSObject
 
 + (NSUInteger)indexOfElement:(id)element inArray:(NSArray*)array;
-+ (NSString*)relativeXPathToSound:(Sound*)sound inSoundList:(NSArray*)soundList;
-+ (NSString*)relativeXPathToLook:(Look*)look inLookList:(NSArray*)lookList;
++ (NSString*)relativeXPathToSound:(Sound*)sound inSoundList:(NSArray*)soundList withDepth:(NSInteger)depth;
++ (NSString*)relativeXPathToLook:(Look*)look inLookList:(NSArray*)lookList withDepth:(NSInteger)depth;
 + (NSString*)relativeXPathFromSourcePositionStack:(CBXMLPositionStack*)sourcePositionStack
                        toDestinationPositionStack:(CBXMLPositionStack*)destinationPositionStack;
++ (NSInteger)getDepthOfResource:(id<BrickProtocol>)scriptOrBrick forSpriteObject:(SpriteObject*)spriteObject;
 
 @end

--- a/src/Catty/Parser&Serialializer/New Parser & Serializer/Helper/CBXMLSerializerHelper.m
+++ b/src/Catty/Parser&Serialializer/New Parser & Serializer/Helper/CBXMLSerializerHelper.m
@@ -23,12 +23,21 @@
 #import "CBXMLSerializerHelper.h"
 #import "CBXMLParserContext.h"
 #import "CBXMLPositionStack.h"
+#import "Script.h"
+#import "SpriteObject.h"
 
 @implementation CBXMLSerializerHelper
 
-+ (NSString*)relativeXPathToRessourceList
++ (NSString*)relativeXPathToRessourceList:(NSInteger)depth
 {
-    return @"../../../../../"; // TODO: should be computed dynamically!
+    NSString *cd = @"../";
+    NSString *path = @"";
+    
+    for (NSInteger i = 0; i < depth; i++) {
+        path = [path stringByAppendingString: cd];
+    }
+    
+    return path;
 }
 
 + (NSString*)indexXPathStringForIndexNumber:(NSUInteger)indexNumber
@@ -54,20 +63,20 @@
     return NSNotFound;
 }
 
-+ (NSString*)relativeXPathToSound:(Sound*)sound inSoundList:(NSArray*)soundList
++ (NSString*)relativeXPathToSound:(Sound*)sound inSoundList:(NSArray*)soundList withDepth:(NSInteger)depth
 {
     NSString *index = [[self class] indexXPathStringForIndexNumber:[[self class] indexOfElement:sound
                                                                                         inArray:soundList]];
     return [NSString stringWithFormat:@"%@soundList/sound%@",
-            [[self class] relativeXPathToRessourceList], index];
+            [[self class] relativeXPathToRessourceList:depth], index];
 }
 
-+ (NSString*)relativeXPathToLook:(Look*)look inLookList:(NSArray*)lookList
++ (NSString*)relativeXPathToLook:(Look*)look inLookList:(NSArray*)lookList withDepth:(NSInteger)depth
 {
     NSString *index = [[self class] indexXPathStringForIndexNumber:[[self class] indexOfElement:look
                                                                                         inArray:lookList]];
     return [NSString stringWithFormat:@"%@lookList/look%@",
-            [[self class] relativeXPathToRessourceList], index];
+            [[self class] relativeXPathToRessourceList:depth], index];
 }
 
 + (NSString*)relativeXPathFromSourcePositionStack:(CBXMLPositionStack*)sourcePositionStack
@@ -100,6 +109,21 @@
         ++index;
     }
     return [path copy];
+}
+
++ (NSInteger)getDepthOfResource:(id<BrickProtocol>)scriptOrBrick forSpriteObject:(SpriteObject*)spriteObject
+{
+    if ([scriptOrBrick conformsToProtocol:@protocol(ScriptProtocol)]) {
+        return 3;
+    }
+    
+    for (Script* script in spriteObject.scriptList) {
+        if ([script.brickList containsObject:scriptOrBrick]) {
+            return 5;
+        }
+    }
+    
+    return 0;
 }
 
 @end

--- a/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/Look/SetBackgroundBrick+CBXMLHandler.m
+++ b/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/Look/SetBackgroundBrick+CBXMLHandler.m
@@ -74,7 +74,9 @@
             self.look = nil;
         } else {
             GDataXMLElement *referenceXMLElement = [GDataXMLElement elementWithName:@"look" context:context];
-            NSString *refPath = [CBXMLSerializerHelper relativeXPathToLook:self.look inLookList:context.spriteObject.lookList];
+            
+            NSInteger depthOfResource = [CBXMLSerializerHelper getDepthOfResource:self forSpriteObject:context.spriteObject];
+            NSString *refPath = [CBXMLSerializerHelper relativeXPathToLook:self.look inLookList:context.spriteObject.lookList withDepth:depthOfResource];
             [referenceXMLElement addAttribute:[GDataXMLElement attributeWithName:@"reference" escapedStringValue:refPath]];
             [brick addChild:referenceXMLElement context:context];
         }

--- a/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/Look/SetLookBrick+CBXMLHandler.m
+++ b/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/Look/SetLookBrick+CBXMLHandler.m
@@ -75,7 +75,8 @@
             self.look = nil;
         } else {
             GDataXMLElement *referenceXMLElement = [GDataXMLElement elementWithName:@"look" context:context];
-            NSString *refPath = [CBXMLSerializerHelper relativeXPathToLook:self.look inLookList:context.spriteObject.lookList];
+            NSUInteger depthOfResource = [CBXMLSerializerHelper getDepthOfResource:self forSpriteObject:context.spriteObject];
+            NSString *refPath = [CBXMLSerializerHelper relativeXPathToLook:self.look inLookList:context.spriteObject.lookList withDepth:depthOfResource];
             [referenceXMLElement addAttribute:[GDataXMLElement attributeWithName:@"reference" escapedStringValue:refPath]];
             [brick addChild:referenceXMLElement context:context];
         }

--- a/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/Sound/PlaySoundAndWaitBrick+CBXMLHandler.m
+++ b/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/Sound/PlaySoundAndWaitBrick+CBXMLHandler.m
@@ -70,8 +70,9 @@
             self.sound = nil;
         } else {
             GDataXMLElement *referenceXMLElement = [GDataXMLElement elementWithName:@"sound" context:context];
+            NSInteger depthOfResource = [CBXMLSerializerHelper getDepthOfResource:self forSpriteObject:context.spriteObject];
             NSString *refPath = [CBXMLSerializerHelper relativeXPathToSound:self.sound
-                                                                inSoundList:context.spriteObject.soundList];
+                                                                inSoundList:context.spriteObject.soundList withDepth:depthOfResource];
             [referenceXMLElement addAttribute:[GDataXMLElement attributeWithName:@"reference" escapedStringValue:refPath]];
             [brick addChild:referenceXMLElement context:context];
         }

--- a/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/Sound/PlaySoundBrick+CBXMLHandler.m
+++ b/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/Sound/PlaySoundBrick+CBXMLHandler.m
@@ -74,8 +74,9 @@
             self.sound = nil;
         } else {
             GDataXMLElement *referenceXMLElement = [GDataXMLElement elementWithName:@"sound" context:context];
+            NSInteger depthOfResource = [CBXMLSerializerHelper getDepthOfResource:self forSpriteObject:context.spriteObject];
             NSString *refPath = [CBXMLSerializerHelper relativeXPathToSound:self.sound
-                                                            inSoundList:context.spriteObject.soundList];
+                                inSoundList:context.spriteObject.soundList withDepth:depthOfResource];
             [referenceXMLElement addAttribute:[GDataXMLElement attributeWithName:@"reference" escapedStringValue:refPath]];
             [brick addChild:referenceXMLElement context:context];
         }

--- a/src/CattyTests/Parser & Serialization/Helper/CBXMLParserHelperTests.swift
+++ b/src/CattyTests/Parser & Serialization/Helper/CBXMLParserHelperTests.swift
@@ -42,4 +42,34 @@ final class CBXMLParserHelperTests: XCTestCase {
         XCTAssertNil(CBXMLParserHelper.findUserList(in: userListArray, withName: "userList"))
     }
 
+    func testGetDepthOfResourceAndRelativePathToResourceList() {
+        let object: SpriteObject! = SpriteObject()
+        let project: Project! = Project.defaultProject(withName: "a", projectID: "1")
+        let spriteNode = CBSpriteNode(spriteObject: object)
+        let startScript = StartScript()
+        object.spriteNode = spriteNode
+        object.project = project
+        object.scriptList.add(startScript)
+
+        let lookBrick = SetLookBrick()
+        let look = Look(name: "lookResource", andPath: "look")
+        lookBrick.look = look
+        object.add(look, andSaveToDisk: false)
+        startScript.add(lookBrick, at: 0)
+
+        let soundBrick = PlaySoundAndWaitBrick()
+        let sound = Sound(name: "soundResource", fileName: "sound")
+        soundBrick.sound = sound
+        object.soundList.add(sound)
+        startScript.add(soundBrick, at: 1)
+
+        let expected_relativePathLook = "../../../../../lookList/look"
+        let expected_relativePathSound = "../../../../../soundList/sound"
+        let expected_depth = 5
+
+        XCTAssertEqual(CBXMLSerializerHelper.getDepthOfResource(lookBrick, for: object), expected_depth)
+        XCTAssertEqual(CBXMLSerializerHelper.getDepthOfResource(soundBrick, for: object), expected_depth)
+        XCTAssertEqual(CBXMLSerializerHelper.relativeXPath(to: look, inLookList: object?.lookList as? [Any], withDepth: expected_depth), expected_relativePathLook)
+        XCTAssertEqual(CBXMLSerializerHelper.relativeXPath(to: sound, inSoundList: (object?.soundList as! [Any]), withDepth: expected_depth), expected_relativePathSound)
+    }
 }


### PR DESCRIPTION
The method relativeXPathToRessourceList in CBXMLSerializerHelper.m returns a static path for every resource (look, sound).
This path should be computed dynamically, in order to work with resources, which may be introduced by new bricks.

- Created a new method to get the depth of the resource (depending on wether resource is linked to script or brick)
- The method "relativeXPathToRessourceList" (CBXMLSerializerHelper.m) now takes the depth of the resource path as an 
argument
- Added a new test

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
