### PR TITLE
CATTY-324 Get all objects and use them in UserDataContainer

### DIFF
--- a/src/Catty/DataModel/Project/Project.h
+++ b/src/Catty/DataModel/Project/Project.h
@@ -54,6 +54,7 @@
 - (void)renameObject:(SpriteObject* _Nonnull)object toName:(NSString* _Nonnull)newObjectName;
 - (void)updateDescriptionWithText:(NSString* _Nonnull)descriptionText;
 - (nonnull NSArray*)allObjectNames;
+- (NSArray<SpriteObject*>* _Nonnull)allObjects;
 - (BOOL)hasObject:(SpriteObject* _Nonnull)object;
 - (SpriteObject* _Nonnull)copyObject:(SpriteObject* _Nonnull)sourceObject
     withNameForCopiedObject:(NSString* _Nonnull)nameOfCopiedObject;

--- a/src/Catty/DataModel/Project/Project.m
+++ b/src/Catty/DataModel/Project/Project.m
@@ -252,6 +252,11 @@
     return [objectNames copy];
 }
 
+- (NSArray<SpriteObject*>*)allObjects
+{
+    return self.objectList;
+}
+
 - (BOOL)hasObject:(SpriteObject *)object
 {
     return [self.objectList containsObject:object];

--- a/src/Catty/Extension&Delegate&Protocol/Extensions/Project+Extension/Project+CustomExtensions.m
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/Project+Extension/Project+CustomExtensions.m
@@ -29,7 +29,8 @@
 
 - (void)updateReferences
 {
-    for (SpriteObject *sprite in self.objectList) {
+    NSArray <SpriteObject*> *allObjects = [[NSMutableArray alloc] initWithArray: self.allObjects];
+    for (SpriteObject *sprite in allObjects) {
         sprite.project = self;
         for (Script *script in sprite.scriptList) {
             script.object = sprite;

--- a/src/Catty/Extension&Delegate&Protocol/Extensions/UserDataExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/UserDataExtension.swift
@@ -28,12 +28,11 @@
         if let vars = NSMutableArray(array: project.userData.programVariableList) as? [UserVariable] {
             allVariables = vars
         }
-        for index in 0..<project.userData.objectVariableList.count() {
-            if let variableList = project.userData.objectVariableList.object(at: index) as? [UserVariable] {
-                if variableList.isNotEmpty {
-                    allVariables.append(contentsOf: variableList)
-                }
-            }
+
+        let allObjects = project.allObjects()
+        for object in allObjects {
+            let objectVariables = UserDataContainer.objectVariables(for: object)
+            allVariables.append(contentsOf: objectVariables)
         }
         return allVariables
     }
@@ -45,12 +44,10 @@
             allLists = lists
         }
 
-        for index in 0..<project.userData.objectListOfLists.count() {
-            if let listOfLists = project.userData.objectListOfLists.object(at: index) as? [UserList] {
-                if listOfLists.isNotEmpty {
-                    allLists.append(contentsOf: listOfLists)
-                }
-            }
+        let allObjects = project.allObjects()
+        for object in allObjects {
+            let objectLists = UserDataContainer.objectLists(for: object)
+            allLists.append(contentsOf: objectLists)
         }
         return allLists
     }

--- a/src/Catty/FormulaEditor/ViewController/FormulaEditorViewController.m
+++ b/src/Catty/FormulaEditor/ViewController/FormulaEditorViewController.m
@@ -1182,7 +1182,7 @@ NS_ENUM(NSInteger, ButtonIndex) {
 - (BOOL)isVariableUsed:(UserVariable*)variable
 {
     if([self.object.project.userData isProjectVariable:variable]) {
-        for(SpriteObject *spriteObject in self.object.project.objectList) {
+        for(SpriteObject *spriteObject in self.object.project.allObjects) {
             for(Script *script in spriteObject.scriptList) {
                 for(id brick in script.brickList) {
                     if([brick isKindOfClass:[Brick class]] && [brick isVariableUsedWithVariable:variable]) {
@@ -1207,7 +1207,7 @@ NS_ENUM(NSInteger, ButtonIndex) {
 - (BOOL)isListUsed:(id<UserDataProtocol>)list
 {
     if([self.object.project.userData isProjectList:list]) {
-        for(SpriteObject *spriteObject in self.object.project.objectList) {
+        for(SpriteObject *spriteObject in self.object.project.allObjects) {
             for(Script *script in spriteObject.scriptList) {
                 for(id brick in script.brickList) {
                     if([brick isKindOfClass:[Brick class]] && [brick isListUsedWithList:list]) {

--- a/src/Catty/Helpers/Util/Util.m
+++ b/src/Catty/Helpers/Util/Util.m
@@ -562,7 +562,7 @@
 + (NSArray*)allMessagesForProject:(Project*)project
 {
     NSMutableArray *messages = [[NSMutableArray alloc] init];
-    for(SpriteObject *object in project.objectList) {
+    for(SpriteObject *object in project.allObjects) {
         for(Script *script in object.scriptList) {
             if([script isKindOfClass:[BroadcastScript class]]) {
                 BroadcastScript *broadcastScript = (BroadcastScript*)script;

--- a/src/CattyTests/DataModel/UserDataContainerTest.swift
+++ b/src/CattyTests/DataModel/UserDataContainerTest.swift
@@ -45,6 +45,8 @@ final class UserDataContainerTest: XCTestCase {
         self.objectB.name = "testObjectB"
         self.objectB.project = self.project
 
+        self.project.objectList.add(objectA as Any)
+        self.project.objectList.add(objectB as Any)
     }
 
     func testAddObjectVariable() {
@@ -391,6 +393,8 @@ final class UserDataContainerTest: XCTestCase {
 
         let copyContainer = container.mutableCopy() as! UserDataContainer
         let copyProject = Project()
+        copyProject.objectList.add(objectA as Any)
+        copyProject.objectList.add(objectB as Any)
         copyProject.userData = copyContainer
 
         XCTAssertTrue(container.isEqual(to: copyContainer))

--- a/src/CattyTests/Project/ProjectTests.swift
+++ b/src/CattyTests/Project/ProjectTests.swift
@@ -25,7 +25,7 @@
 import Nimble
 import XCTest
 
-class ProjectsTest: XCTestCase {
+class ProjectTest: XCTestCase {
 
     var project: Project!
     var fileManager: CBFileManager!
@@ -364,5 +364,18 @@ class ProjectsTest: XCTestCase {
 
         let expectedNotification = Notification(name: .projectInvalidVersion, object: loadingInfo)
         expect(Project(loadingInfo: loadingInfo!)).to(postNotifications(equal([expectedNotification])))
+    }
+
+    func testAllObject() {
+        self.project = Project()
+
+        XCTAssertEqual(0, self.project.allObjects().count)
+
+        let objectA = SpriteObject()
+        objectA.name = "objectA"
+
+        project.objectList.add(objectA)
+        XCTAssertEqual(1, self.project.allObjects().count)
+        XCTAssertTrue(self.project.allObjects()[0] === objectA)
     }
 }


### PR DESCRIPTION
Impleneted `allObjects` method in the Project class to get all the objects. Also, used the `allObjects` method in UserDataContainer instead of accessing the objectVariableList and objectListOfLists directly

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
