### PR TITLE
CATTY-326 Accelerator Sensor behaviour landscape mode

### DIFF
--- a/src/Catty/PlayerEngine/Sensors/Motion/AccelerationXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/AccelerationXSensor.swift
@@ -39,7 +39,11 @@
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
-        self.getMotionManager()?.deviceMotion?.userAcceleration.x ?? type(of: self).defaultRawValue
+        if !landscapeMode {
+            return self.getMotionManager()?.deviceMotion?.userAcceleration.x ?? type(of: self).defaultRawValue
+        } else {
+            return self.getMotionManager()?.deviceMotion?.userAcceleration.y ?? type(of: self).defaultRawValue
+        }
     }
 
     func convertToStandardized(rawValue: Double) -> Double {

--- a/src/Catty/PlayerEngine/Sensors/Motion/AccelerationYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/AccelerationYSensor.swift
@@ -39,7 +39,11 @@
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
-        self.getMotionManager()?.deviceMotion?.userAcceleration.y ?? type(of: self).defaultRawValue
+        if !landscapeMode {
+            return self.getMotionManager()?.deviceMotion?.userAcceleration.y ?? type(of: self).defaultRawValue
+        } else {
+            return self.getMotionManager()?.deviceMotion?.userAcceleration.x ?? type(of: self).defaultRawValue
+        }
     }
 
     func convertToStandardized(rawValue: Double) -> Double {

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationXSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationXSensorTest.swift
@@ -49,16 +49,23 @@ final class AccelerationXSensorTest: XCTestCase {
 
     func testRawValue() {
         motionManager.xUserAcceleration = 0
-        XCTAssertEqual(0, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        motionManager.yUserAcceleration = 0
+        XCTAssertEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(motionManager.yUserAcceleration, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.xUserAcceleration = 9.8
-        XCTAssertEqual(9.8, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(9.8, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertNotEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+
+        motionManager.yUserAcceleration = 9.8
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
 
         motionManager.xUserAcceleration = -9.8
-        XCTAssertEqual(-9.8, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(-9.8, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertNotEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+
+        motionManager.yUserAcceleration = -9.8
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
     }
 
     func testConvertToStandardized() {

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationYSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationYSensorTest.swift
@@ -49,16 +49,23 @@ final class AccelerationYSensorTest: XCTestCase {
 
     func testRawValue() {
         motionManager.yUserAcceleration = 0
-        XCTAssertEqual(0, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        motionManager.xUserAcceleration = 0
+        XCTAssertEqual(motionManager.yUserAcceleration, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.yUserAcceleration = 9.8
-        XCTAssertEqual(9.8, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(9.8, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertEqual(motionManager.yUserAcceleration, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertNotEqual(motionManager.yUserAcceleration, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+
+        motionManager.xUserAcceleration = 9.8
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
 
         motionManager.yUserAcceleration = -9.8
-        XCTAssertEqual(-9.8, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(-9.8, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertEqual(motionManager.yUserAcceleration, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertNotEqual(motionManager.yUserAcceleration, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+
+        motionManager.xUserAcceleration = -9.8
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
     }
 
     func testConvertToStandardized() {


### PR DESCRIPTION
Added landscape specific sensor behavior for Acceleration Sensors. If the project is in landscape Mode the Acceleration Sensors should use the values of the opposite sensors. _AccelerationXSensor_ uses values of _AccelerationYSensor_ and vice versa. https://jira.catrob.at/browse/CATTY-326

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline]
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
