### PR TITLE
CATTY-327 Inclination Sensor behaviour landscape mode

### DIFF
--- a/src/Catty/PlayerEngine/Sensors/Motion/InclinationXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/InclinationXSensor.swift
@@ -39,11 +39,33 @@
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
+        if !landscapeMode {
+            guard let inclinationSensor = self.getMotionManager() else { return type(of: self).defaultRawValue }
+            guard let deviceMotion = inclinationSensor.deviceMotion else {
+                return type(of: self).defaultRawValue
+            }
+            return deviceMotion.attitude.roll
+        } else {
+            let faceDown = (getMotionManager()?.accelerometerData?.acceleration.z ?? 0) > 0
+            if faceDown == false {
+                // screen up
+                return -rawValueYSensor()
+            } else {
+                if rawValueYSensor() > Double.epsilon {
+                    return Double.pi + rawValueYSensor()
+                } else {
+                    return -Double.pi + rawValueYSensor()
+                }
+            }
+        }
+    }
+
+    func rawValueYSensor() -> Double {
         guard let inclinationSensor = self.getMotionManager() else { return type(of: self).defaultRawValue }
         guard let deviceMotion = inclinationSensor.deviceMotion else {
             return type(of: self).defaultRawValue
         }
-        return deviceMotion.attitude.roll
+        return deviceMotion.attitude.pitch
     }
 
     // roll is between -pi, pi on both iOS and Android

--- a/src/Catty/PlayerEngine/Sensors/Motion/InclinationYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/InclinationYSensor.swift
@@ -41,12 +41,23 @@ import CoreMotion
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
-        guard let inclinationSensor = getMotionManager() else { return type(of: self).defaultRawValue }
+        if !landscapeMode {
+            guard let inclinationSensor = getMotionManager() else { return type(of: self).defaultRawValue }
+            guard let deviceMotion = inclinationSensor.deviceMotion else {
+                return type(of: self).defaultRawValue
+            }
+            return deviceMotion.attitude.pitch
+        } else {
+            return rawValueXSensor()
+        }
+    }
+
+    func rawValueXSensor() -> Double {
+        guard let inclinationSensor = self.getMotionManager() else { return type(of: self).defaultRawValue }
         guard let deviceMotion = inclinationSensor.deviceMotion else {
             return type(of: self).defaultRawValue
         }
-        return deviceMotion.attitude.pitch
-
+        return deviceMotion.attitude.roll
     }
 
     // pitch is between -pi/2, pi/2 on iOS and -pi,pi on Android

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationXSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationXSensorTest.swift
@@ -52,26 +52,55 @@ final class InclinationXSensorTest: XCTestCase {
         // test maximum value
         motionManager.attitude = (roll: Double.pi, pitch: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), Double.pi, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi, accuracy: Double.epsilon)
+        XCTAssertNotEqual(-sensor.rawValue(landscapeMode: true), Double.pi, accuracy: Double.epsilon)
+
+        motionManager.attitude = (roll: Double.pi, pitch: Double.pi)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), Double.pi, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         // test minimum value
         motionManager.attitude = (roll: -Double.pi, pitch: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), -Double.pi, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi, accuracy: Double.epsilon)
+        XCTAssertNotEqual(-sensor.rawValue(landscapeMode: true), -Double.pi, accuracy: Double.epsilon)
+
+        motionManager.attitude = (roll: -Double.pi, pitch: -Double.pi)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), -Double.pi, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         // test no inclination
         motionManager.attitude = (roll: 0, pitch: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), 0, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), 0, accuracy: Double.epsilon)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), 0, accuracy: Double.epsilon)
 
         // tests inside the range
         motionManager.attitude = (roll: Double.pi / 2, pitch: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), Double.pi / 2, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertNotEqual(-sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
+
+        motionManager.attitude = (roll: Double.pi / 2, pitch: Double.pi / 2)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.attitude = (roll: -Double.pi / 3, pitch: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), -Double.pi / 3, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 3, accuracy: Double.epsilon)
+        XCTAssertNotEqual(-sensor.rawValue(landscapeMode: true), -Double.pi / 3, accuracy: Double.epsilon)
+
+        motionManager.attitude = (roll: -Double.pi / 3, pitch: -Double.pi / 3)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), -Double.pi / 3, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+    }
+
+    func testRawValueLandscapeModeScreenDown() {
+        motionManager.zAcceleration = 0.5 // or any other positive value read by accelerationZ the sensors
+
+        motionManager.attitude.pitch = Double.pi / 4
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi + motionManager.attitude.pitch, accuracy: Double.epsilon)
+
+        motionManager.attitude.pitch = 0
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi + motionManager.attitude.pitch, accuracy: Double.epsilon)
+
+        motionManager.attitude.pitch = -Double.pi / 4
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi + motionManager.attitude.pitch, accuracy: Double.epsilon)
     }
 
     // does not depend on the orientation of the screen (left/right, up/down)
@@ -96,6 +125,11 @@ final class InclinationXSensorTest: XCTestCase {
 
         // test screen right, then down
         XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi), -180, accuracy: Double.epsilon)
+    }
+
+    func testRawValueYSensor() {
+        motionManager.attitude.pitch = Double.pi / 4
+        XCTAssertEqual(sensor.rawValueYSensor(), motionManager.attitude.pitch, accuracy: Double.epsilon)
     }
 
     func testStandardizedValue() {

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationYSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationYSensorTest.swift
@@ -51,26 +51,43 @@ final class InclinationYSensorTest: XCTestCase {
         // test maximum value
         motionManager.attitude = (pitch: Double.pi / 2, roll: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertNotEqual(sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
+
+        motionManager.attitude = (pitch: Double.pi / 2, roll: Double.pi / 2)
         XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         // test minimum value
         motionManager.attitude = (pitch: -Double.pi / 2, roll: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), -Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertNotEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 2, accuracy: Double.epsilon)
+
+        motionManager.attitude = (pitch: -Double.pi / 2, roll: -Double.pi / 2)
         XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         // test no inclination
         motionManager.attitude = (pitch: 0, roll: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), 0, accuracy: Double.epsilon)
         XCTAssertEqual(sensor.rawValue(landscapeMode: true), 0, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         // tests inside the range
         motionManager.attitude = (pitch: Double.pi / 3, roll: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), Double.pi / 3, accuracy: Double.epsilon)
+        XCTAssertNotEqual(sensor.rawValue(landscapeMode: true), Double.pi / 3, accuracy: Double.epsilon)
+
+        motionManager.attitude = (pitch: Double.pi / 3, roll: Double.pi / 3)
         XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi / 3, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.attitude = (pitch: -Double.pi / 6, roll: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), -Double.pi / 6, accuracy: Double.epsilon)
+        XCTAssertNotEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 6, accuracy: Double.epsilon)
+
+        motionManager.attitude = (pitch: -Double.pi / 6, roll: -Double.pi / 6)
         XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 6, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testConvertToStandardizedScreenUp() {
@@ -100,6 +117,11 @@ final class InclinationYSensorTest: XCTestCase {
 
         // half down - home button up
         XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 4), -135, accuracy: Double.epsilon)
+    }
+
+    func testRawValueXSensor() {
+        motionManager.attitude.roll = Double.pi / 4
+        XCTAssertEqual(sensor.rawValueXSensor(), motionManager.attitude.roll, accuracy: Double.epsilon)
     }
 
     func testStandardizedValue() {


### PR DESCRIPTION
Added landscape specific sensor behavior for Inclination Sensors. If the project is in landscape Mode the Acceleration Sensors should use the values of the opposite sensors. InclinationXSensor uses values of InclinationYSensor and vice versa.
https://jira.catrob.at/browse/CATTY-327


- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline]
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
