### PR TITLE
CATTY-350 Change Sensor evaluation for landscape mode

### DIFF
--- a/src/Catty/PlayerEngine/Sensors/Audio/LoudnessSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Audio/LoudnessSensor.swift
@@ -37,11 +37,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getAudioManager()?.loudness() ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         let rawValueConverted = pow(10, 0.05 * rawValue)
         return rawValueConverted * 100
     }

--- a/src/Catty/PlayerEngine/Sensors/Camera/FaceDetectedSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FaceDetectedSensor.swift
@@ -38,12 +38,12 @@ class FaceDetectedSensor: DeviceSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         guard let isFaceDetected = self.getFaceDetectionManager()?.isFaceDetected else { return type(of: self).defaultRawValue }
         return isFaceDetected ? 1.0 : 0.0
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Camera/FacePositionXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FacePositionXSensor.swift
@@ -40,12 +40,12 @@ class FacePositionXSensor: DeviceSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         guard let positionX = self.getFaceDetectionManager()?.facePositionRatioFromLeft else { return type(of: self).defaultRawValue }
         return positionX
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         if rawValue == type(of: self).defaultRawValue {
             return rawValue
         }

--- a/src/Catty/PlayerEngine/Sensors/Camera/FacePositionYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FacePositionYSensor.swift
@@ -40,12 +40,12 @@ class FacePositionYSensor: DeviceSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         guard let positionY = self.getFaceDetectionManager()?.facePositionRatioFromBottom else { return type(of: self).defaultRawValue }
         return positionY
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         if rawValue == type(of: self).defaultRawValue {
             return rawValue
         }

--- a/src/Catty/PlayerEngine/Sensors/Camera/FaceSizeSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FaceSizeSensor.swift
@@ -40,12 +40,12 @@ class FaceSizeSensor: DeviceSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         guard let faceSize = self.getFaceDetectionManager()?.faceSizeRatio else { return type(of: self).defaultRawValue }
         return Double(faceSize)
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         guard let frameSize = self.getFaceDetectionManager()?.faceDetectionFrameSize,
             let sceneWidth = self.sceneWidth
             else { return type(of: self).defaultRawValue }

--- a/src/Catty/PlayerEngine/Sensors/Date/DateDaySensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/DateDaySensor.swift
@@ -36,11 +36,11 @@ class DateDaySensor: DateSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         Double(Calendar.current.component(.day, from: self.date()))
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Date/DateMonthSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/DateMonthSensor.swift
@@ -36,11 +36,11 @@ class DateMonthSensor: DateSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         Double(Calendar.current.component(.month, from: self.date()))
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Date/DateWeekdaySensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/DateWeekdaySensor.swift
@@ -36,11 +36,11 @@ class DateWeekdaySensor: DateSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         Double(Calendar.current.component(.weekday, from: self.date()))
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         var weekday = rawValue
         if weekday == 1.0 { //Sunday
             weekday = 7

--- a/src/Catty/PlayerEngine/Sensors/Date/DateYearSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/DateYearSensor.swift
@@ -36,11 +36,11 @@ class DateYearSensor: DateSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         Double(Calendar.current.component(.year, from: self.date()))
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Date/TimeHourSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/TimeHourSensor.swift
@@ -36,11 +36,11 @@ class TimeHourSensor: DateSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         Double(Calendar.current.component(.hour, from: self.date()))
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Date/TimeMinuteSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/TimeMinuteSensor.swift
@@ -36,11 +36,11 @@ class TimeMinuteSensor: DateSensor {
         Date()
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         Double(Calendar.current.component(.minute, from: self.date()))
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Date/TimeSecondSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Date/TimeSecondSensor.swift
@@ -36,11 +36,11 @@ class TimeSecondSensor: DateSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         Double(Calendar.current.component(.second, from: self.date()))
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Heading/CompassDirectionSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Heading/CompassDirectionSensor.swift
@@ -38,11 +38,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getLocationManager()?.heading?.magneticHeading ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         if rawValue <= 180 {
             return -rawValue
         }

--- a/src/Catty/PlayerEngine/Sensors/Location/AltitudeSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Location/AltitudeSensor.swift
@@ -38,11 +38,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getLocationManager()?.location?.altitude ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Location/LatitudeSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Location/LatitudeSensor.swift
@@ -38,11 +38,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getLocationManager()?.location?.coordinate.latitude ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Location/LocationAccuracySensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Location/LocationAccuracySensor.swift
@@ -38,11 +38,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getLocationManager()?.location?.horizontalAccuracy ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         if rawValue < 0 {
             return 0
         }

--- a/src/Catty/PlayerEngine/Sensors/Location/LongitudeSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Location/LongitudeSensor.swift
@@ -38,11 +38,11 @@ class LongitudeSensor: NSObject, DeviceSensor {
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getLocationManager()?.location?.coordinate.longitude ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Motion/AccelerationXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/AccelerationXSensor.swift
@@ -38,11 +38,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getMotionManager()?.deviceMotion?.userAcceleration.x ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue * 9.8
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Motion/AccelerationYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/AccelerationYSensor.swift
@@ -38,11 +38,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getMotionManager()?.deviceMotion?.userAcceleration.y ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue * 9.8
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Motion/AccelerationZSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/AccelerationZSensor.swift
@@ -38,11 +38,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getMotionManager()?.deviceMotion?.userAcceleration.z ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue * 9.8
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Motion/InclinationXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/InclinationXSensor.swift
@@ -38,19 +38,18 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         guard let inclinationSensor = self.getMotionManager() else { return type(of: self).defaultRawValue }
         guard let deviceMotion = inclinationSensor.deviceMotion else {
             return type(of: self).defaultRawValue
         }
-
         return deviceMotion.attitude.roll
     }
 
     // roll is between -pi, pi on both iOS and Android
     // going to right, it is negative on Android and positive on iOS
     // going to left, it is positive on Android and negative on iOS
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         Util.radians(toDegree: -rawValue)
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Motion/InclinationYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/InclinationYSensor.swift
@@ -40,7 +40,7 @@ import CoreMotion
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         guard let inclinationSensor = getMotionManager() else { return type(of: self).defaultRawValue }
         guard let deviceMotion = inclinationSensor.deviceMotion else {
             return type(of: self).defaultRawValue
@@ -52,7 +52,7 @@ import CoreMotion
     // pitch is between -pi/2, pi/2 on iOS and -pi,pi on Android
     // going forward, it is positive on both iOS and Android
     // going backwards, it is negative on both iOS and Android
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         let faceDown = (getMotionManager()?.accelerometerData?.acceleration.z ?? 0) > 0
         if faceDown == false {
             // screen up

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomLeftSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomLeftSensor.swift
@@ -39,11 +39,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getBluetoothService()?.getSensorPhiro()?.getSensorValue(type(of: self).pinNumber) ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomRightSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomRightSensor.swift
@@ -39,11 +39,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getBluetoothService()?.getSensorPhiro()?.getSensorValue(type(of: self).pinNumber) ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontLeftSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontLeftSensor.swift
@@ -39,11 +39,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getBluetoothService()?.getSensorPhiro()?.getSensorValue(type(of: self).pinNumber) ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontRightSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontRightSensor.swift
@@ -39,11 +39,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getBluetoothService()?.getSensorPhiro()?.getSensorValue(type(of: self).pinNumber) ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideLeftSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideLeftSensor.swift
@@ -39,11 +39,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getBluetoothService()?.getSensorPhiro()?.getSensorValue(type(of: self).pinNumber) ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideRightSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideRightSensor.swift
@@ -39,11 +39,11 @@
         type(of: self).tag
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         self.getBluetoothService()?.getSensorPhiro()?.getSensorValue(type(of: self).pinNumber) ?? type(of: self).defaultRawValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Protocols/DeviceSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Protocols/DeviceSensor.swift
@@ -23,15 +23,15 @@
 protocol DeviceSensor: Sensor {
 
     // The iOS device specific value of the sensor
-    func rawValue() -> Double
+    func rawValue(landscapeMode: Bool) -> Double
 
     // Convert the iOS specific value (rawValue) to the Pocket Code standardized sensor value
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double
+    func convertToStandardized(rawValue: Double) -> Double
 }
 
 extension DeviceSensor {
     // The Pocket Code standardized sensor value
     func standardizedValue(landscapeMode: Bool) -> Double {
-        convertToStandardized(rawValue: self.rawValue(), landscapeMode: landscapeMode)
+        convertToStandardized(rawValue: self.rawValue(landscapeMode: landscapeMode))
     }
 }

--- a/src/CattyTests/PlayerEngine/Sensors/Audio/LoudnessSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Audio/LoudnessSensorTest.swift
@@ -43,36 +43,40 @@ final class LoudnessSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = LoudnessSensor { nil }
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         audioManager.mockedLoudnessInDecibels = 3
-        XCTAssertEqual(3, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(3, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(3, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         audioManager.mockedLoudnessInDecibels = -50
-        XCTAssertEqual(-50, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(-50, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(-50, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         audioManager.mockedLoudnessInDecibels = 10.786
-        XCTAssertEqual(10.786, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(10.786, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(10.786, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testConvertToStandardized() {
         // background noise
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: -40, landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: -40), accuracy: Double.epsilon)
 
-        let whisper = sensor.convertToStandardized(rawValue: -24, landscapeMode: false)
+        let whisper = sensor.convertToStandardized(rawValue: -24)
         XCTAssertEqual(6.3095, whisper, accuracy: Double.epsilon)
 
-        let normalVoice = sensor.convertToStandardized(rawValue: -15, landscapeMode: false)
+        let normalVoice = sensor.convertToStandardized(rawValue: -15)
         XCTAssertEqual(17.7827, normalVoice, accuracy: Double.epsilon)
 
-        let shouting = sensor.convertToStandardized(rawValue: -0.99, landscapeMode: false)
+        let shouting = sensor.convertToStandardized(rawValue: -0.99)
         XCTAssertEqual(89.2277, shouting, accuracy: Double.epsilon)
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Camera/FaceDetectionSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Camera/FaceDetectionSensorTest.swift
@@ -31,7 +31,8 @@ final class FaceDetectionSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = FaceDetectedSensor { nil }
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     override func setUp() {
@@ -48,19 +49,21 @@ final class FaceDetectionSensorTest: XCTestCase {
 
     func testRawValue() {
         self.cameraManagerMock.isFaceDetected = true
-        XCTAssertEqual(1, self.sensor.rawValue())
+        XCTAssertEqual(1, self.sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(1, self.sensor.rawValue(landscapeMode: true))
 
         self.cameraManagerMock.isFaceDetected = false
-        XCTAssertEqual(0, self.sensor.rawValue())
+        XCTAssertEqual(0, self.sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(0, self.sensor.rawValue(landscapeMode: true))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0, landscapeMode: false))
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: false))
+        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0))
+        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1))
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Camera/FacePositionXSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Camera/FacePositionXSensorTest.swift
@@ -45,29 +45,32 @@ final class FacePositionXSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = FacePositionXSensor(sceneSize: sceneSize, faceDetectionManagerGetter: { nil })
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         // only positive values - (0, 0) is at the bottom left
         self.cameraManagerMock.facePositionRatioFromLeft = 0
-        XCTAssertEqual(0, self.sensor.rawValue())
+        XCTAssertEqual(0, self.sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(0, self.sensor.rawValue(landscapeMode: true))
 
         self.cameraManagerMock.facePositionRatioFromLeft = 56
-        XCTAssertEqual(56, self.sensor.rawValue())
+        XCTAssertEqual(56, self.sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(56, self.sensor.rawValue(landscapeMode: true))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.convertToStandardized(rawValue: 0, landscapeMode: false))
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.convertToStandardized(rawValue: 0))
 
-        XCTAssertEqual(Double(sceneSize.width * 0.02) - Double(sceneSize.width / 2), sensor.convertToStandardized(rawValue: 0.02, landscapeMode: false))
-        XCTAssertEqual(Double(sceneSize.width * 0.45) - Double(sceneSize.width / 2), sensor.convertToStandardized(rawValue: 0.45, landscapeMode: false))
-        XCTAssertEqual(Double(sceneSize.width * 0.93) - Double(sceneSize.width / 2), sensor.convertToStandardized(rawValue: 0.93, landscapeMode: false))
-        XCTAssertEqual(Double(sceneSize.width / 2), sensor.convertToStandardized(rawValue: 1.0, landscapeMode: false))
+        XCTAssertEqual(Double(sceneSize.width * 0.02) - Double(sceneSize.width / 2), sensor.convertToStandardized(rawValue: 0.02))
+        XCTAssertEqual(Double(sceneSize.width * 0.45) - Double(sceneSize.width / 2), sensor.convertToStandardized(rawValue: 0.45))
+        XCTAssertEqual(Double(sceneSize.width * 0.93) - Double(sceneSize.width / 2), sensor.convertToStandardized(rawValue: 0.93))
+        XCTAssertEqual(Double(sceneSize.width / 2), sensor.convertToStandardized(rawValue: 1.0))
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Camera/FacePositionYSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Camera/FacePositionYSensorTest.swift
@@ -45,29 +45,32 @@ final class FacePositionYSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = FacePositionYSensor(sceneSize: self.sceneSize, faceDetectionManagerGetter: { nil })
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         // only positive values - (0, 0) is at the bottom left
         self.cameraManagerMock.facePositionRatioFromBottom = 0
-        XCTAssertEqual(0, self.sensor.rawValue())
+        XCTAssertEqual(0, self.sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(0, self.sensor.rawValue(landscapeMode: true))
 
         self.cameraManagerMock.facePositionRatioFromBottom = 256
-        XCTAssertEqual(256, self.sensor.rawValue())
+        XCTAssertEqual(256, self.sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(256, self.sensor.rawValue(landscapeMode: true))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.convertToStandardized(rawValue: 0, landscapeMode: false))
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.convertToStandardized(rawValue: 0))
 
-        XCTAssertEqual(Double(sceneSize.height * 0.01) - Double(sceneSize.height / 2), sensor.convertToStandardized(rawValue: 0.01, landscapeMode: false))
-        XCTAssertEqual(Double(sceneSize.height * 0.4) - Double(sceneSize.height / 2), sensor.convertToStandardized(rawValue: 0.4, landscapeMode: false))
-        XCTAssertEqual(Double(sceneSize.height * 0.95) - Double(sceneSize.height / 2), sensor.convertToStandardized(rawValue: 0.95, landscapeMode: false))
-        XCTAssertEqual(Double(sceneSize.height / 2), sensor.convertToStandardized(rawValue: 1.0, landscapeMode: false))
+        XCTAssertEqual(Double(sceneSize.height * 0.01) - Double(sceneSize.height / 2), sensor.convertToStandardized(rawValue: 0.01))
+        XCTAssertEqual(Double(sceneSize.height * 0.4) - Double(sceneSize.height / 2), sensor.convertToStandardized(rawValue: 0.4))
+        XCTAssertEqual(Double(sceneSize.height * 0.95) - Double(sceneSize.height / 2), sensor.convertToStandardized(rawValue: 0.95))
+        XCTAssertEqual(Double(sceneSize.height / 2), sensor.convertToStandardized(rawValue: 1.0))
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Camera/FaceSizeSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Camera/FaceSizeSensorTest.swift
@@ -46,18 +46,22 @@ final class FaceSizeSensorTest: XCTestCase {
     func testDefaultRawValue() {
         let sensor = FaceSizeSensor(sceneSize: sceneSize, faceDetectionManagerGetter: { nil })
 
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         self.cameraManagerMock.faceSizeRatio = 0.2
-        XCTAssertEqual(0.2, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(0.2, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(0.2, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         self.cameraManagerMock.faceSizeRatio = 0.5
-        XCTAssertEqual(0.5, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(0.5, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(0.5, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         self.cameraManagerMock.faceSizeRatio = 1.0
-        XCTAssertEqual(1.0, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(1.0, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(1.0, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testConvertToStandardized() {
@@ -65,18 +69,18 @@ final class FaceSizeSensorTest: XCTestCase {
         let scaleFactor = Double(self.sceneSize.width) / Double(frameWidth)
         self.cameraManagerMock.faceDetectionFrameSize = CGSize(width: frameWidth, height: 700)
 
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(0.5 * scaleFactor * 100, sensor.convertToStandardized(rawValue: 0.5, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 1, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: -20, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 150, landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0), accuracy: Double.epsilon)
+        XCTAssertEqual(0.5 * scaleFactor * 100, sensor.convertToStandardized(rawValue: 0.5), accuracy: Double.epsilon)
+        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 1), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: -20), accuracy: Double.epsilon)
+        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 150), accuracy: Double.epsilon)
 
         self.cameraManagerMock.faceDetectionFrameSize = nil
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.convertToStandardized(rawValue: 20, landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.convertToStandardized(rawValue: 20), accuracy: Double.epsilon)
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Date/DateDaySensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Date/DateDaySensorTest.swift
@@ -57,24 +57,27 @@ final class DateDaySensorTest: XCTestCase {
     func testRawValue() {
         /* test one digit */
         self.sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 4, day: 6, hour: 5))!
-        XCTAssertEqual(6, Int(sensor.rawValue()))
+        XCTAssertEqual(6, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(6, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test two digits */
         self.sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 8, day: 22, hour: 7))!
-        XCTAssertEqual(22, Int(sensor.rawValue()))
+        XCTAssertEqual(22, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(22, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test edge case - almost the beginning of the next day */
         self.sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 6, day: 18, hour: 23))!
-        XCTAssertEqual(18, Int(sensor.rawValue()))
+        XCTAssertEqual(18, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(18, Int(sensor.rawValue(landscapeMode: true)))
     }
 
     func testConvertToStandardizedValue() {
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: false))
-        XCTAssertEqual(10, sensor.convertToStandardized(rawValue: 10, landscapeMode: false))
+        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1))
+        XCTAssertEqual(10, sensor.convertToStandardized(rawValue: 10))
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Date/DateMonthSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Date/DateMonthSensorTest.swift
@@ -57,22 +57,23 @@ final class DateMonthSensorTest: XCTestCase {
     func testRawValue() {
         /* test one digit */
         self.sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 5, day: 3, hour: 10))!
-        XCTAssertEqual(5, Int(sensor.rawValue()))
+        XCTAssertEqual(5, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(5, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test two digits */
         self.sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2017, month: 12, day: 16, hour: 17))!
-        XCTAssertEqual(12, Int(sensor.rawValue()))
+        XCTAssertEqual(12, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(12, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test edge case - almost the beginning of the next month */
         self.sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 10, day: 31, hour: 23))!
-        XCTAssertEqual(10, Int(sensor.rawValue()))
+        XCTAssertEqual(10, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(10, Int(sensor.rawValue(landscapeMode: true)))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: false))
-        XCTAssertEqual(10, sensor.convertToStandardized(rawValue: 10, landscapeMode: false))
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: true))
-        XCTAssertEqual(10, sensor.convertToStandardized(rawValue: 10, landscapeMode: true))
+        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1))
+        XCTAssertEqual(10, sensor.convertToStandardized(rawValue: 10))
     }
 
     func testFormulaEditorSections() {

--- a/src/CattyTests/PlayerEngine/Sensors/Date/DateWeekdaySensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Date/DateWeekdaySensorTest.swift
@@ -57,65 +57,66 @@ final class DateWeekdaySensorTest: XCTestCase {
     func testRawValue() {
         /* test Sunday */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 6, day: 17, hour: 10))!
-        XCTAssertEqual(1, Int(sensor.rawValue()))
+        XCTAssertEqual(1, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(1, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test Monday */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 6, day: 18, hour: 10))!
-        XCTAssertEqual(2, Int(sensor.rawValue()))
+        XCTAssertEqual(2, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(2, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test Tuesday */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 6, day: 19, hour: 10))!
-        XCTAssertEqual(3, Int(sensor.rawValue()))
+        XCTAssertEqual(3, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(3, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test Wednesday */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 6, day: 20, hour: 10))!
-        XCTAssertEqual(4, Int(sensor.rawValue()))
+        XCTAssertEqual(4, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(4, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test Thursday */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 6, day: 21, hour: 10))!
-        XCTAssertEqual(5, Int(sensor.rawValue()))
+        XCTAssertEqual(5, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(5, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test Friday */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 6, day: 22, hour: 10))!
-        XCTAssertEqual(6, Int(sensor.rawValue()))
+        XCTAssertEqual(6, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(6, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test Saturday */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 6, day: 23, hour: 10))!
-        XCTAssertEqual(7, Int(sensor.rawValue()))
+        XCTAssertEqual(7, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(7, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test edge case - almost the beginning of the next day - Tuesday */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 6, day: 19, hour: 23))!
-        XCTAssertEqual(3, Int(sensor.rawValue()))
+        XCTAssertEqual(3, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(3, Int(sensor.rawValue(landscapeMode: true)))
     }
 
     func testConvertToStandardized() {
         /* test Sunday */
-        XCTAssertEqual(7, Int(sensor.convertToStandardized(rawValue: 1, landscapeMode: false)))
-        XCTAssertEqual(7, Int(sensor.convertToStandardized(rawValue: 1, landscapeMode: true)))
+        XCTAssertEqual(7, Int(sensor.convertToStandardized(rawValue: 1)))
 
         /* test Monday */
-        XCTAssertEqual(1, Int(sensor.convertToStandardized(rawValue: 2, landscapeMode: false)))
-        XCTAssertEqual(1, Int(sensor.convertToStandardized(rawValue: 2, landscapeMode: true)))
+        XCTAssertEqual(1, Int(sensor.convertToStandardized(rawValue: 2)))
 
         /* test Tuesday */
-        XCTAssertEqual(2, Int(sensor.convertToStandardized(rawValue: 3, landscapeMode: false)))
-        XCTAssertEqual(2, Int(sensor.convertToStandardized(rawValue: 3, landscapeMode: true)))
+        XCTAssertEqual(2, Int(sensor.convertToStandardized(rawValue: 3)))
 
         /* test Wednesday */
-        XCTAssertEqual(3, Int(sensor.convertToStandardized(rawValue: 4, landscapeMode: false)))
-        XCTAssertEqual(3, Int(sensor.convertToStandardized(rawValue: 4, landscapeMode: true)))
+        XCTAssertEqual(3, Int(sensor.convertToStandardized(rawValue: 4)))
 
         /* test Thursday */
-        XCTAssertEqual(4, Int(sensor.convertToStandardized(rawValue: 5, landscapeMode: false)))
-        XCTAssertEqual(4, Int(sensor.convertToStandardized(rawValue: 5, landscapeMode: true)))
+        XCTAssertEqual(4, Int(sensor.convertToStandardized(rawValue: 5)))
 
         /* test Friday */
-        XCTAssertEqual(5, Int(sensor.convertToStandardized(rawValue: 6, landscapeMode: false)))
-        XCTAssertEqual(5, Int(sensor.convertToStandardized(rawValue: 6, landscapeMode: true)))
+        XCTAssertEqual(5, Int(sensor.convertToStandardized(rawValue: 6)))
 
         /* test Saturday */
-        XCTAssertEqual(6, Int(sensor.convertToStandardized(rawValue: 7, landscapeMode: false)))
-        XCTAssertEqual(6, Int(sensor.convertToStandardized(rawValue: 7, landscapeMode: true)))
+        XCTAssertEqual(6, Int(sensor.convertToStandardized(rawValue: 7)))
     }
 
     func testFormulaEditorSections() {

--- a/src/CattyTests/PlayerEngine/Sensors/Date/DateYearSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Date/DateYearSensorTest.swift
@@ -57,18 +57,18 @@ final class DateYearSensorTest: XCTestCase {
     func testRawValue() {
         /* test during the year */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2017, month: 6, day: 7, hour: 10))!
-        XCTAssertEqual(2017, Int(sensor.rawValue()))
+        XCTAssertEqual(2017, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(2017, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test edge case - almost the beginning of the next year  */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 12, day: 31, hour: 23))!
-        XCTAssertEqual(2018, Int(sensor.rawValue()))
+        XCTAssertEqual(2018, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(2018, Int(sensor.rawValue(landscapeMode: true)))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: false))
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100, landscapeMode: false))
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: true))
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100, landscapeMode: true))
+        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1))
+        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100))
     }
 
     func testFormulaEditorSections() {

--- a/src/CattyTests/PlayerEngine/Sensors/Date/TimeHourSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Date/TimeHourSensorTest.swift
@@ -57,23 +57,23 @@ final class TimeHourSensorTest: XCTestCase {
     func testRawValue() {
         /* test one digit */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 6, day: 6, hour: 7))!
-        XCTAssertEqual(7, Int(sensor.rawValue()))
+        XCTAssertEqual(7, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(7, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test two digits */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2017, month: 8, day: 10, hour: 16))!
-        XCTAssertEqual(16, Int(sensor.rawValue()))
+        XCTAssertEqual(16, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(16, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test edge case - almost the beginning of the next day */
         sensor.mockDate = Calendar.current.date(from: DateComponents(year: 2018, month: 8, day: 22, hour: 23))!
-        XCTAssertEqual(23, Int(sensor.rawValue()))
-
+        XCTAssertEqual(23, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(23, Int(sensor.rawValue(landscapeMode: true)))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: false))
-        XCTAssertEqual(10, sensor.convertToStandardized(rawValue: 10, landscapeMode: false))
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: true))
-        XCTAssertEqual(10, sensor.convertToStandardized(rawValue: 10, landscapeMode: true))
+        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1))
+        XCTAssertEqual(10, sensor.convertToStandardized(rawValue: 10))
     }
 
     func testFormulaEditorSections() {

--- a/src/CattyTests/PlayerEngine/Sensors/Date/TimeMinuteSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Date/TimeMinuteSensorTest.swift
@@ -57,18 +57,18 @@ final class TimeMinuteSensorTest: XCTestCase {
     func testRawValue() {
         /* test one digit */
         self.sensor.mockDate = Date.init(timeIntervalSince1970: 1529345340)
-        XCTAssertEqual(9, Int(sensor.rawValue()))
+        XCTAssertEqual(9, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(9, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test two digits */
         self.sensor.mockDate = Date.init(timeIntervalSince1970: 1529326620)
-        XCTAssertEqual(57, Int(sensor.rawValue()))
+        XCTAssertEqual(57, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(57, Int(sensor.rawValue(landscapeMode: true)))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: false))
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100, landscapeMode: false))
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: true))
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100, landscapeMode: true))
+        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1))
+        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100))
     }
 
     func testFormulaEditorSections() {

--- a/src/CattyTests/PlayerEngine/Sensors/Date/TimeSecondSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Date/TimeSecondSensorTest.swift
@@ -57,18 +57,18 @@ final class TimeSecondSensorTest: XCTestCase {
     func testRawValue() {
         /* test one digit */
         self.sensor.mockDate = Date.init(timeIntervalSince1970: 1529301965)
-        XCTAssertEqual(5, Int(sensor.rawValue()))
+        XCTAssertEqual(5, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(5, Int(sensor.rawValue(landscapeMode: true)))
 
         /* test two digits */
         self.sensor.mockDate = Date.init(timeIntervalSince1970: 1528265185)
-        XCTAssertEqual(25, Int(sensor.rawValue()))
+        XCTAssertEqual(25, Int(sensor.rawValue(landscapeMode: false)))
+        XCTAssertEqual(25, Int(sensor.rawValue(landscapeMode: true)))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: false))
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100, landscapeMode: false))
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1, landscapeMode: true))
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100, landscapeMode: true))
+        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1))
+        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100))
     }
 
     func testFormulaEditorSections() {

--- a/src/CattyTests/PlayerEngine/Sensors/Heading/CompassDirectionSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Heading/CompassDirectionSensorTest.swift
@@ -43,56 +43,60 @@ final class CompassDirectionSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = CompassDirectionSensor { nil }
-        XCTAssertEqual(CompassDirectionSensor.defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(CompassDirectionSensor.defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(CompassDirectionSensor.defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         // N
         locationManager.magneticHeading = 0
-        XCTAssertEqual(0, sensor.rawValue())
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true))
 
         // E
         locationManager.magneticHeading = 90
-        XCTAssertEqual(90, sensor.rawValue())
+        XCTAssertEqual(90, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(90, sensor.rawValue(landscapeMode: true))
 
         // S
         locationManager.magneticHeading = 180
-        XCTAssertEqual(180, sensor.rawValue())
+        XCTAssertEqual(180, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(180, sensor.rawValue(landscapeMode: true))
 
         // W
         locationManager.magneticHeading = 270
-        XCTAssertEqual(270, sensor.rawValue())
-
+        XCTAssertEqual(270, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(270, sensor.rawValue(landscapeMode: true))
     }
 
     func testConvertToStandardized() {
         // N
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0, landscapeMode: false))
+        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0))
 
         // N-E
-        XCTAssertEqual(-45, sensor.convertToStandardized(rawValue: 45, landscapeMode: false))
+        XCTAssertEqual(-45, sensor.convertToStandardized(rawValue: 45))
 
         // E
-        XCTAssertEqual(-90, sensor.convertToStandardized(rawValue: 90, landscapeMode: false))
+        XCTAssertEqual(-90, sensor.convertToStandardized(rawValue: 90))
 
         // S-E
-        XCTAssertEqual(-135, sensor.convertToStandardized(rawValue: 135, landscapeMode: false))
+        XCTAssertEqual(-135, sensor.convertToStandardized(rawValue: 135))
 
         // S
-        XCTAssertEqual(-180, sensor.convertToStandardized(rawValue: 180, landscapeMode: false))
+        XCTAssertEqual(-180, sensor.convertToStandardized(rawValue: 180))
 
         // S-W
-        XCTAssertEqual(135, sensor.convertToStandardized(rawValue: 225, landscapeMode: false))
+        XCTAssertEqual(135, sensor.convertToStandardized(rawValue: 225))
 
         // W
-        XCTAssertEqual(90, sensor.convertToStandardized(rawValue: 270, landscapeMode: false))
+        XCTAssertEqual(90, sensor.convertToStandardized(rawValue: 270))
 
         // Kanye's daughter
-        XCTAssertEqual(45, sensor.convertToStandardized(rawValue: 315, landscapeMode: false))
+        XCTAssertEqual(45, sensor.convertToStandardized(rawValue: 315))
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Location/AltitudeSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Location/AltitudeSensorTest.swift
@@ -43,41 +43,48 @@ final class AltitudeSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = AltitudeSensor { nil }
-        XCTAssertEqual(AltitudeSensor.defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(AltitudeSensor.defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(AltitudeSensor.defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         // sea level
         locationManager.altitude = 0
-        XCTAssertEqual(0, sensor.rawValue())
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true))
 
         // below sea level
         locationManager.altitude = -250
-        XCTAssertEqual(-250, sensor.rawValue())
+        XCTAssertEqual(-250, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(-250, sensor.rawValue(landscapeMode: true))
 
         // field
         locationManager.altitude = 600
-        XCTAssertEqual(600, sensor.rawValue())
+        XCTAssertEqual(600, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(600, sensor.rawValue(landscapeMode: true))
 
         // mountain
         locationManager.altitude = 1500
-        XCTAssertEqual(1500, sensor.rawValue())
+        XCTAssertEqual(1500, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(1500, sensor.rawValue(landscapeMode: true))
 
         // Mt. Everest
         locationManager.altitude = 8848
-        XCTAssertEqual(8848, sensor.rawValue())
+        XCTAssertEqual(8848, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(8848, sensor.rawValue(landscapeMode: true))
 
         // float attitude
         locationManager.altitude = 2555.875
-        XCTAssertEqual(2555.875, sensor.rawValue())
+        XCTAssertEqual(2555.875, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(2555.875, sensor.rawValue(landscapeMode: true))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100, landscapeMode: false))
+        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100))
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Location/LatitudeSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Location/LatitudeSensorTest.swift
@@ -43,41 +43,48 @@ final class LatitudeSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = LatitudeSensor { nil }
-        XCTAssertEqual(LatitudeSensor.defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(LatitudeSensor.defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(LatitudeSensor.defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         // min value - South Pole
         locationManager.latitude = -90
-        XCTAssertEqual(-90, sensor.rawValue())
+        XCTAssertEqual(-90, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(-90, sensor.rawValue(landscapeMode: true))
 
         // max value - North Pole
         locationManager.latitude = 90
-        XCTAssertEqual(90, sensor.rawValue())
+        XCTAssertEqual(90, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(90, sensor.rawValue(landscapeMode: true))
 
         // center
         locationManager.latitude = 0
-        XCTAssertEqual(0, sensor.rawValue())
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true))
 
         // London
         locationManager.latitude = 51.5
-        XCTAssertEqual(51.5, sensor.rawValue())
+        XCTAssertEqual(51.5, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(51.5, sensor.rawValue(landscapeMode: true))
 
         // Cape Town
         locationManager.latitude = -33.92
-        XCTAssertEqual(-33.92, sensor.rawValue())
+        XCTAssertEqual(-33.92, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(-33.92, sensor.rawValue(landscapeMode: true))
 
         // Munich
         locationManager.latitude = 48.13
-        XCTAssertEqual(48.13, sensor.rawValue())
+        XCTAssertEqual(48.13, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(48.13, sensor.rawValue(landscapeMode: true))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100, landscapeMode: false))
+        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100))
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Location/LocationAccuracySensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Location/LocationAccuracySensorTest.swift
@@ -43,29 +43,32 @@ final class LocationAccuracySensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = LocationAccuracySensor { nil }
-        XCTAssertEqual(LocationAccuracySensor.defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(LocationAccuracySensor.defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(LocationAccuracySensor.defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         // positive value => valid location
         locationManager.locationAccuracy = 10
-        XCTAssertEqual(10, sensor.rawValue())
+        XCTAssertEqual(10, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(10, sensor.rawValue(landscapeMode: true))
 
         // negative value => invalid location
         locationManager.locationAccuracy = -5
-        XCTAssertEqual(-5, sensor.rawValue())
+        XCTAssertEqual(-5, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(-5, sensor.rawValue(landscapeMode: true))
     }
 
     func testConvertToStandardized() {
         // valid location
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100, landscapeMode: false))
+        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100))
 
         // invalid location
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: -1, landscapeMode: false))
+        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: -1))
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Location/LongitudeSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Location/LongitudeSensorTest.swift
@@ -43,41 +43,48 @@ final class LongitudeSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = LongitudeSensor { nil }
-        XCTAssertEqual(LongitudeSensor.defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(LongitudeSensor.defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(LongitudeSensor.defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         // min value
         locationManager.longitude = -180
-        XCTAssertEqual(-180, sensor.rawValue())
+        XCTAssertEqual(-180, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(-180, sensor.rawValue(landscapeMode: true))
 
         // max value
         locationManager.longitude = 180
-        XCTAssertEqual(180, sensor.rawValue())
+        XCTAssertEqual(180, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(180, sensor.rawValue(landscapeMode: true))
 
         // center
         locationManager.longitude = 0
-        XCTAssertEqual(0, sensor.rawValue())
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true))
 
         // London
         locationManager.longitude = -0.127
-        XCTAssertEqual(-0.127, sensor.rawValue())
+        XCTAssertEqual(-0.127, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(-0.127, sensor.rawValue(landscapeMode: true))
 
         // Cape Town
         locationManager.longitude = 18.424
-        XCTAssertEqual(18.424, sensor.rawValue())
+        XCTAssertEqual(18.424, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(18.424, sensor.rawValue(landscapeMode: true))
 
         // Alaska
         locationManager.longitude = -149.49
-        XCTAssertEqual(-149.49, sensor.rawValue())
+        XCTAssertEqual(-149.49, sensor.rawValue(landscapeMode: false))
+        XCTAssertEqual(-149.49, sensor.rawValue(landscapeMode: true))
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100, landscapeMode: false))
+        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 100))
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Mocks/DeviceSensorMock.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Mocks/DeviceSensorMock.swift
@@ -52,11 +52,11 @@ final class DeviceSensorMock: SensorMock, DeviceSensor {
         self.init(tag: tag, formulaEditorSections: [])
     }
 
-    func rawValue() -> Double {
+    func rawValue(landscapeMode: Bool) -> Double {
         mockedValue
     }
 
-    func convertToStandardized(rawValue: Double, landscapeMode: Bool) -> Double {
+    func convertToStandardized(rawValue: Double) -> Double {
         rawValue
     }
 }

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationXSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationXSensorTest.swift
@@ -43,30 +43,34 @@ final class AccelerationXSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = AccelerationXSensor { nil }
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         motionManager.xUserAcceleration = 0
-        XCTAssertEqual(0, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.xUserAcceleration = 9.8
-        XCTAssertEqual(9.8, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(9.8, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(9.8, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.xUserAcceleration = -9.8
-        XCTAssertEqual(-9.8, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(-9.8, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(-9.8, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(9.8, sensor.convertToStandardized(rawValue: 1, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(-9.8, sensor.convertToStandardized(rawValue: -1, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(98, sensor.convertToStandardized(rawValue: 10, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(-98, sensor.convertToStandardized(rawValue: -10, landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0), accuracy: Double.epsilon)
+        XCTAssertEqual(9.8, sensor.convertToStandardized(rawValue: 1), accuracy: Double.epsilon)
+        XCTAssertEqual(-9.8, sensor.convertToStandardized(rawValue: -1), accuracy: Double.epsilon)
+        XCTAssertEqual(98, sensor.convertToStandardized(rawValue: 10), accuracy: Double.epsilon)
+        XCTAssertEqual(-98, sensor.convertToStandardized(rawValue: -10), accuracy: Double.epsilon)
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationYSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationYSensorTest.swift
@@ -43,30 +43,34 @@ final class AccelerationYSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = AccelerationYSensor { nil }
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         motionManager.yUserAcceleration = 0
-        XCTAssertEqual(0, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.yUserAcceleration = 9.8
-        XCTAssertEqual(9.8, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(9.8, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(9.8, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.yUserAcceleration = -9.8
-        XCTAssertEqual(-9.8, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(-9.8, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(-9.8, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(9.8, sensor.convertToStandardized(rawValue: 1, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(-9.8, sensor.convertToStandardized(rawValue: -1, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(98, sensor.convertToStandardized(rawValue: 10, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(-98, sensor.convertToStandardized(rawValue: -10, landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0), accuracy: Double.epsilon)
+        XCTAssertEqual(9.8, sensor.convertToStandardized(rawValue: 1), accuracy: Double.epsilon)
+        XCTAssertEqual(-9.8, sensor.convertToStandardized(rawValue: -1), accuracy: Double.epsilon)
+        XCTAssertEqual(98, sensor.convertToStandardized(rawValue: 10), accuracy: Double.epsilon)
+        XCTAssertEqual(-98, sensor.convertToStandardized(rawValue: -10), accuracy: Double.epsilon)
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationZSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationZSensorTest.swift
@@ -42,30 +42,34 @@ final class AccelerationZSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = AccelerationZSensor { nil }
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         motionManager.zUserAcceleration = 0
-        XCTAssertEqual(0, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.zUserAcceleration = 9.8
-        XCTAssertEqual(9.8, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(9.8, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(9.8, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.zUserAcceleration = -9.8
-        XCTAssertEqual(-9.8, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(-9.8, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(-9.8, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(9.8, sensor.convertToStandardized(rawValue: 1, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(-9.8, sensor.convertToStandardized(rawValue: -1, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(98, sensor.convertToStandardized(rawValue: 10, landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(-98, sensor.convertToStandardized(rawValue: -10, landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0), accuracy: Double.epsilon)
+        XCTAssertEqual(9.8, sensor.convertToStandardized(rawValue: 1), accuracy: Double.epsilon)
+        XCTAssertEqual(-9.8, sensor.convertToStandardized(rawValue: -1), accuracy: Double.epsilon)
+        XCTAssertEqual(98, sensor.convertToStandardized(rawValue: 10), accuracy: Double.epsilon)
+        XCTAssertEqual(-98, sensor.convertToStandardized(rawValue: -10), accuracy: Double.epsilon)
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationXSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationXSensorTest.swift
@@ -43,56 +43,63 @@ final class InclinationXSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = InclinationXSensor { nil }
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+
     }
 
     func testRawValue() {
         // test maximum value
         motionManager.attitude = (roll: Double.pi, pitch: 0)
-        XCTAssertEqual(sensor.rawValue(), Double.pi, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), Double.pi, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi, accuracy: Double.epsilon)
 
         // test minimum value
         motionManager.attitude = (roll: -Double.pi, pitch: 0)
-        XCTAssertEqual(sensor.rawValue(), -Double.pi, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -Double.pi, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi, accuracy: Double.epsilon)
 
         // test no inclination
         motionManager.attitude = (roll: 0, pitch: 0)
-        XCTAssertEqual(sensor.rawValue(), 0, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), 0, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), 0, accuracy: Double.epsilon)
 
         // tests inside the range
         motionManager.attitude = (roll: Double.pi / 2, pitch: 0)
-        XCTAssertEqual(sensor.rawValue(), Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
 
         motionManager.attitude = (roll: -Double.pi / 3, pitch: 0)
-        XCTAssertEqual(sensor.rawValue(), -Double.pi / 3, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -Double.pi / 3, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 3, accuracy: Double.epsilon)
     }
 
     // does not depend on the orientation of the screen (left/right, up/down)
     func testConvertToStandardized() {
         // test no inclination
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: 0, landscapeMode: false), 0, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: 0), 0, accuracy: Double.epsilon)
 
         // test screen half left
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 4, landscapeMode: false), 45, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 4), 45, accuracy: Double.epsilon)
 
         // test screen half right
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 4, landscapeMode: false), -45, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 4), -45, accuracy: Double.epsilon)
 
         // test screen left
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 2, landscapeMode: false), 90, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 2), 90, accuracy: Double.epsilon)
 
         // test screen right
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 2, landscapeMode: false), -90, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 2), -90, accuracy: Double.epsilon)
 
         // test screen left, then down
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi, landscapeMode: false), 180, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi), 180, accuracy: Double.epsilon)
 
         // test screen right, then down
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi, landscapeMode: false), -180, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi), -180, accuracy: Double.epsilon)
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationYSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationYSensorTest.swift
@@ -43,61 +43,67 @@ final class InclinationYSensorTest: XCTestCase {
 
     func testDefaultRawValue() {
         let sensor = InclinationYSensor { nil }
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
         // test maximum value
         motionManager.attitude = (pitch: Double.pi / 2, roll: 0)
-        XCTAssertEqual(sensor.rawValue(), Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
 
         // test minimum value
         motionManager.attitude = (pitch: -Double.pi / 2, roll: 0)
-        XCTAssertEqual(sensor.rawValue(), -Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 2, accuracy: Double.epsilon)
 
         // test no inclination
         motionManager.attitude = (pitch: 0, roll: 0)
-        XCTAssertEqual(sensor.rawValue(), 0, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), 0, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), 0, accuracy: Double.epsilon)
 
         // tests inside the range
         motionManager.attitude = (pitch: Double.pi / 3, roll: 0)
-        XCTAssertEqual(sensor.rawValue(), Double.pi / 3, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), Double.pi / 3, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi / 3, accuracy: Double.epsilon)
 
         motionManager.attitude = (pitch: -Double.pi / 6, roll: 0)
-        XCTAssertEqual(sensor.rawValue(), -Double.pi / 6, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -Double.pi / 6, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 6, accuracy: Double.epsilon)
     }
 
     func testConvertToStandardizedScreenUp() {
         motionManager.zAcceleration = -0.5 // or any other negative value read by acceleration the sensors
 
         // no inclination
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: 0, landscapeMode: false), 0, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: 0), 0, accuracy: Double.epsilon)
 
         // half up - home botton down
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 4, landscapeMode: false), 45, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 4), 45, accuracy: Double.epsilon)
 
         // up - face to face to the user
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 2, landscapeMode: false), 90, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 2), 90, accuracy: Double.epsilon)
 
         // half up - home button up
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 4, landscapeMode: false), -45, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 4), -45, accuracy: Double.epsilon)
     }
 
     func testConvertToStandardizedScreenDown() {
         motionManager.zAcceleration = 0.5 //or any other positive value read by the acceleration sensors
 
         // half down - home button down
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 4, landscapeMode: false), 135, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 4), 135, accuracy: Double.epsilon)
 
         // up - with the back to the user
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 2, landscapeMode: false), -90, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 2), -90, accuracy: Double.epsilon)
 
         // half down - home button up
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 4, landscapeMode: false), -135, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 4), -135, accuracy: Double.epsilon)
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(), landscapeMode: false)
+        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)

--- a/src/CattyTests/PlayerEngine/Sensors/Phiro/PhiroSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Phiro/PhiroSensorTest.swift
@@ -125,17 +125,11 @@ final class PhiroSensorTest: XCTestCase {
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(100, phiroSideLeft.convertToStandardized(rawValue: 100, landscapeMode: false))
-        XCTAssertEqual(100, phiroSideLeft.convertToStandardized(rawValue: 100, landscapeMode: true))
-        XCTAssertEqual(100, phiroSideRight.convertToStandardized(rawValue: 100, landscapeMode: false))
-        XCTAssertEqual(100, phiroSideRight.convertToStandardized(rawValue: 100, landscapeMode: true))
-        XCTAssertEqual(100, phiroFrontLeft.convertToStandardized(rawValue: 100, landscapeMode: false))
-        XCTAssertEqual(100, phiroFrontLeft.convertToStandardized(rawValue: 100, landscapeMode: true))
-        XCTAssertEqual(100, phiroFrontRight.convertToStandardized(rawValue: 100, landscapeMode: false))
-        XCTAssertEqual(100, phiroFrontRight.convertToStandardized(rawValue: 100, landscapeMode: true))
-        XCTAssertEqual(100, phiroBottomLeft.convertToStandardized(rawValue: 100, landscapeMode: false))
-        XCTAssertEqual(100, phiroBottomLeft.convertToStandardized(rawValue: 100, landscapeMode: true))
-        XCTAssertEqual(100, phiroBottomRight.convertToStandardized(rawValue: 100, landscapeMode: false))
-        XCTAssertEqual(100, phiroBottomRight.convertToStandardized(rawValue: 100, landscapeMode: true))
+        XCTAssertEqual(100, phiroSideLeft.convertToStandardized(rawValue: 100))
+        XCTAssertEqual(100, phiroSideRight.convertToStandardized(rawValue: 100))
+        XCTAssertEqual(100, phiroFrontLeft.convertToStandardized(rawValue: 100))
+        XCTAssertEqual(100, phiroFrontRight.convertToStandardized(rawValue: 100))
+        XCTAssertEqual(100, phiroBottomLeft.convertToStandardized(rawValue: 100))
+        XCTAssertEqual(100, phiroBottomRight.convertToStandardized(rawValue: 100))
     }
 }

--- a/src/CattyTests/PlayerEngine/Sensors/SensorManagerTests.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/SensorManagerTests.swift
@@ -117,8 +117,10 @@ final class SensorManagerTests: XCTestCase {
         type(of: manager).defaultValueForUndefinedSensor = 12.3
 
         XCTAssertEqual(type(of: manager).defaultValueForUndefinedSensor, manager.value(tag: "undefinedTag", spriteObject: object) as! Double)
-        XCTAssertEqual(sensorA.rawValue(), manager.value(tag: sensorA.tag(), spriteObject: object) as! Double)
-        XCTAssertEqual(sensorA.rawValue(), manager.value(tag: sensorA.tag(), spriteObject: nil) as! Double)
+        XCTAssertEqual(sensorA.rawValue(landscapeMode: false), manager.value(tag: sensorA.tag(), spriteObject: object) as! Double)
+        XCTAssertEqual(sensorA.rawValue(landscapeMode: true), manager.value(tag: sensorA.tag(), spriteObject: object) as! Double)
+        XCTAssertEqual(sensorA.rawValue(landscapeMode: false), manager.value(tag: sensorA.tag(), spriteObject: nil) as! Double)
+        XCTAssertEqual(sensorA.rawValue(landscapeMode: true), manager.value(tag: sensorA.tag(), spriteObject: nil) as! Double)
         XCTAssertEqual(type(of: sensorB).rawValue(for: SpriteObject()), manager.value(tag: sensorB.tag(), spriteObject: object) as! Double)
         XCTAssertEqual(type(of: sensorC).rawValue(for: object), manager.value(tag: sensorC.tag(), spriteObject: object) as! String)
         XCTAssertEqual(type(of: sensorC).defaultRawValue, manager.value(tag: sensorC.tag()) as! Double)


### PR DESCRIPTION
Changed the sensor evaluation for landscape mode. The Sensor behaviour depending on the orientation will now be determined in the rawValue method of the sensors. Therefore the landscape bool of the convertToStandardized method was removed. The key changes are in the _DeviceSensor_ protocol. The other changes are a result of these.
https://jira.catrob.at/browse/CATTY-350

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline]
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
