### PR TITLE
CATTY-339 Compare UserDataContainer order-insensitive

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -846,6 +846,7 @@
 		6F5865FA2471756900A7B4B2 /* CBXMLParserHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5865F92471756900A7B4B2 /* CBXMLParserHelperTests.swift */; };
 		6F58F0B124ABA59900AB8C99 /* StoreProjectDownloader.uploadProject.fail.invalidChecksum.json in Resources */ = {isa = PBXBuildFile; fileRef = 6F58F0AE24ABA59800AB8C99 /* StoreProjectDownloader.uploadProject.fail.invalidChecksum.json */; };
 		6F58F0C224AC956000AB8C99 /* StoreProjectUpload.uploadProject.fail.invalidBody.json in Resources */ = {isa = PBXBuildFile; fileRef = 6F58F0C124AC956000AB8C99 /* StoreProjectUpload.uploadProject.fail.invalidBody.json */; };
+		6F59BB5524B46A3000BBD6EA /* GDataXMLElementExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F59BB5424B46A3000BBD6EA /* GDataXMLElementExtensionTests.swift */; };
 		6F5ADF13247D4703008FC2C5 /* BrickExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5ADF12247D4703008FC2C5 /* BrickExtension.swift */; };
 		6F5CACA1246ADE0000BC58A4 /* CBFileManagerMockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F5CACA0246ADE0000BC58A4 /* CBFileManagerMockTests.swift */; };
 		6F61FD8524A8B38800C6C969 /* StoreProjectDownloader.uploadProject.fail.authentication.json in Resources */ = {isa = PBXBuildFile; fileRef = 6F61FD8424A8B38800C6C969 /* StoreProjectDownloader.uploadProject.fail.authentication.json */; };
@@ -2492,6 +2493,7 @@
 		6F5865F92471756900A7B4B2 /* CBXMLParserHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBXMLParserHelperTests.swift; sourceTree = "<group>"; };
 		6F58F0AE24ABA59800AB8C99 /* StoreProjectDownloader.uploadProject.fail.invalidChecksum.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = StoreProjectDownloader.uploadProject.fail.invalidChecksum.json; sourceTree = "<group>"; };
 		6F58F0C124AC956000AB8C99 /* StoreProjectUpload.uploadProject.fail.invalidBody.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = StoreProjectUpload.uploadProject.fail.invalidBody.json; sourceTree = "<group>"; };
+		6F59BB5424B46A3000BBD6EA /* GDataXMLElementExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GDataXMLElementExtensionTests.swift; path = Extensions/GDataXMLElementExtensionTests.swift; sourceTree = "<group>"; };
 		6F5ADF12247D4703008FC2C5 /* BrickExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrickExtension.swift; sourceTree = "<group>"; };
 		6F5CACA0246ADE0000BC58A4 /* CBFileManagerMockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CBFileManagerMockTests.swift; sourceTree = "<group>"; };
 		6F61FD8424A8B38800C6C969 /* StoreProjectDownloader.uploadProject.fail.authentication.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = StoreProjectDownloader.uploadProject.fail.authentication.json; sourceTree = "<group>"; };
@@ -8603,6 +8605,7 @@
 				6F9CF132246F0B81008CED1C /* NSDateExtensionTests.swift */,
 				18B5B528247E542A007D24A3 /* NSDataExtensionTests.swift */,
 				18B5B52F247EB059007D24A3 /* NSStringExtensionTests.swift */,
+				6F59BB5424B46A3000BBD6EA /* GDataXMLElementExtensionTests.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -9901,6 +9904,7 @@
 				D3AF5C19243F6A4C00B04BC6 /* BrickCategoryTest.swift in Sources */,
 				4CC50A5C213BBD7D004BC914 /* FormulaManagerInterpreterTests.swift in Sources */,
 				4C5AEEF722F6F3EA00280F8B /* NextLookBrickCellTests.swift in Sources */,
+				6F59BB5524B46A3000BBD6EA /* GDataXMLElementExtensionTests.swift in Sources */,
 				4C82265E213FA7A400F3D750 /* LastFingerIndexSensorTest.swift in Sources */,
 				4C6FE168212D2D2E0067B7D5 /* TanFunctionTest.swift in Sources */,
 				4C7182E123EEF47500195BC7 /* UICollectionViewMock.swift in Sources */,

--- a/src/CattyTests/Extensions/GDataXMLElementExtensionTests.swift
+++ b/src/CattyTests/Extensions/GDataXMLElementExtensionTests.swift
@@ -1,0 +1,168 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+@testable import Pocket_Code
+
+class GDataXMLElementExtensionTests: XCTestCase {
+    var rootElement: GDataXMLElement!
+    var attribute: GDataXMLElement!
+    var secondAttribute: GDataXMLElement!
+
+    override func setUp() {
+        self.rootElement = self.createGDXMLElementWith(xmlString: "testElement")
+
+        self.attribute = self.createGDXMLElementWith(xmlString: "testAttribute")
+        self.attribute.setStringValue("stringValue1")
+
+        self.secondAttribute = self.createGDXMLElementWith(xmlString: "testAttribute2")
+        self.secondAttribute.setStringValue("stringValue2")
+    }
+
+    func createGDXMLElementWith(xmlString: String) -> GDataXMLElement? {
+        do {
+            let element = try GDataXMLElement(xmlString: "<\(xmlString)/>")
+            return element
+        } catch {
+            XCTFail("Error in GDataXMLElement")
+        }
+        return nil
+    }
+
+    func testIsEqualForDifferentNumberOfAttributes() {
+        let testRootElement = GDataXMLElement()
+
+        rootElement.addAttribute(attribute)
+        XCTAssertFalse(testRootElement.isEqual(to: self.rootElement))
+        XCTAssertNil(testRootElement.attributes())
+        XCTAssertNotNil(self.rootElement.attributes())
+        XCTAssertEqual(1, self.rootElement.attributes().count)
+    }
+
+    func testIsEqualForDifferentAttributes() {
+        let testRootElement = self.createGDXMLElementWith(xmlString: "testElement2")
+
+        self.rootElement.addAttribute(attribute)
+        testRootElement!.addAttribute(secondAttribute)
+
+        XCTAssertFalse(testRootElement!.isEqual(to: self.rootElement))
+        XCTAssertEqual(testRootElement!.attributes().count, self.rootElement.attributes().count)
+    }
+
+    func testIsEqualForObjectUserDataEqualToElementWithObjectListOfList() {
+        self.rootElement = self.createGDXMLElementWith(xmlString: "objectListOfList")
+        let testRootElement = self.createGDXMLElementWith(xmlString: "objectListOfList")
+
+        let entry1 = self.createGDXMLElementWith(xmlString: "entry")
+        let entry2 = self.createGDXMLElementWith(xmlString: "entry")
+
+        let list1 = self.createGDXMLElementWith(xmlString: "list")
+        let list2 = self.createGDXMLElementWith(xmlString: "list")
+
+        let object1 = self.createGDXMLElementWith(xmlString: "object1")
+        object1!.setStringValue("object1StringValue")
+
+        list1!.addChild(object1)
+        entry1!.addChild(list1)
+        testRootElement!.addChild(entry1)
+        XCTAssertFalse(testRootElement!.isEqual(to: self.rootElement))
+
+        entry2!.addChild(list2)
+        self.rootElement.addChild(entry2)
+        XCTAssertFalse(testRootElement!.isEqual(to: self.rootElement))
+
+        testRootElement!.addChild(entry2)
+        self.rootElement.addChild(entry1)
+        XCTAssertTrue(testRootElement!.isEqual(to: self.rootElement))
+    }
+
+    func testIsEqualForObjectUserDataEqualToElementWithObjectVariableList() {
+        self.rootElement = self.createGDXMLElementWith(xmlString: "objectVariableList")
+        let testRootElement = self.createGDXMLElementWith(xmlString: "objectVariableList")
+
+        let entry1 = self.createGDXMLElementWith(xmlString: "entry")
+        let entry2 = self.createGDXMLElementWith(xmlString: "entry")
+
+        let list1 = self.createGDXMLElementWith(xmlString: "list")
+        let list2 = self.createGDXMLElementWith(xmlString: "list")
+
+        let variable1 = self.createGDXMLElementWith(xmlString: "variable1")
+        variable1!.setStringValue("variable1StringValue")
+
+        list1!.addChild(variable1)
+        entry1!.addChild(list1)
+        testRootElement!.addChild(entry1)
+        XCTAssertFalse(testRootElement!.isEqual(to: self.rootElement))
+
+        entry2!.addChild(list2)
+        self.rootElement.addChild(entry2)
+        XCTAssertFalse(testRootElement!.isEqual(to: self.rootElement))
+
+        testRootElement!.addChild(entry2)
+        self.rootElement.addChild(entry1)
+        XCTAssertTrue(testRootElement!.isEqual(to: self.rootElement))
+    }
+
+    func testIsEqualForDifferentNumberOfChild() {
+        let testRootElement = self.createGDXMLElementWith(xmlString: "testElement2")
+
+        rootElement.addChild(self.attribute)
+        XCTAssertFalse(testRootElement!.isEqual(to: self.rootElement))
+        XCTAssertNil(testRootElement!.children())
+        XCTAssertNotNil(self.rootElement.children())
+        XCTAssertEqual(1, self.rootElement.children().count)
+    }
+
+    func testIsEqualForDifferentChild() {
+        let testRootElement = self.createGDXMLElementWith(xmlString: "testElement2")
+
+        self.rootElement.addChild(attribute)
+        testRootElement!.addChild(secondAttribute)
+
+        XCTAssertFalse(testRootElement!.isEqual(to: self.rootElement))
+        XCTAssertEqual(testRootElement!.children().count, self.rootElement.children().count)
+    }
+
+    func testIsEqualForStringValue() {
+        let testRootElement = self.createGDXMLElementWith(xmlString: "testElement2")
+
+        XCTAssertTrue(testRootElement!.isEqual(to: self.rootElement))
+        XCTAssertEqual(self.rootElement.stringValue(), testRootElement!.stringValue())
+        XCTAssertEqual("", self.rootElement.stringValue())
+        XCTAssertEqual("", testRootElement!.stringValue())
+
+        self.rootElement.setStringValue("stringValue1")
+
+        XCTAssertFalse(testRootElement!.isEqual(to: self.rootElement))
+        XCTAssertNotEqual(self.rootElement.stringValue(), testRootElement!.stringValue())
+        XCTAssertEqual("stringValue1", self.rootElement.stringValue())
+        XCTAssertEqual("", testRootElement!.stringValue())
+
+        testRootElement!.setStringValue("stringValue2")
+
+        XCTAssertFalse(testRootElement!.isEqual(to: self.rootElement))
+        XCTAssertNotEqual(self.rootElement.stringValue(), testRootElement!.stringValue())
+        XCTAssertEqual("stringValue1", self.rootElement.stringValue())
+        XCTAssertEqual("stringValue2", testRootElement!.stringValue())
+    }
+}

--- a/src/CattyTests/Resources/ParserTests/Custom/ValidProjectAllBricks/ValidProjectAllBricks0991.xml
+++ b/src/CattyTests/Resources/ParserTests/Custom/ValidProjectAllBricks/ValidProjectAllBricks0991.xml
@@ -634,6 +634,10 @@
           <userVariable reference="../../../../../objectList/object/scriptList/script/brickList/brick[14]/userVariable"/>
         </list>
       </entry>
+      <entry>
+         <object reference="../../../../objectList/object/scriptList/script/brickList/brick[10]/pointedObject"/>
+        <list/>
+      </entry>
     </objectVariableList>
     <programListOfLists/>
     <programVariableList>


### PR DESCRIPTION
-  Changed the comparison of the serialized XML files so that the order of the entries (entry) in the objectVariableList and objectVariableList do not matter.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
