### PR TITLE
CATTY-315 Text can not be joined with lists

### DIFF
--- a/src/Catty/Functions/Protocols/Function.swift
+++ b/src/Catty/Functions/Protocols/Function.swift
@@ -97,6 +97,30 @@ extension Function {
             }
             return String(number)
         }
+        if let userVariable = parameter as? UserVariable {
+            return self.interpretParameter(parameter: userVariable.value as AnyObject?)
+        }
+        if let userList = parameter as? UserList {
+            var value = ""
+            if !userList.isEmpty {
+                var allElemenetsAreSilgleLength = true
+                var elements = [String]()
+
+                for index in 1...userList.count {
+                    let newValue = self.interpretParameter(parameter: userList.element(at: index) as AnyObject?)
+                    elements.append(newValue)
+                    if newValue.count > 1 {
+                        allElemenetsAreSilgleLength = false
+                    }
+                }
+                if allElemenetsAreSilgleLength {
+                    value = elements.joined()
+                } else {
+                    value = elements.joined(separator: " ")
+                }
+            }
+            return value
+        }
         return ""
     }
 

--- a/src/CattyTests/PlayerEngine/Functions/Text/JoinFunctionTest.swift
+++ b/src/CattyTests/PlayerEngine/Functions/Text/JoinFunctionTest.swift
@@ -56,6 +56,23 @@ class JoinFunctionTest: XCTestCase {
         XCTAssertEqual("XCode 9", function.value(firstParameter: "XCode " as AnyObject, secondParameter: 9 as AnyObject))
         XCTAssertEqual("XCode 9.4", function.value(firstParameter: "XCode " as AnyObject, secondParameter: 9.4 as AnyObject))
         XCTAssertEqual("limit inf", function.value(firstParameter: "limit " as AnyObject, secondParameter: Double.infinity as AnyObject))
+
+        var list = UserList(name: "testList")
+        list.add(element: 1)
+        list.add(element: "A")
+        XCTAssertEqual("list 1A", function.value(firstParameter: "list " as AnyObject, secondParameter: list as AnyObject))
+
+        list.add(element: "testValue")
+        XCTAssertEqual("list 1 A testValue", function.value(firstParameter: "list " as AnyObject, secondParameter: list as AnyObject))
+
+        list = UserList(name: "newTestList")
+        list.add(element: "itemA")
+        list.add(element: "itemB")
+        XCTAssertEqual("list itemA itemB", function.value(firstParameter: "list " as AnyObject, secondParameter: list as AnyObject))
+
+        let variable = UserVariable(name: "testVariable")
+        variable.value = "testValue"
+        XCTAssertEqual("variable testValue", function.value(firstParameter: "variable " as AnyObject, secondParameter: variable as AnyObject))
     }
 
     func testFirstParameter() {


### PR DESCRIPTION
Bug fixed

- The text could be joined with the content of a list(i.e UserList) using `JOIN Function`.
- The text could be joined with the value of a variable(i.e UserVariable) using `JOIN Function`.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
