### PR TITLE
CATTY-363 App crashing with unavailable resources

### DIFF
--- a/src/Catty/ViewController/Scene/ScenePresenterViewController+Resources.swift
+++ b/src/Catty/ViewController/Scene/ScenePresenterViewController+Resources.swift
@@ -99,13 +99,15 @@ import CoreBluetooth
         }
 
         if !unavailableResourceNames.isEmpty {
-            AlertControllerBuilder.alert(title: kLocalizedPocketCode, message: unavailableResourceNames.joined(separator: ", ") + " " + kLocalizedNotAvailable)
+            DispatchQueue.main.async {
+                AlertControllerBuilder.alert(title: kLocalizedPocketCode, message: unavailableResourceNames.joined(separator: ", ") + " " + kLocalizedNotAvailable)
                 .addCancelAction(title: kLocalizedCancel, handler: nil)
                 .addDefaultAction(title: kLocalizedYes) {
                     self.continueWithoutRequiredResources(navigationController: navigationController)
                 }
                 .build()
                 .showWithController(navigationController)
+            }
 
             return false
         }
@@ -116,18 +118,20 @@ import CoreBluetooth
     @nonobjc private func bluetoothDevicesUnconnected(navigationController: UINavigationController, bluetoothDevices: [BluetoothDeviceID]) {
         let intDevices = bluetoothDevices.map { $0.rawValue }
 
-        if CentralManager.sharedInstance.state == ManagerState.poweredOn || CentralManager.sharedInstance.state == ManagerState.unknown {
-            let storyboard = UIStoryboard(name: "iPhone", bundle: nil)
-            let bvc: BluetoothPopupVC = storyboard.instantiateViewController(withIdentifier: "bluetoothPopupVC") as! BluetoothPopupVC
-            bvc.deviceArray = intDevices
+        DispatchQueue.main.async {
+            if CentralManager.sharedInstance.state == ManagerState.poweredOn || CentralManager.sharedInstance.state == ManagerState.unknown {
+                let storyboard = UIStoryboard(name: "iPhone", bundle: nil)
+                let bvc: BluetoothPopupVC = storyboard.instantiateViewController(withIdentifier: "bluetoothPopupVC") as! BluetoothPopupVC
+                bvc.deviceArray = intDevices
 
-            let navController = UINavigationController(rootViewController: bvc)
-            self.present(navController, animated: true)
+                let navController = UINavigationController(rootViewController: bvc)
+                self.present(navController, animated: true)
 
-        } else if CentralManager.sharedInstance.state == ManagerState.poweredOff {
-            Util.alert(withText: kLocalizedBluetoothPoweredOff)
-        } else {
-            Util.alert(withText: kLocalizedBluetoothNotAvailable)
+            } else if CentralManager.sharedInstance.state == ManagerState.poweredOff {
+                Util.alert(withText: kLocalizedBluetoothPoweredOff)
+            } else {
+                Util.alert(withText: kLocalizedBluetoothNotAvailable)
+            }
         }
     }
 


### PR DESCRIPTION
Bug fixed

- Now app does not crash when resources are unavailable.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
