### PR TITLE
CATTY-349 Scale landscape background images automatically in Paint

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
 		4C03A4C22133FDE7007BFFD2 /* FormulaManager+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C03A4C12133FDE7007BFFD2 /* FormulaManager+Editor.swift */; };
 		4C03A4C42133FF4B007BFFD2 /* FormulaManager+Interpreter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C03A4C32133FF4B007BFFD2 /* FormulaManager+Interpreter.swift */; };
 		4C099F6E1C282B3C00E190CA /* CBBackendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C099F6D1C282B3C00E190CA /* CBBackendTests.swift */; };
+		4C0A209824CEA46700CC9B04 /* PaintViewControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0A209524CEA46600CC9B04 /* PaintViewControllerMock.swift */; };
 		4C0C164921439B2F005ADE86 /* ChartProjectsStoreDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0C164821439B2F005ADE86 /* ChartProjectsStoreDataSourceTests.swift */; };
 		4C0E25E920D39E5000A80273 /* ScenePresenterViewController+Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0E25E820D39E5000A80273 /* ScenePresenterViewController+Resources.swift */; };
 		4C0EEE6C23F423E9005340B2 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 4C0EEE6B23F423E9005340B2 /* GoogleService-Info.plist */; };
@@ -2000,6 +2001,7 @@
 		4C03A4C12133FDE7007BFFD2 /* FormulaManager+Editor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormulaManager+Editor.swift"; sourceTree = "<group>"; };
 		4C03A4C32133FF4B007BFFD2 /* FormulaManager+Interpreter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormulaManager+Interpreter.swift"; sourceTree = "<group>"; };
 		4C099F6D1C282B3C00E190CA /* CBBackendTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CBBackendTests.swift; path = PlayerEngine/CBBackendTests.swift; sourceTree = "<group>"; };
+		4C0A209524CEA46600CC9B04 /* PaintViewControllerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaintViewControllerMock.swift; sourceTree = "<group>"; };
 		4C0C164821439B2F005ADE86 /* ChartProjectsStoreDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartProjectsStoreDataSourceTests.swift; sourceTree = "<group>"; };
 		4C0E25E820D39E5000A80273 /* ScenePresenterViewController+Resources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ScenePresenterViewController+Resources.swift"; sourceTree = "<group>"; };
 		4C0EEE6B23F423E9005340B2 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = "GoogleService-Info.plist"; path = "Catty/Supporting Files/Firebase/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -6506,6 +6508,7 @@
 				5973F235202EF2BB00A4CED9 /* MediaLibraryCollectionViewDataSourceDelegateMock.swift */,
 				599E64A5202DB2FB009494B5 /* MediaLibraryDownloaderMock.swift */,
 				4CB73A9123FC1F1300D5E9A7 /* NavigationControllerMock.swift */,
+				4C0A209524CEA46600CC9B04 /* PaintViewControllerMock.swift */,
 				D3CF3A0E23D07F06006B2667 /* ProjectMock.swift */,
 				4CFABF5C24AB0DD40023D581 /* RuntimeImageCacheMock.swift */,
 				9E05FAB0247FF57F008951DE /* ScenePresenterViewControllerSpy.swift */,
@@ -10136,6 +10139,7 @@
 				2ED418C42411213E00AFE2FD /* XMLParserBlackBoxTests093.swift in Sources */,
 				4CD487761ED2C2A3001BB80A /* ChangeVariableBrickTests.swift in Sources */,
 				2ED418C62411213E00AFE2FD /* XMLParserTests092.swift in Sources */,
+				4C0A209824CEA46700CC9B04 /* PaintViewControllerMock.swift in Sources */,
 				4C82267B213FA7A400F3D750 /* BackgroundNumberSensorTest.swift in Sources */,
 				59A58D83202C714A008B1A8F /* MediaLibraryDownloaderTests.swift in Sources */,
 				9E24D7072326EBC300608203 /* ShowBrickTests.swift in Sources */,

--- a/src/Catty/PocketPaint/ViewController/PaintViewController.h
+++ b/src/Catty/PocketPaint/ViewController/PaintViewController.h
@@ -74,9 +74,11 @@
 
 @property (weak, nonatomic) IBOutlet UIButton *colorButton;
 
+- (void)setupZoomForImage:(UIImage*)image;
 - (void)updateToolbar;
 - (void)setImagePickerImage:(UIImage*)image;
 - (id)getUndoManager;
 - (id)getResizeViewManager;
 - (id)getPointerTool;
+
 @end

--- a/src/CattyTests/Mocks/PaintViewControllerMock.swift
+++ b/src/CattyTests/Mocks/PaintViewControllerMock.swift
@@ -20,29 +20,29 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-class NavigationControllerMock: UINavigationController {
+class PaintViewControllerMock: PaintViewController {
 
-    var currentViewController: UIViewController?
-    var navigationBarFrame = CGRect.zero
-    var toolbarFrame = CGRect.zero
+    let navigationControllerMock: UINavigationController
 
-    override var navigationBar: UINavigationBar {
-        let navigationBar = UINavigationBar()
-        navigationBar.frame = self.navigationBarFrame
-        return navigationBar
+    override var navigationController: UINavigationController? { navigationControllerMock }
+
+    init?(editingImage: UIImage, navigationController: UINavigationController) {
+        let data = NSMutableData()
+        let archiver = NSKeyedArchiver(forWritingWith: data)
+        archiver.finishEncoding()
+        let coder = NSKeyedUnarchiver(forReadingWith: data as Data)
+
+        self.navigationControllerMock = navigationController
+
+        super.init(coder: coder)
+
+        self.editingImage = editingImage
+        self.helper = UIView()
+        self.drawView = UIImageView()
+        self.saveView = UIImageView()
     }
 
-    override var toolbar: UIToolbar {
-        let toolbar = UIToolbar()
-        toolbar.frame = self.toolbarFrame
-        return toolbar
-    }
-
-    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
-        self.currentViewController = viewController
-    }
-
-    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
-        self.currentViewController = viewControllerToPresent
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/src/CattyTests/ViewController/PaintViewControllerTests.swift
+++ b/src/CattyTests/ViewController/PaintViewControllerTests.swift
@@ -27,7 +27,13 @@ import XCTest
 
 final class PaintViewControllerTests: XCTestCase {
 
+    var navigationController: NavigationControllerMock!
+
     override func setUp() {
+        self.navigationController = NavigationControllerMock()
+        self.navigationController.navigationBarFrame = CGRect(origin: .zero, size: CGSize(width: 100, height: 40))
+        self.navigationController.toolbarFrame = CGRect(origin: CGPoint(x: 0, y: 900), size: .zero)
+
         super.setUp()
     }
 
@@ -36,5 +42,93 @@ final class PaintViewControllerTests: XCTestCase {
         let expectedNotification = Notification(name: .paintViewControllerDidAppear, object: controller)
 
         expect(controller.viewDidAppear(true)).to(postNotifications(contain(expectedNotification)))
+    }
+
+    func testSetupZoom() {
+        let width = CGFloat(100)
+        let height = CGFloat(150)
+
+        let image = createImage(CGSize(width: width, height: height))
+        let controller = PaintViewControllerMock(editingImage: image, navigationController: navigationController)
+
+        XCTAssertEqual(width, image.size.width)
+
+        XCTAssertEqual(CGRect.zero, controller!.drawView.frame)
+
+        controller?.setupZoom(for: image)
+
+        XCTAssertEqual(width, controller!.drawView.frame.width)
+        XCTAssertEqual(height, controller!.drawView.frame.height)
+    }
+
+    func testSetupZoomLongPortrait() {
+        let width = CGFloat(1200)
+        let height = CGFloat(3648)
+        let ratio = width / height
+
+        let image = createImage(CGSize(width: width, height: height))
+        let controller = PaintViewControllerMock(editingImage: image, navigationController: navigationController)
+
+        XCTAssertEqual(width, image.size.width)
+
+        XCTAssertEqual(CGRect.zero, controller!.drawView.frame)
+
+        controller?.setupZoom(for: image)
+        let ratioAfterZoom = controller!.drawView.frame.width / controller!.drawView.frame.height
+        XCTAssertTrue(Double(ratio - ratioAfterZoom) <= Double.epsilon)
+
+        let viewHeight = controller!.navigationController!.toolbar.frame.origin.y - Util.statusBarHeight() - controller!.navigationController!.navigationBar.frame.size.height
+        XCTAssertEqual(viewHeight * 0.9, controller!.drawView.frame.height)
+    }
+
+    func testSetupZoomWideLandscape() {
+        let width = CGFloat(2500)
+        let height = CGFloat(479)
+        let ratio = width / height
+
+        let image = createImage(CGSize(width: width, height: height))
+        let controller = PaintViewControllerMock(editingImage: image, navigationController: navigationController)
+
+        XCTAssertEqual(width, image.size.width)
+
+        XCTAssertEqual(CGRect.zero, controller!.drawView.frame)
+
+        controller?.setupZoom(for: image)
+        let ratioAfterZoom = controller!.drawView.frame.width / controller!.drawView.frame.height
+        XCTAssertTrue(Double(ratio - ratioAfterZoom) <= Double.epsilon)
+
+        let viewWidth = controller!.view.bounds.size.width
+        XCTAssertEqual(viewWidth * 0.9, controller!.drawView.frame.width)
+    }
+
+    func testSetupZoomCenterPosition() {
+        let width = CGFloat(100)
+        let height = CGFloat(150)
+
+        let image = createImage(CGSize(width: width, height: height))
+        let controller = PaintViewControllerMock(editingImage: image, navigationController: navigationController)
+
+        controller?.setupZoom(for: image)
+
+        let horizontalDistanceLeftEdge = controller!.helper.frame.origin.x
+        let horizontalDistanceRightEdge = controller!.scrollView.bounds.size.width - (horizontalDistanceLeftEdge + controller!.helper.frame.size.width)
+
+        XCTAssertTrue(Double(horizontalDistanceLeftEdge - horizontalDistanceRightEdge) <= Double.epsilon)
+
+        let verticalDistanceUpperEdge = controller!.helper.frame.origin.y
+        let verticalDistanceLowerEdge = controller!.scrollView.bounds.size.height - (verticalDistanceUpperEdge + controller!.helper.frame.size.height)
+
+        XCTAssertTrue(Double(verticalDistanceUpperEdge - verticalDistanceLowerEdge) <= Double.epsilon)
+    }
+
+    private func createImage(_ size: CGSize) -> UIImage {
+        let rect = CGRect(origin: .zero, size: size)
+
+        UIGraphicsBeginImageContextWithOptions(rect.size, false, 1.0)
+
+        let image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return UIImage(cgImage: image!.cgImage!)
     }
 }


### PR DESCRIPTION
Landscape background images are cut off by the width of the screen by default. When the background is shown cut off, the entire image can only be seen when the user zooms out by himself. Same for very long portrayed images.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
