### PR TITLE
CATTY-329 Compass Direction Sensor behaviour landscape mode

### DIFF
--- a/src/Catty/PlayerEngine/Sensors/Heading/CompassDirectionSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Heading/CompassDirectionSensor.swift
@@ -39,14 +39,22 @@
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
-        self.getLocationManager()?.heading?.magneticHeading ?? type(of: self).defaultRawValue
+        guard let compassSensor = self.getLocationManager() else { return type(of: self).defaultRawValue }
+        guard let compassSensorHeading = compassSensor.heading?.magneticHeading else { return type(of: self).defaultRawValue }
+
+        if !landscapeMode {
+            return compassSensorHeading
+        } else {
+            return compassSensorHeading - 90.0
+        }
     }
 
     func convertToStandardized(rawValue: Double) -> Double {
         if rawValue <= 180 {
             return -rawValue
+        } else {
+            return 360 - rawValue
         }
-        return 360 - rawValue
     }
 
     func formulaEditorSections(for spriteObject: SpriteObject) -> [FormulaEditorSection] {

--- a/src/CattyTests/PlayerEngine/Sensors/Heading/CompassDirectionSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Heading/CompassDirectionSensorTest.swift
@@ -51,22 +51,22 @@ final class CompassDirectionSensorTest: XCTestCase {
         // N
         locationManager.magneticHeading = 0
         XCTAssertEqual(0, sensor.rawValue(landscapeMode: false))
-        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true))
+        XCTAssertEqual(-90, sensor.rawValue(landscapeMode: true))
 
         // E
         locationManager.magneticHeading = 90
         XCTAssertEqual(90, sensor.rawValue(landscapeMode: false))
-        XCTAssertEqual(90, sensor.rawValue(landscapeMode: true))
+        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true))
 
         // S
         locationManager.magneticHeading = 180
         XCTAssertEqual(180, sensor.rawValue(landscapeMode: false))
-        XCTAssertEqual(180, sensor.rawValue(landscapeMode: true))
+        XCTAssertEqual(90, sensor.rawValue(landscapeMode: true))
 
         // W
         locationManager.magneticHeading = 270
         XCTAssertEqual(270, sensor.rawValue(landscapeMode: false))
-        XCTAssertEqual(270, sensor.rawValue(landscapeMode: true))
+        XCTAssertEqual(180, sensor.rawValue(landscapeMode: true))
     }
 
     func testConvertToStandardized() {
@@ -100,7 +100,7 @@ final class CompassDirectionSensorTest: XCTestCase {
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)
-        XCTAssertEqual(standardizedValue, standardizedValueLandscape)
+        XCTAssertEqual(standardizedValue, standardizedValueLandscape - 90.0)
     }
 
     func testTag() {


### PR DESCRIPTION
Added landscape specific sensor behavior for Compass Sensor. If the project is in landscape Mode the Compass Value should adapt by 90 degrees.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
