### PR TITLE
CATTY-373 Change default raw value sensor evaluation

### DIFF
--- a/src/Catty/PlayerEngine/Sensors/Motion/InclinationXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/InclinationXSensor.swift
@@ -39,33 +39,25 @@
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
+        guard let inclinationSensor = self.getMotionManager() else { return type(of: self).defaultRawValue }
+        guard let deviceMotion = inclinationSensor.deviceMotion else { return type(of: self).defaultRawValue }
+
         if !landscapeMode {
-            guard let inclinationSensor = self.getMotionManager() else { return type(of: self).defaultRawValue }
-            guard let deviceMotion = inclinationSensor.deviceMotion else {
-                return type(of: self).defaultRawValue
-            }
             return deviceMotion.attitude.roll
         } else {
+            let rawValueYSensor = deviceMotion.attitude.pitch
             let faceDown = (getMotionManager()?.accelerometerData?.acceleration.z ?? 0) > 0
             if faceDown == false {
-                // screen up
-                return -rawValueYSensor()
+            // screen up
+                return -rawValueYSensor
             } else {
-                if rawValueYSensor() > Double.epsilon {
-                    return Double.pi + rawValueYSensor()
+                if rawValueYSensor > Double.epsilon {
+                    return Double.pi + rawValueYSensor
                 } else {
-                    return -Double.pi + rawValueYSensor()
+                    return -Double.pi + rawValueYSensor
                 }
             }
         }
-    }
-
-    func rawValueYSensor() -> Double {
-        guard let inclinationSensor = self.getMotionManager() else { return type(of: self).defaultRawValue }
-        guard let deviceMotion = inclinationSensor.deviceMotion else {
-            return type(of: self).defaultRawValue
-        }
-        return deviceMotion.attitude.pitch
     }
 
     // roll is between -pi, pi on both iOS and Android

--- a/src/Catty/PlayerEngine/Sensors/Motion/InclinationYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/InclinationYSensor.swift
@@ -41,23 +41,13 @@ import CoreMotion
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
+        guard let inclinationSensor = getMotionManager() else { return type(of: self).defaultRawValue }
+        guard let deviceMotion = inclinationSensor.deviceMotion else { return type(of: self).defaultRawValue }
         if !landscapeMode {
-            guard let inclinationSensor = getMotionManager() else { return type(of: self).defaultRawValue }
-            guard let deviceMotion = inclinationSensor.deviceMotion else {
-                return type(of: self).defaultRawValue
-            }
             return deviceMotion.attitude.pitch
         } else {
-            return rawValueXSensor()
+            return deviceMotion.attitude.roll
         }
-    }
-
-    func rawValueXSensor() -> Double {
-        guard let inclinationSensor = self.getMotionManager() else { return type(of: self).defaultRawValue }
-        guard let deviceMotion = inclinationSensor.deviceMotion else {
-            return type(of: self).defaultRawValue
-        }
-        return deviceMotion.attitude.roll
     }
 
     // pitch is between -pi/2, pi/2 on iOS and -pi,pi on Android

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationXSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationXSensorTest.swift
@@ -127,11 +127,6 @@ final class InclinationXSensorTest: XCTestCase {
         XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi), -180, accuracy: Double.epsilon)
     }
 
-    func testRawValueYSensor() {
-        motionManager.attitude.pitch = Double.pi / 4
-        XCTAssertEqual(sensor.rawValueYSensor(), motionManager.attitude.pitch, accuracy: Double.epsilon)
-    }
-
     func testStandardizedValue() {
         let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationYSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationYSensorTest.swift
@@ -119,11 +119,6 @@ final class InclinationYSensorTest: XCTestCase {
         XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 4), -135, accuracy: Double.epsilon)
     }
 
-    func testRawValueXSensor() {
-        motionManager.attitude.roll = Double.pi / 4
-        XCTAssertEqual(sensor.rawValueXSensor(), motionManager.attitude.roll, accuracy: Double.epsilon)
-    }
-
     func testStandardizedValue() {
         let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)


### PR DESCRIPTION
I changed the InclinationXSensor and InclinationYSensor behaviour if the sensor is not available. There is only one standard path used to evaluate if the sensor is available. The rawValue methods (including the tests) for the opposite sensors were removed.

- [x] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
