### PR TITLE
CATTY-388 SetColorBrick with a number is than INT-MAX crashes

### DIFF
--- a/src/Catty/PlayerEngine/Sensors/Object/ColorSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/ColorSensor.swift
@@ -50,13 +50,13 @@
 
     static func convertToRaw(userInput: Double, for spriteObject: SpriteObject) -> Double {
         var valueToConvert = userInput
-        let whole = Int(valueToConvert)
+        let whole = valueToConvert.rounded(.down)
         let fraction = valueToConvert.truncatingRemainder(dividingBy: 1)
 
         if valueToConvert >= 200 {
-            valueToConvert = Double(whole % 200) + fraction
+            valueToConvert = whole.truncatingRemainder(dividingBy: 200) + fraction
         } else if valueToConvert < 0 {
-            valueToConvert = 200 - (Double(-whole % 200) + fraction)
+            valueToConvert = 200 - (-whole.truncatingRemainder(dividingBy: 200) + fraction)
             if valueToConvert == 200 {
                 valueToConvert = 0
             }

--- a/src/CattyTests/PlayerEngine/Sensors/Object/ColorSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Object/ColorSensorTest.swift
@@ -74,6 +74,7 @@ final class ColorSensorTest: XCTestCase {
         XCTAssertEqual(0, type(of: sensor).convertToRaw(userInput: 0, for: spriteObject), accuracy: Double.epsilon)
         XCTAssertEqual(Double.pi, type(of: sensor).convertToRaw(userInput: 100, for: spriteObject), accuracy: Double.epsilon)
         XCTAssertEqual(Double.pi / 4, type(of: sensor).convertToRaw(userInput: 25, for: spriteObject), accuracy: Double.epsilon)
+        XCTAssertEqual(0.5 * Double.pi, type(of: sensor).convertToRaw(userInput: 10000000050, for: spriteObject), accuracy: Double.epsilon)
 
         // outside the range
         XCTAssertEqual(0, type(of: sensor).convertToRaw(userInput: 200, for: spriteObject), accuracy: Double.epsilon)
@@ -81,7 +82,8 @@ final class ColorSensorTest: XCTestCase {
         XCTAssertEqual(0, type(of: sensor).convertToRaw(userInput: 400, for: spriteObject), accuracy: Double.epsilon)
         XCTAssertEqual(Double.pi, type(of: sensor).convertToRaw(userInput: -100, for: spriteObject), accuracy: Double.epsilon)
         XCTAssertEqual(Double.pi, type(of: sensor).convertToRaw(userInput: -300, for: spriteObject), accuracy: Double.epsilon)
-
+        XCTAssertEqual(0, type(of: sensor).convertToRaw(userInput: 100000000000000000000, for: spriteObject), accuracy: Double.epsilon)
+        XCTAssertEqual(0, type(of: sensor).convertToRaw(userInput: -100000000000000000000, for: spriteObject), accuracy: Double.epsilon)
     }
 
     func testTag() {


### PR DESCRIPTION
Bug fixed
- Now the app does not crash even if number is greater then INT-MAX

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
