### PR TITLE
CATTY-208 changed error to build-warning when catrobat header is prev…

### DIFF
--- a/src/RunScripts/license-validator.swift
+++ b/src/RunScripts/license-validator.swift
@@ -54,6 +54,7 @@ let licenseSearchStringTemplate = "/**\n *  Copyright (C) 2010-%d The Catrobat T
 
 let year = Calendar.current.component(.year, from: Date())
 let licenseSearchStringCurrentYear = String(format: licenseSearchStringTemplate, year)
+let licenseSearchStringPreviousYear = String(format: licenseSearchStringTemplate, year - 1)
 
 let kErrorSuccess: Int32 = 0
 let kErrorFailed: Int32 = 1
@@ -201,7 +202,18 @@ func checkLicenseOfFile(_ filePath: String) {
                 return
             }
         }
-
+        
+        do {
+            let content = try String(contentsOfFile: filePath, encoding: String.Encoding.utf8)
+            let previousYear = content.range(of: licenseSearchStringPreviousYear)
+            if previousYear != nil {
+                printWarning("Wrong year in license header!\n", withFilePath: filePath)
+                return
+            }
+        } catch let error as NSError {
+            printErrorAndExitIfFailed("Could not open file \(error)")
+        }
+        
         guard let license = license3rdPartyDict[libraryName] else {
             printErrorAndExitIfFailed("No license specified for library: \(libraryName).Please add the license also to our license folder", withFilePath: filePath)
             return

--- a/src/RunScripts/precompile-tests.swift
+++ b/src/RunScripts/precompile-tests.swift
@@ -207,7 +207,7 @@ func licenseCheck(_ filePath: String, fileContent: String, lineNumberOffset: Int
                 lineNumber = 1
             }
         }
-        return (true, "\(filePath):\(lineNumber + lineNumberOffset): error : Wrong year in license header!\n")
+        return (false, "\(filePath):\(lineNumber + lineNumberOffset): warning : Wrong year in license header!\n")
     }
 
     let lineNumber = 1 // license header must be at the very top of source file


### PR DESCRIPTION
Altered the license validator so that if the catrobat header contains the previous year a warning is shown in the editor and no longer a build blocking error. This is especially important considering the New Years evening.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
