### PR TITLE
CATTY-401 Uploading a project with multiple tags/categories displays categories with wrong separator

### DIFF
--- a/src/Catty/ViewController/Upload/UploadViewController.swift
+++ b/src/Catty/ViewController/Upload/UploadViewController.swift
@@ -337,7 +337,7 @@ class UploadViewController: UIViewController, UploadCategoryViewControllerDelega
         } else {
             selectCategoriesValueLabel.text = kLocalizedNoCategoriesSelected
         }
-        project?.header.tags = tags.joined(separator: ",")
+        project?.header.tags = tags.joined(separator: ", ")
     }
     // MARK: - Actions
 

--- a/src/CattyTests/ViewController/UploadViewControllerTests.swift
+++ b/src/CattyTests/ViewController/UploadViewControllerTests.swift
@@ -64,6 +64,27 @@ class UploadViewControllerTests: XCTestCase {
         XCTAssertNotNil(selectedCategoriesValueLabel.text)
         XCTAssertEqual(selectedCategoriesValueLabel.text, "testTag1, testTag2")
         XCTAssertFalse(project.header.tags.isEmpty)
-        XCTAssertEqual(project.header.tags, "testTag1,testTag2")
+        XCTAssertEqual(project.header.tags, "testTag1, testTag2")
+    }
+
+    func testProjectTag() {
+        XCTAssertNil(uploaderMock.projectToUpload?.header.tags)
+
+        uploadViewController.uploadAction()
+        XCTAssertNil(uploaderMock.projectToUpload?.header.tags)
+
+        uploadViewController.categoriesSelected(tags: [String]())
+        uploadViewController.uploadAction()
+        XCTAssertTrue(uploaderMock.projectToUpload!.header.tags.isEmpty)
+
+        uploadViewController.categoriesSelected(tags: ["testTag1", "testTag2"])
+        uploadViewController.uploadAction()
+        XCTAssertFalse(uploaderMock.projectToUpload!.header.tags.isEmpty)
+        XCTAssertEqual(uploaderMock.projectToUpload!.header.tags, "testTag1, testTag2")
+
+        uploadViewController.categoriesSelected(tags: ["testTag1", "testTag2 with space"])
+        uploadViewController.uploadAction()
+        XCTAssertFalse(uploaderMock.projectToUpload!.header.tags.isEmpty)
+        XCTAssertEqual(uploaderMock.projectToUpload!.header.tags, "testTag1, testTag2 with space")
     }
 }


### PR DESCRIPTION
- Corrected category joining so that now when trying to upload a project with more than one tags/categories then the available tags are listed as ", "-separated i.e comma without space.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
