### PR TITLE
CATTY-403 Sensor behavior landscape mode

### DIFF
--- a/src/Catty/PlayerEngine/Sensors/Heading/CompassDirectionSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Heading/CompassDirectionSensor.swift
@@ -45,7 +45,7 @@
         if !landscapeMode {
             return compassSensorHeading
         } else {
-            return compassSensorHeading - 90.0
+            return compassSensorHeading + 90.0
         }
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Motion/AccelerationXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/AccelerationXSensor.swift
@@ -42,7 +42,7 @@
         if !landscapeMode {
             return self.getMotionManager()?.deviceMotion?.userAcceleration.x ?? type(of: self).defaultRawValue
         } else {
-            return self.getMotionManager()?.deviceMotion?.userAcceleration.y ?? type(of: self).defaultRawValue
+            return -(self.getMotionManager()?.deviceMotion?.userAcceleration.y ?? type(of: self).defaultRawValue)
         }
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Motion/InclinationXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/InclinationXSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorInclinationX
     static let defaultRawValue = 0.0
     static let position = 50
-    static let requiredResource = ResourceType.deviceMotion
+    static let requiredResource = ResourceType.accelerometerAndDeviceMotion
 
     let getMotionManager: () -> MotionManager?
 
@@ -54,7 +54,7 @@
                 if rawValueYSensor > Double.epsilon {
                     return Double.pi + rawValueYSensor
                 } else {
-                    return -Double.pi + rawValueYSensor
+                    return -Double.pi - rawValueYSensor
                 }
             }
         }
@@ -64,7 +64,7 @@
     // going to right, it is negative on Android and positive on iOS
     // going to left, it is positive on Android and negative on iOS
     func convertToStandardized(rawValue: Double) -> Double {
-        Util.radians(toDegree: -rawValue)
+        Util.radians(toDegree: rawValue)
     }
 
     func formulaEditorSections(for spriteObject: SpriteObject) -> [FormulaEditorSection] {

--- a/src/Catty/PlayerEngine/Sensors/Motion/InclinationYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Motion/InclinationYSensor.swift
@@ -46,7 +46,7 @@ import CoreMotion
         if !landscapeMode {
             return deviceMotion.attitude.pitch
         } else {
-            return deviceMotion.attitude.roll
+            return -deviceMotion.attitude.roll
         }
     }
 

--- a/src/CattyTests/PlayerEngine/Sensors/Heading/CompassDirectionSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Heading/CompassDirectionSensorTest.swift
@@ -51,22 +51,22 @@ final class CompassDirectionSensorTest: XCTestCase {
         // N
         locationManager.magneticHeading = 0
         XCTAssertEqual(0, sensor.rawValue(landscapeMode: false))
-        XCTAssertEqual(-90, sensor.rawValue(landscapeMode: true))
+        XCTAssertEqual(90, sensor.rawValue(landscapeMode: true))
 
         // E
         locationManager.magneticHeading = 90
         XCTAssertEqual(90, sensor.rawValue(landscapeMode: false))
-        XCTAssertEqual(0, sensor.rawValue(landscapeMode: true))
+        XCTAssertEqual(180, sensor.rawValue(landscapeMode: true))
 
         // S
         locationManager.magneticHeading = 180
         XCTAssertEqual(180, sensor.rawValue(landscapeMode: false))
-        XCTAssertEqual(90, sensor.rawValue(landscapeMode: true))
+        XCTAssertEqual(270, sensor.rawValue(landscapeMode: true))
 
         // W
         locationManager.magneticHeading = 270
         XCTAssertEqual(270, sensor.rawValue(landscapeMode: false))
-        XCTAssertEqual(180, sensor.rawValue(landscapeMode: true))
+        XCTAssertEqual(360, sensor.rawValue(landscapeMode: true))
     }
 
     func testConvertToStandardized() {
@@ -100,7 +100,7 @@ final class CompassDirectionSensorTest: XCTestCase {
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)
-        XCTAssertEqual(standardizedValue, standardizedValueLandscape - 90.0)
+        XCTAssertEqual(standardizedValue, standardizedValueLandscape + 90.0)
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationXSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/AccelerationXSensorTest.swift
@@ -51,21 +51,21 @@ final class AccelerationXSensorTest: XCTestCase {
         motionManager.xUserAcceleration = 0
         motionManager.yUserAcceleration = 0
         XCTAssertEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(motionManager.yUserAcceleration, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertEqual(motionManager.yUserAcceleration, -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.xUserAcceleration = 9.8
         XCTAssertEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertNotEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertNotEqual(motionManager.xUserAcceleration, -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.yUserAcceleration = 9.8
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
 
         motionManager.xUserAcceleration = -9.8
         XCTAssertEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertNotEqual(motionManager.xUserAcceleration, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertNotEqual(motionManager.xUserAcceleration, -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.yUserAcceleration = -9.8
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
     }
 
     func testConvertToStandardized() {
@@ -81,7 +81,7 @@ final class AccelerationXSensorTest: XCTestCase {
         let standardizedValue = sensor.standardizedValue(landscapeMode: false)
         let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
         XCTAssertEqual(convertToStandardizedValue, standardizedValue)
-        XCTAssertEqual(standardizedValue, standardizedValueLandscape)
+        XCTAssertEqual(standardizedValue, -standardizedValueLandscape)
     }
 
     func testTag() {

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationXSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationXSensorTest.swift
@@ -100,7 +100,7 @@ final class InclinationXSensorTest: XCTestCase {
         XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi + motionManager.attitude.pitch, accuracy: Double.epsilon)
 
         motionManager.attitude.pitch = -Double.pi / 4
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi + motionManager.attitude.pitch, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi - motionManager.attitude.pitch, accuracy: Double.epsilon)
     }
 
     // does not depend on the orientation of the screen (left/right, up/down)
@@ -109,22 +109,22 @@ final class InclinationXSensorTest: XCTestCase {
         XCTAssertEqual(sensor.convertToStandardized(rawValue: 0), 0, accuracy: Double.epsilon)
 
         // test screen half left
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 4), 45, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 4), 45, accuracy: Double.epsilon)
 
         // test screen half right
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 4), -45, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 4), -45, accuracy: Double.epsilon)
 
         // test screen left
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 2), 90, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 2), 90, accuracy: Double.epsilon)
 
         // test screen right
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi / 2), -90, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi / 2), -90, accuracy: Double.epsilon)
 
         // test screen left, then down
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi), 180, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi), 180, accuracy: Double.epsilon)
 
         // test screen right, then down
-        XCTAssertEqual(sensor.convertToStandardized(rawValue: Double.pi), -180, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.convertToStandardized(rawValue: -Double.pi), -180, accuracy: Double.epsilon)
     }
 
     func testStandardizedValue() {
@@ -140,7 +140,7 @@ final class InclinationXSensorTest: XCTestCase {
     }
 
     func testRequiredResources() {
-        XCTAssertEqual(ResourceType.deviceMotion, type(of: sensor).requiredResource)
+        XCTAssertEqual(ResourceType.accelerometerAndDeviceMotion, type(of: sensor).requiredResource)
     }
 
     func testFormulaEditorSections() {

--- a/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationYSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Motion/InclinationYSensorTest.swift
@@ -51,43 +51,43 @@ final class InclinationYSensorTest: XCTestCase {
         // test maximum value
         motionManager.attitude = (pitch: Double.pi / 2, roll: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), Double.pi / 2, accuracy: Double.epsilon)
-        XCTAssertNotEqual(sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertNotEqual(-sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
 
         motionManager.attitude = (pitch: Double.pi / 2, roll: Double.pi / 2)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: false), sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         // test minimum value
         motionManager.attitude = (pitch: -Double.pi / 2, roll: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), -Double.pi / 2, accuracy: Double.epsilon)
-        XCTAssertNotEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertNotEqual(-sensor.rawValue(landscapeMode: true), -Double.pi / 2, accuracy: Double.epsilon)
 
         motionManager.attitude = (pitch: -Double.pi / 2, roll: -Double.pi / 2)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 2, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: false), sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), -Double.pi / 2, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         // test no inclination
         motionManager.attitude = (pitch: 0, roll: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), 0, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), 0, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: false), sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), 0, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         // tests inside the range
         motionManager.attitude = (pitch: Double.pi / 3, roll: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), Double.pi / 3, accuracy: Double.epsilon)
-        XCTAssertNotEqual(sensor.rawValue(landscapeMode: true), Double.pi / 3, accuracy: Double.epsilon)
+        XCTAssertNotEqual(-sensor.rawValue(landscapeMode: true), Double.pi / 3, accuracy: Double.epsilon)
 
         motionManager.attitude = (pitch: Double.pi / 3, roll: Double.pi / 3)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), Double.pi / 3, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: false), sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), Double.pi / 3, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
         motionManager.attitude = (pitch: -Double.pi / 6, roll: 0)
         XCTAssertEqual(sensor.rawValue(landscapeMode: false), -Double.pi / 6, accuracy: Double.epsilon)
-        XCTAssertNotEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 6, accuracy: Double.epsilon)
+        XCTAssertNotEqual(-sensor.rawValue(landscapeMode: true), -Double.pi / 6, accuracy: Double.epsilon)
 
         motionManager.attitude = (pitch: -Double.pi / 6, roll: -Double.pi / 6)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: true), -Double.pi / 6, accuracy: Double.epsilon)
-        XCTAssertEqual(sensor.rawValue(landscapeMode: false), sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        XCTAssertEqual(-sensor.rawValue(landscapeMode: true), -Double.pi / 6, accuracy: Double.epsilon)
+        XCTAssertEqual(sensor.rawValue(landscapeMode: false), -sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testConvertToStandardizedScreenUp() {

--- a/src/CattyTests/Project/RequiredResources.m
+++ b/src/CattyTests/Project/RequiredResources.m
@@ -183,7 +183,7 @@
     Project *project = [self getProjectWithOneSpriteWithBrick:brick];
     
     NSInteger resources = [project getRequiredResources];
-    XCTAssertEqual(resources, kDeviceMotion, @"Resourses ChangeTransparencyByNBrick not correctly calculated");
+    XCTAssertEqual(resources, kAccelerometerAndDeviceMotion, @"Resourses ChangeTransparencyByNBrick not correctly calculated");
 }
 - (void)testChangeBrightnessByNBrickResources
 {
@@ -202,7 +202,7 @@
     Project *project = [self getProjectWithOneSpriteWithBrick:brick];
     
     NSInteger resources = [project getRequiredResources];
-    XCTAssertEqual(resources, kDeviceMotion, @"Resourses ChangeBrightnessByNBrick not correctly calculated");
+    XCTAssertEqual(resources, kAccelerometerAndDeviceMotion, @"Resourses ChangeBrightnessByNBrick not correctly calculated");
 }
 - (void)testChangeColorByNBrickResources
 {


### PR DESCRIPTION
Modified the behavior of sensors in landscape mode to fix bugs listed in the ticket. The Sensors behaved in the exact opposite from the landscape mode. It got fixed by changing signing of the return value for Accelerator and Inclination Sensor and by modifying the return value of the compass by 180 degree.

- [x] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
