### PR TITLE
CATTY-408 Add common method to open Project in UI

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -703,6 +703,7 @@
 		4CB412202198635900FC4594 /* UserDataContainerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB4121D2198635900FC4594 /* UserDataContainerTest.swift */; };
 		4CB4FE061B95DF2900431757 /* BrickInsertManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CB4FE031B95DF2900431757 /* BrickInsertManager.m */; };
 		4CB4FE071B95DF2900431757 /* BrickMoveManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CB4FE051B95DF2900431757 /* BrickMoveManager.m */; };
+		4CB562FC24EA95C40000A5A9 /* UIViewControllerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB562FB24EA95C40000A5A9 /* UIViewControllerExtensionTests.swift */; };
 		4CB73A9023FC1F0400D5E9A7 /* CatrobatTableViewControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB73A8F23FC1F0300D5E9A7 /* CatrobatTableViewControllerMock.swift */; };
 		4CB73A9223FC1F1300D5E9A7 /* NavigationControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB73A9123FC1F1300D5E9A7 /* NavigationControllerMock.swift */; };
 		4CBDF1A621CF82F100325338 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CBDF1A521CF82F000325338 /* Operator.swift */; };
@@ -2418,6 +2419,7 @@
 		4CB4FE031B95DF2900431757 /* BrickInsertManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BrickInsertManager.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		4CB4FE041B95DF2900431757 /* BrickMoveManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BrickMoveManager.h; sourceTree = "<group>"; };
 		4CB4FE051B95DF2900431757 /* BrickMoveManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BrickMoveManager.m; sourceTree = "<group>"; };
+		4CB562FB24EA95C40000A5A9 /* UIViewControllerExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIViewControllerExtensionTests.swift; path = Extensions/UIViewControllerExtensionTests.swift; sourceTree = "<group>"; };
 		4CB73A8F23FC1F0300D5E9A7 /* CatrobatTableViewControllerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CatrobatTableViewControllerMock.swift; sourceTree = "<group>"; };
 		4CB73A9123FC1F1300D5E9A7 /* NavigationControllerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationControllerMock.swift; sourceTree = "<group>"; };
 		4CBDF1A521CF82F000325338 /* Operator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
@@ -2931,7 +2933,6 @@
 		92FF2E2A1A24C5A700093DA7 /* UIImage+CatrobatUIImageExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+CatrobatUIImageExtensions.h"; sourceTree = "<group>"; };
 		92FF2E2B1A24C5A700093DA7 /* UIImage+CatrobatUIImageExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+CatrobatUIImageExtensions.m"; sourceTree = "<group>"; };
 		92FF2E431A24C5F300093DA7 /* ProjectStoreDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProjectStoreDelegate.h; sourceTree = "<group>"; };
-		92FF2E441A24C5F300093DA7 /* ProjectUpdateDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProjectUpdateDelegate.h; sourceTree = "<group>"; };
 		92FF2E451A24C5F300093DA7 /* SpriteManagerDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpriteManagerDelegate.h; sourceTree = "<group>"; };
 		92FF2E4E1A24C7D800093DA7 /* AudioManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioManager.h; sourceTree = "<group>"; };
 		92FF2E4F1A24C7D800093DA7 /* AudioManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AudioManager.m; sourceTree = "<group>"; };
@@ -7285,7 +7286,6 @@
 			isa = PBXGroup;
 			children = (
 				92FF2E431A24C5F300093DA7 /* ProjectStoreDelegate.h */,
-				92FF2E441A24C5F300093DA7 /* ProjectUpdateDelegate.h */,
 				92FF2E451A24C5F300093DA7 /* SpriteManagerDelegate.h */,
 			);
 			name = Delegates;
@@ -8832,6 +8832,7 @@
 				18B5B52F247EB059007D24A3 /* NSStringExtensionTests.swift */,
 				6F59BB5424B46A3000BBD6EA /* GDataXMLElementExtensionTests.swift */,
 				1858252A24D1A5E300092407 /* UIColorExtensionTests.swift */,
+				4CB562FB24EA95C40000A5A9 /* UIViewControllerExtensionTests.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -10127,6 +10128,7 @@
 				186FBE65247C29AD00AE3F17 /* LineShapeNodeTests.swift in Sources */,
 				E4C5C1122143A3150054F236 /* SearchStoreDataSourceTests.swift in Sources */,
 				4CAEB26C23F3F8BC00DB31BB /* CatrobatTableViewControllerTests.swift in Sources */,
+				4CB562FC24EA95C40000A5A9 /* UIViewControllerExtensionTests.swift in Sources */,
 				4C6FE177212D2D2E0067B7D5 /* LengthFunctionTest.swift in Sources */,
 				22524C38239FAFC500DD515E /* LoginViewControllerTests.swift in Sources */,
 				6F5865FA2471756900A7B4B2 /* CBXMLParserHelperTests.swift in Sources */,

--- a/src/Catty/Defines/SegueDefines.h
+++ b/src/Catty/Defines/SegueDefines.h
@@ -20,8 +20,6 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-#define kSegueToContinue @"segueToContinue"
-#define kSegueToNewProject @"segueToNewProject"
 #define kSegueToProjects @"segueToProjects"
 #define kSegueToHelp @"segueToHelp"
 #define kSegueToExplore @"segueToExplore"

--- a/src/Catty/Storyboard+XIB/iPhone.storyboard
+++ b/src/Catty/Storyboard+XIB/iPhone.storyboard
@@ -7,7 +7,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--New Project-->
+        <!--Project-->
         <scene sceneID="zhR-1R-Y6s">
             <objects>
                 <tableViewController storyboardIdentifier="ProjectTableViewController" id="BYa-g9-OiT" customClass="ProjectTableViewController" sceneMemberID="viewController">
@@ -218,7 +218,7 @@
                             <outlet property="delegate" destination="BYa-g9-OiT" id="tMB-vk-erl"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="New Project" id="mXA-lG-Ivg"/>
+                    <navigationItem key="navigationItem" title="Project" id="mXA-lG-Ivg"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
@@ -703,8 +703,6 @@
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <segue destination="s37-PF-3iN" kind="show" identifier="segueToProjects" id="d1c-M4-4gJ"/>
-                        <segue destination="BYa-g9-OiT" kind="show" identifier="segueToNewProject" id="aum-BR-x1G"/>
-                        <segue destination="BYa-g9-OiT" kind="show" identifier="segueToContinue" id="1kj-7D-Va7"/>
                         <segue destination="39D-hJ-FD1" kind="show" identifier="segueToExplore" id="7JT-6F-5d1"/>
                         <segue destination="IZh-b2-DYW" kind="show" identifier="segueToHelp" id="A6m-lh-qyH"/>
                         <segue destination="bYj-Ga-eye" kind="show" identifier="segueToUpload" id="d5M-d9-Nnc"/>
@@ -1150,10 +1148,6 @@
                     <navigationItem key="navigationItem" title="Projects" id="WNU-lr-3un"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
-                    <connections>
-                        <segue destination="BYa-g9-OiT" kind="show" identifier="segueToNewProject" id="Ynr-aF-UI3"/>
-                        <segue destination="BYa-g9-OiT" kind="show" identifier="segueToContinue" id="9ao-Sd-kbH"/>
-                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ysn-tw-Bdd" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -1509,7 +1503,6 @@
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="scrollViewOutlet" destination="qwE-Ve-7jz" id="s6T-uY-bi7"/>
-                        <segue destination="BYa-g9-OiT" kind="show" identifier="segueToContinue" id="mUB-CR-2KD"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dmN-gD-N9f" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -2257,6 +2250,5 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="5UD-6W-Ykq"/>
-        <segue reference="9ao-Sd-kbH"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/src/Catty/ViewController/CatrobatTableViewController/CatrobatTableViewController.m
+++ b/src/Catty/ViewController/CatrobatTableViewController/CatrobatTableViewController.m
@@ -47,7 +47,6 @@ NS_ENUM(NSInteger, ViewControllerIndex) {
 
 @property (nonatomic, strong) NSArray *cells;
 @property (nonatomic, strong) NSArray *imageNames;
-@property (nonatomic, strong) NSMutableArray *identifiers;
 @property (nonatomic, strong) Project *lastUsedProject;
 @property (nonatomic, strong) Project *defaultProject;
 @property (nonatomic, assign) BOOL freshLogin;
@@ -140,7 +139,6 @@ NS_ENUM(NSInteger, ViewControllerIndex) {
                   kLocalizedUploadProject, nil];
 
     self.imageNames = [[NSArray alloc] initWithObjects:kMenuImageNameContinue, kMenuImageNameNew, kMenuImageNameProjects, kMenuImageNameHelp, kMenuImageNameExplore, kMenuImageNameUpload, nil];
-    self.identifiers = [[NSMutableArray alloc] initWithObjects:kSegueToContinue, kSegueToNewProject, kSegueToProjects, kSegueToHelp, kSegueToExplore, kSegueToUpload, nil];
 }
 
 - (void)initNavigationBar
@@ -172,14 +170,13 @@ NS_ENUM(NSInteger, ViewControllerIndex) {
     [self.navigationController pushViewController:sTVC animated:YES];
 }
 
-- (void)addProjectAndSegueToItActionForProjectWithName:(NSString*)projectName
+- (void)createAndOpenProjectWithName:(NSString*)projectName
 {
-    static NSString *segueToNewProjectIdentifier = kSegueToNewProject;
     [self showLoadingView];
     self.defaultProject = [Project defaultProjectWithName:projectName projectID:nil];
-    if ([self shouldPerformSegueWithIdentifier:segueToNewProjectIdentifier sender:self]) {
+    if (self.defaultProject) {
         [self hideLoadingView];
-        [self performSegueWithIdentifier:segueToNewProjectIdentifier sender:self];
+        [self openProject:self.defaultProject];
     }
 }
 
@@ -239,10 +236,11 @@ NS_ENUM(NSInteger, ViewControllerIndex) {
 #pragma mark - table view delegate
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath
 {
-    NSString* identifier = [self.identifiers objectAtIndex:indexPath.row];
+    NSString *segueIdentifier = nil;
+    
     switch (indexPath.row) {
         case kNewProjectVC:
-            [Util askUserForUniqueNameAndPerformAction:@selector(addProjectAndSegueToItActionForProjectWithName:)
+            [Util askUserForUniqueNameAndPerformAction:@selector(createAndOpenProjectWithName:)
                                                 target:self
                                            promptTitle:kLocalizedNewProject
                                          promptMessage:[NSString stringWithFormat:@"%@:", kLocalizedProjectName]
@@ -254,19 +252,29 @@ NS_ENUM(NSInteger, ViewControllerIndex) {
                                          existingNames:[Project allProjectNames]];
             break;
         case kContinueProjectVC:
-        case kLocalProjectsVC:
-        case kExploreVC:
-        case kHelpVC:
-            if ([self shouldPerformSegueWithIdentifier:identifier sender:self]) {
-                [self performSegueWithIdentifier:identifier sender:self];
+            if (!self.lastUsedProject) {
+                [Util setLastProjectWithName:nil projectID:nil];
+                NSIndexPath *indexPath = [NSIndexPath indexPathForRow:0 inSection:0];
+                [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
+                [Util alertWithText:kLocalizedUnableToLoadProject];
+                
+                return;
             }
+            
+            [self openProject:self.lastUsedProject];
+            break;
+        case kLocalProjectsVC:
+            segueIdentifier = kSegueToProjects;
+            break;
+        case kExploreVC:
+            segueIdentifier = kSegueToExplore;
+            break;
+        case kHelpVC:
+            segueIdentifier = kSegueToHelp;
             break;
         case kUploadVC:
-            if ([[[NSUserDefaults standardUserDefaults] valueForKey: NetworkDefines.kUserIsLoggedIn] boolValue]) {
-                if ([self shouldPerformSegueWithIdentifier:identifier sender:self]) {
-                    [self performSegueWithIdentifier:@"segueToUpload" sender:self];
-                }
-    
+            if ([[[NSUserDefaults standardUserDefaults] valueForKey:NetworkDefines.kUserIsLoggedIn] boolValue]) {
+                segueIdentifier = kSegueToUpload;
             } else {
                 UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"iPhone" bundle: nil];
                 LoginViewController * vc = [storyboard instantiateViewControllerWithIdentifier:@"LoginController"];
@@ -275,10 +283,14 @@ NS_ENUM(NSInteger, ViewControllerIndex) {
             }
 
             break;
-            
         default:
             break;
     }
+    
+    if (segueIdentifier && [self shouldPerformSegueWithIdentifier:segueIdentifier sender:self]) {
+        [self performSegueWithIdentifier:segueIdentifier sender:self];
+    }
+    
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 
@@ -386,59 +398,7 @@ NS_ENUM(NSInteger, ViewControllerIndex) {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 }
 
-#pragma mark - segue handling
-- (BOOL)shouldPerformSegueWithIdentifier:(NSString*)identifier sender:(id)sender
-{
-    if ([identifier isEqualToString:kSegueToContinue]) {
-        // check if project loaded successfully -> not nil
-        if (self.lastUsedProject) {
-            return YES;
-        }
-
-        // project failed loading...
-        // update continue cell
-        [Util setLastProjectWithName:nil projectID:nil];
-        NSIndexPath *indexPath = [NSIndexPath indexPathForRow:0 inSection:0];
-        [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];
-        [Util alertWithText:kLocalizedUnableToLoadProject];
-        return NO;
-    } else if ([identifier isEqualToString:kSegueToNewProject]) {
-        // if there is no project name, abort performing this segue and ask user for project name
-        // after user entered a valid project name this segue will be called again and accepted
-        if (! self.defaultProject) {
-            return NO;
-        }
-        return YES;
-    }
-    
-    return [super shouldPerformSegueWithIdentifier:identifier sender:sender];
-}
-
-#pragma mark - segue handling
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
-{
-    if ([segue.identifier isEqualToString:kSegueToContinue]) {
-        if ([segue.destinationViewController isKindOfClass:[ProjectTableViewController class]]) {
-            ProjectTableViewController *projectTableViewController = (ProjectTableViewController*)segue.destinationViewController;
-            projectTableViewController.project = self.lastUsedProject;
-            self.lastUsedProject = nil;
-        }
-    } else if ([segue.identifier isEqualToString:kSegueToNewProject]) {
-        if ([segue.destinationViewController isKindOfClass:[ProjectTableViewController class]]) {
-            ProjectTableViewController *projectTableViewController = (ProjectTableViewController*)segue.destinationViewController;
-            projectTableViewController.project = self.defaultProject;
-            self.defaultProject = nil;
-        }
-    }
-}
-
 #pragma mark - network status
-
-- (void)dealloc
-{
-    [self.identifiers removeAllObjects];
-}
-
 -(void)addProjectFromInboxWithName:(NSString*)newProjectName
 {
     NSFileManager* filemgr = [NSFileManager defaultManager];
@@ -476,4 +436,3 @@ NS_ENUM(NSInteger, ViewControllerIndex) {
 }
 
 @end
-

--- a/src/Catty/ViewController/Continue&New/ProjectTableViewController.h
+++ b/src/Catty/ViewController/Continue&New/ProjectTableViewController.h
@@ -26,11 +26,9 @@
 
 @class ProjectLoadingInfo;
 @class Project;
-@protocol ProjectUpdateDelegate;
 
 @interface ProjectTableViewController : BaseTableViewController
 
-@property (nonatomic, weak) id<ProjectUpdateDelegate> delegate;
 @property (nonatomic, strong) Project *project;
 
 @property (nonatomic,assign) BOOL showAddObjectActionSheetAtStart;

--- a/src/Catty/ViewController/Continue&New/ProjectTableViewController.m
+++ b/src/Catty/ViewController/Continue&New/ProjectTableViewController.m
@@ -30,7 +30,6 @@
 #import "DarkBlueGradientImageDetailCell.h"
 #import "Util.h"
 #import "UIUtil.h"
-#import "ProjectUpdateDelegate.h"
 #import "CellTagDefines.h"
 #import "ProjectTableHeaderView.h"
 #import "RuntimeImageCache.h"
@@ -46,13 +45,6 @@
 @end
 
 @implementation ProjectTableViewController
-
-#pragma mark - getter and setters
-- (void)setProject:(Project *)project
-{
-    [project setAsLastUsedProject];
-    _project = project;
-}
 
 #pragma mark - initialization
 - (void)initNavigationBar
@@ -173,12 +165,8 @@
         return;
 
     [self showLoadingView];
-    NSString *oldProjectName = self.project.header.programName;
     newProjectName = [Util uniqueName:newProjectName existingNames:[Project allProjectNames]];
     [self.project renameToProjectName:newProjectName andShowSaveNotification:YES];
-    [self.delegate renameOldProjectWithName:oldProjectName
-                                  projectID:self.project.header.programID
-                           toNewProjectName:self.project.header.programName];
     self.navigationItem.title = self.title = self.project.header.programName;
     [self hideLoadingView];
 }
@@ -322,14 +310,6 @@
     [self.tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:((indexPath.row != 0) ? UITableViewRowAnimationTop : UITableViewRowAnimationFade)];
     [self showPlaceHolder:!(BOOL)[self.project.scene numberOfNormalObjects]];
     [self hideLoadingView];
-}
-
-- (void)deleteProjectAction
-{
-    [self.delegate removeProjectWithName:self.project.header.programName projectID:self.project.header.programID];
-    [self.project removeFromDisk];
-    self.project = nil;
-    [self.navigationController popViewControllerAnimated:YES];
 }
 
 #pragma mark - table view data source

--- a/src/Catty/ViewController/Projects/MyProjectsViewController.m
+++ b/src/Catty/ViewController/Projects/MyProjectsViewController.m
@@ -29,7 +29,6 @@
 #import "CellTagDefines.h"
 #import "CatrobatImageCell.h"
 #import "SegueDefines.h"
-#import "ProjectUpdateDelegate.h"
 #import "DarkBlueGradientImageDetailCell.h"
 #import "RuntimeImageCache.h"
 #import "NSMutableArray+CustomExtensions.h"
@@ -37,7 +36,7 @@
 #import "Pocket_Code-Swift.h"
 #import "ViewControllerDefines.h"
 
-@interface MyProjectsViewController () <ProjectUpdateDelegate, UITextFieldDelegate, SetProjectDescriptionDelegate>
+@interface MyProjectsViewController () <UITextFieldDelegate, SetProjectDescriptionDelegate>
 @property (nonatomic) BOOL useDetailCells;
 @property (nonatomic) NSInteger projectsCounter;
 @property (nonatomic, strong) NSArray *sectionTitles;
@@ -72,8 +71,6 @@
     self.tableView.separatorInset = UIEdgeInsetsZero;
     self.tableView.sectionIndexBackgroundColor = UIColor.background;
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];
-
-    [self setupObservers];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -137,7 +134,7 @@
 - (void)addProjectAction:(id)sender
 {
     [self.tableView setEditing:false animated:YES];
-    [Util askUserForUniqueNameAndPerformAction:@selector(addProjectAndSegueToItActionForProjectWithName:)
+    [Util askUserForUniqueNameAndPerformAction:@selector(createAndOpenProjectWithName:)
                                         target:self
                                    promptTitle:kLocalizedNewProject
                                  promptMessage:[NSString stringWithFormat:@"%@:", kLocalizedProjectName]
@@ -149,14 +146,14 @@
                                  existingNames:[Project allProjectNames]];
 }
 
-- (void)addProjectAndSegueToItActionForProjectWithName:(NSString*)projectName
+- (void)createAndOpenProjectWithName:(NSString*)projectName
 {
-    static NSString *segueToNewProjectIdentifier = kSegueToNewProject;
     projectName = [Util uniqueName:projectName existingNames:[Project allProjectNames]];
     self.defaultProject = [Project defaultProjectWithName:projectName projectID:nil];
-    if ([self shouldPerformSegueWithIdentifier:segueToNewProjectIdentifier sender:self]) {
+    
+    if (self.defaultProject) {
         [self addProject:self.defaultProject.header.programName];
-        [self performSegueWithIdentifier:segueToNewProjectIdentifier sender:self];
+        [self openProject:self.defaultProject];
     }
 }
 
@@ -501,12 +498,24 @@
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     [super tableView:tableView didSelectRowAtIndexPath:indexPath];
-    static NSString *segueToContinue = kSegueToContinue;
     if (! self.editing) {
-        UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-        if ([self shouldPerformSegueWithIdentifier:segueToContinue sender:cell]) {
-            [self performSegueWithIdentifier:segueToContinue sender:cell];
+        NSString *sectionTitle = [self.sectionTitles objectAtIndex:indexPath.section];
+        NSArray *sectionInfos = [self.projectLoadingInfoDict objectForKey:[[sectionTitle substringToIndex:1] uppercaseString]];
+
+        ProjectLoadingInfo *info = [sectionInfos objectAtIndex:indexPath.row];
+        self.selectedProject = [Project projectWithLoadingInfo:info];
+        
+        if (!self.selectedProject) {
+            [Util alertWithText:kLocalizedUnableToLoadProject];
+            return;
         }
+        
+        if (![self.selectedProject.header.programName isEqualToString:info.visibleName]) {
+            self.selectedProject.header.programName = info.visibleName;
+            [self.selectedProject saveToDiskWithNotification:YES];
+        }
+        
+        [self openProject:self.selectedProject];
     }
 }
 
@@ -523,65 +532,6 @@
 {
     return [self.sectionTitles indexOfObject:title];
 }
-#pragma mark - segue handling
-- (BOOL)shouldPerformSegueWithIdentifier:(NSString *)identifier sender:(id)sender
-{
-    if (self.editing) {
-        return NO;
-    }
-    
-    static NSString *segueToContinue = kSegueToContinue;
-    static NSString *segueToNewProject = kSegueToNewProject;
-    if ([identifier isEqualToString:segueToContinue]) {
-        if ([sender isKindOfClass:[UITableViewCell class]]) {
-            NSIndexPath *path = [self.tableView indexPathForCell:sender];
-            // check if project loaded successfully -> not nil
-            NSString *sectionTitle = [self.sectionTitles objectAtIndex:path.section];
-            NSArray *sectionInfos = [self.projectLoadingInfoDict objectForKey:[[sectionTitle substringToIndex:1] uppercaseString]];
-
-            ProjectLoadingInfo *info = [sectionInfos objectAtIndex:path.row];
-            self.selectedProject = [Project projectWithLoadingInfo:info];
-            if (![self.selectedProject.header.programName isEqualToString:info.visibleName]) {
-                self.selectedProject.header.programName = info.visibleName;
-                [self.selectedProject saveToDiskWithNotification:YES];
-            }
-            if (self.selectedProject) {
-                return YES;
-            }
-            
-            // project failed loading...
-            [Util alertWithText:kLocalizedUnableToLoadProject];
-            return NO;
-        }
-    } else if ([identifier isEqualToString:segueToNewProject]) {
-        if (! self.defaultProject) {
-            return NO;
-        }
-        return YES;
-    }
-    return [super shouldPerformSegueWithIdentifier:identifier sender:sender];
-}
-
-- (void)prepareForSegue:(UIStoryboardSegue*)segue sender:(id)sender
-{
-    static NSString *segueToContinue = kSegueToContinue;
-    static NSString *segueToNewProject = kSegueToNewProject;
-    if ([segue.identifier isEqualToString:segueToContinue]) {
-        if ([segue.destinationViewController isKindOfClass:[ProjectTableViewController class]]) {
-            if ([sender isKindOfClass:[UITableViewCell class]]) {
-                [self.dataCache removeObjectForKey:self.selectedProject.header.programName];
-                ProjectTableViewController *projectTableViewController = (ProjectTableViewController*)segue.destinationViewController;
-                projectTableViewController.delegate = self;
-                projectTableViewController.project = self.selectedProject;
-            }
-        }
-    } else if ([segue.identifier isEqualToString:segueToNewProject]) {
-        ProjectTableViewController *projectTableViewController = (ProjectTableViewController*)segue.destinationViewController;
-        projectTableViewController.delegate = self;
-        projectTableViewController.project = self.defaultProject;
-    }
-}
-
 #pragma mark - project handling
 - (ProjectLoadingInfo*)addProject:(NSString*)projectName
 {
@@ -737,24 +687,6 @@
     }
     
     self.sectionTitles = [[self.projectLoadingInfoDict allKeys] sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
-}
-
-#pragma mark - Notifications
-
-- (void)setupObservers
-{
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(downloadFinished:)
-                                                 name:kProjectDownloadedNotification
-                                               object:nil];
-}
-
-- (void)downloadFinished:(NSNotification*)notification
-{
-    if ([[notification name] isEqualToString:kProjectDownloadedNotification]){
-        [self reloadTableView];
-        
-    }
 }
 
 #pragma mark reload TableView

--- a/src/CattyTests/Extensions/UIViewControllerExtensionTests.swift
+++ b/src/CattyTests/Extensions/UIViewControllerExtensionTests.swift
@@ -20,25 +20,32 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-extension UIViewController {
-    func hideKeyboardWhenTapInViewController() {
-        let tapGesture = UITapGestureRecognizer(target: self,
-                                                action: #selector(UIViewController.dismissKeyboard))
-        tapGesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(tapGesture)
+import XCTest
+
+@testable import Pocket_Code
+
+final class UIViewControllerExtensionTests: XCTestCase {
+
+    var controller: CatrobatTableViewControllerMock?
+    var navigationController: NavigationControllerMock?
+
+    override func setUp() {
+        super.setUp()
+        navigationController = NavigationControllerMock()
+        controller = CatrobatTableViewControllerMock(navigationController!)
     }
 
-    @objc func dismissKeyboard() {
-        view.endEditing(true)
-    }
+    func testOpenProject() {
+        XCTAssertNil(navigationController?.currentViewController)
 
-    @objc func openProject(_ project: Project) {
-        let storyboard = UIStoryboard.init(name: "iPhone", bundle: nil)
-        guard let viewController = storyboard.instantiateViewController(withIdentifier: "ProjectTableViewController") as? ProjectTableViewController else { return }
+        let project = ProjectMock()
+        XCTAssertFalse(project.isLastUsedProject)
 
-        viewController.project = project
-        project.setAsLastUsedProject()
+        controller!.openProject(project)
 
-        self.navigationController?.pushViewController(viewController, animated: true)
+        let projectTableViewController = navigationController?.currentViewController as? ProjectTableViewController
+
+        XCTAssertEqual(project, projectTableViewController?.project)
+        XCTAssertTrue(project.isLastUsedProject)
     }
 }

--- a/src/CattyTests/Mocks/ProjectMock.swift
+++ b/src/CattyTests/Mocks/ProjectMock.swift
@@ -25,6 +25,7 @@ class ProjectMock: Project {
     private var mockedRequiredResources: Int = 0
     public var saveNotificationShown: Bool = false
     public var saved: Bool = false
+    public var isLastUsedProject = false
 
     override convenience init() {
         self.init(width: 300, andHeight: 400)
@@ -57,5 +58,9 @@ class ProjectMock: Project {
     override func saveToDisk(withNotification notify: Bool) {
         self.saved = true
         self.saveNotificationShown = notify
+    }
+
+    override func setAsLastUsedProject() {
+        isLastUsedProject = true
     }
 }


### PR DESCRIPTION
Remove segues and add common loading method for Project. Move code from `shouldPerformSegue` and `prepareForSegue` to designated method to load project which will contain a more advanced logic at some point later.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
