### PR TITLE
CATTY-15 Implement WhenConditionScript

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -836,7 +836,9 @@
 		4CFD5C5B23C47E2100980CD0 /* GlideToBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFD5C5823C47E2100980CD0 /* GlideToBrickTests.swift */; };
 		590200D223FC03A900F0978B /* BrickExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590200D123FC03A900F0978B /* BrickExtensionTests.swift */; };
 		59032EE524A29CAE00BD86C4 /* WhenBackgroundChangesScript+Condition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59032EE424A29CAE00BD86C4 /* WhenBackgroundChangesScript+Condition.swift */; };
+		5908EBE024EE64A6002EB16E /* WhenConditionScript+Condition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5908EBDF24EE64A6002EB16E /* WhenConditionScript+Condition.swift */; };
 		5912C21623C4EAC700B3D9C0 /* FormulaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5912C21523C4EAC700B3D9C0 /* FormulaTest.swift */; };
+		591553B724F274C9005BBF75 /* WhenConditionScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591553B624F274C9005BBF75 /* WhenConditionScriptTests.swift */; };
 		591FCF0324EFB81500E5DD6B /* WhenBackgroundChangesScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 591FCF0224EFB81500E5DD6B /* WhenBackgroundChangesScriptTests.swift */; };
 		5921F2AB24F51F3B0044D936 /* BrickCellLookDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5921F2AA24F51F3B0044D936 /* BrickCellLookDataTests.swift */; };
 		592EF6E62094B3D700BD6000 /* SpriteObjectProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592EF6E52094B3D700BD6000 /* SpriteObjectProtocol.swift */; };
@@ -885,6 +887,7 @@
 		59A58D83202C714A008B1A8F /* MediaLibraryDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A58D82202C714A008B1A8F /* MediaLibraryDownloaderTests.swift */; };
 		59ABDC622021BBFB00061403 /* LooksTableViewController+MediaLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59ABDC5F2021BBFB00061403 /* LooksTableViewController+MediaLibrary.swift */; };
 		59ABDC652021D7DA00061403 /* UIAlertController+AddAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59ABDC642021D7DA00061403 /* UIAlertController+AddAction.swift */; };
+		59B7A8D32504E83F001C736A /* StageMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B7A8D22504E83F001C736A /* StageMock.swift */; };
 		59B9F633202D8F8500937299 /* MediaLibraryDownloader.downloadIndex.success.json in Resources */ = {isa = PBXBuildFile; fileRef = 59B9F631202D8F6200937299 /* MediaLibraryDownloader.downloadIndex.success.json */; };
 		59D008E9208E3FDC000539E7 /* MotionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D008E8208E3FDC000539E7 /* MotionManager.swift */; };
 		59D008ED208E4249000539E7 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D008EC208E4249000539E7 /* LocationManager.swift */; };
@@ -892,6 +895,8 @@
 		59D9EC672061171F0019EC10 /* DVR.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 59D9EC62206117000019EC10 /* DVR.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		59EA52B424FCD1E800AC6E8D /* WhenBackgroundChangesScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EA52B324FCD1E800AC6E8D /* WhenBackgroundChangesScript.swift */; };
 		59EA52B824FCF9E400AC6E8D /* WhenBackgroundChangesScriptCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EA52B724FCF9E400AC6E8D /* WhenBackgroundChangesScriptCell.swift */; };
+		59EA52BB24FD468900AC6E8D /* WhenConditionScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EA52BA24FD468900AC6E8D /* WhenConditionScript.swift */; };
+		59EA52BF24FD4BEE00AC6E8D /* WhenConditionScriptCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EA52BE24FD4BEE00AC6E8D /* WhenConditionScriptCell.swift */; };
 		59F5C2AF23F2E36D00D95016 /* BrickCellPickerViewerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F5C2AE23F2E36D00D95016 /* BrickCellPickerViewerTest.swift */; };
 		5E0B361E220A55BB0056EB12 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 92300CE918B2196700F2B4DC /* Localizable.strings */; };
 		5E0B3622220A5F3C0056EB12 /* LanguageTranslationDefinesUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0B3621220A5F3C0056EB12 /* LanguageTranslationDefinesUI.swift */; };
@@ -2590,7 +2595,9 @@
 		58272AE1A8D3A638A258B722 /* bs */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = bs; path = bs.lproj/Localizable.strings; sourceTree = "<group>"; };
 		590200D123FC03A900F0978B /* BrickExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrickExtensionTests.swift; sourceTree = "<group>"; };
 		59032EE424A29CAE00BD86C4 /* WhenBackgroundChangesScript+Condition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WhenBackgroundChangesScript+Condition.swift"; sourceTree = "<group>"; };
+		5908EBDF24EE64A6002EB16E /* WhenConditionScript+Condition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WhenConditionScript+Condition.swift"; sourceTree = "<group>"; };
 		5912C21523C4EAC700B3D9C0 /* FormulaTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FormulaTest.swift; path = Formula/FormulaTest.swift; sourceTree = "<group>"; };
+		591553B624F274C9005BBF75 /* WhenConditionScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenConditionScriptTests.swift; sourceTree = "<group>"; };
 		591FCF0224EFB81500E5DD6B /* WhenBackgroundChangesScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenBackgroundChangesScriptTests.swift; sourceTree = "<group>"; };
 		5921F2AA24F51F3B0044D936 /* BrickCellLookDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrickCellLookDataTests.swift; sourceTree = "<group>"; };
 		592EF6E52094B3D700BD6000 /* SpriteObjectProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteObjectProtocol.swift; sourceTree = "<group>"; };
@@ -2633,12 +2640,15 @@
 		59A58D82202C714A008B1A8F /* MediaLibraryDownloaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryDownloaderTests.swift; sourceTree = "<group>"; };
 		59ABDC5F2021BBFB00061403 /* LooksTableViewController+MediaLibrary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "LooksTableViewController+MediaLibrary.swift"; sourceTree = "<group>"; };
 		59ABDC642021D7DA00061403 /* UIAlertController+AddAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+AddAction.swift"; sourceTree = "<group>"; };
+		59B7A8D22504E83F001C736A /* StageMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StageMock.swift; sourceTree = "<group>"; };
 		59B9F631202D8F6200937299 /* MediaLibraryDownloader.downloadIndex.success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = MediaLibraryDownloader.downloadIndex.success.json; sourceTree = "<group>"; };
 		59D008E8208E3FDC000539E7 /* MotionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionManager.swift; sourceTree = "<group>"; };
 		59D008EC208E4249000539E7 /* LocationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
 		59D9EC62206117000019EC10 /* DVR.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DVR.framework; path = Carthage/Build/iOS/DVR.framework; sourceTree = "<group>"; };
 		59EA52B324FCD1E800AC6E8D /* WhenBackgroundChangesScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenBackgroundChangesScript.swift; sourceTree = "<group>"; };
 		59EA52B724FCF9E400AC6E8D /* WhenBackgroundChangesScriptCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenBackgroundChangesScriptCell.swift; sourceTree = "<group>"; };
+		59EA52BA24FD468900AC6E8D /* WhenConditionScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenConditionScript.swift; sourceTree = "<group>"; };
+		59EA52BE24FD4BEE00AC6E8D /* WhenConditionScriptCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenConditionScriptCell.swift; sourceTree = "<group>"; };
 		59F5C2AE23F2E36D00D95016 /* BrickCellPickerViewerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrickCellPickerViewerTest.swift; sourceTree = "<group>"; };
 		5E0B3621220A5F3C0056EB12 /* LanguageTranslationDefinesUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LanguageTranslationDefinesUI.swift; sourceTree = "<group>"; };
 		5E18A81121A547AA00541536 /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
@@ -6439,6 +6449,7 @@
 				4CF429F2213A88A600B78897 /* RepeatUntilBrick+Condition.swift */,
 				BA987D0C2194E647002DAA05 /* WaitUntilBrick+Condition.swift */,
 				59032EE424A29CAE00BD86C4 /* WhenBackgroundChangesScript+Condition.swift */,
+				5908EBDF24EE64A6002EB16E /* WhenConditionScript+Condition.swift */,
 			);
 			path = Condition;
 			sourceTree = "<group>";
@@ -6447,6 +6458,7 @@
 			isa = PBXGroup;
 			children = (
 				591FCF0224EFB81500E5DD6B /* WhenBackgroundChangesScriptTests.swift */,
+				591553B624F274C9005BBF75 /* WhenConditionScriptTests.swift */,
 			);
 			path = Scripts;
 			sourceTree = "<group>";
@@ -6555,6 +6567,7 @@
 				6F954C6324D1A3E300E10BB3 /* UploadCategoryViewControllerDelegateMock.swift */,
 				6F19119D24E7C8CF00CF1B4F /* SceneMock.swift */,
 				180DDF422506800600EA526C /* AnalyticsMock.swift */,
+				59B7A8D22504E83F001C736A /* StageMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -7753,6 +7766,7 @@
 				92FF30B91A24DCAA00093DA7 /* WhenScript.h */,
 				92FF30BA1A24DCAA00093DA7 /* WhenScript.m */,
 				59EA52B324FCD1E800AC6E8D /* WhenBackgroundChangesScript.swift */,
+				59EA52BA24FD468900AC6E8D /* WhenConditionScript.swift */,
 			);
 			path = Scripts;
 			sourceTree = "<group>";
@@ -8823,6 +8837,7 @@
 				AA74F0911BC05FCE00D1E954 /* WhenScriptCell.h */,
 				AA74F0921BC05FCE00D1E954 /* WhenScriptCell.m */,
 				59EA52B724FCF9E400AC6E8D /* WhenBackgroundChangesScriptCell.swift */,
+				59EA52BE24FD4BEE00AC6E8D /* WhenConditionScriptCell.swift */,
 			);
 			path = ScriptCells;
 			sourceTree = "<group>";
@@ -10244,6 +10259,7 @@
 				9E0F741822B55E4D0030CD89 /* MockAudioPlayerFactory.swift in Sources */,
 				4C7182DA23EEAFF600195BC7 /* BaseCollectionViewControllerTests.swift in Sources */,
 				4C822670213FA7A400F3D750 /* AccelerationYSensorTest.swift in Sources */,
+				591553B724F274C9005BBF75 /* WhenConditionScriptTests.swift in Sources */,
 				4C6FE16A212D2D2E0067B7D5 /* AtanFunctionTest.swift in Sources */,
 				4CEB224F1B95E47500B3BE2F /* BrickMoveManagerForeverTests.m in Sources */,
 				4C68FC951B25A00B00AB3EE8 /* InternFormulaTokenSelectionTest.m in Sources */,
@@ -10301,6 +10317,7 @@
 				9E05FAB1247FF57F008951DE /* ScenePresenterViewControllerSpy.swift in Sources */,
 				4C6FE170212D2D2E0067B7D5 /* AbsFunctionTest.swift in Sources */,
 				4C68FC931B25A00B00AB3EE8 /* InternFormulaTest.m in Sources */,
+				59B7A8D32504E83F001C736A /* StageMock.swift in Sources */,
 				18E83F852493C978003295DA /* PenClearBrickTests.swift in Sources */,
 				44B76EC12476BF0100DC30E2 /* FirebaseCrashlyticsReporterTests.swift in Sources */,
 				186FBE65247C29AD00AE3F17 /* LineShapeNodeTests.swift in Sources */,
@@ -10662,6 +10679,7 @@
 				927F79E01BEE39CB008D1635 /* PhiroIfLogicBeginBrick.m in Sources */,
 				AA74EEFF1BC057C900D1E954 /* SetTransparencyBrick+CBXMLHandler.m in Sources */,
 				44B76EC82476C19600DC30E2 /* FirebaseAnalyticsReporter.swift in Sources */,
+				59EA52BF24FD4BEE00AC6E8D /* WhenConditionScriptCell.swift in Sources */,
 				92EC985F1BC3ABB90003A891 /* PhiroPlayToneBrick+CBXMLHandler.m in Sources */,
 				92FF2EA21A24C7D800093DA7 /* TableUtil.m in Sources */,
 				4CDA808121366AD20052FA24 /* FormulaInterpreterProtocol.swift in Sources */,
@@ -10748,6 +10766,7 @@
 				AA74EFE81BC05B5F00D1E954 /* LoopEndBrick.m in Sources */,
 				9200C2DB1C8084AA002F5CA4 /* HideTextBrick+CBXMLHandler.m in Sources */,
 				AA74EEDD1BC057B900D1E954 /* ForeverBrick+CBXMLHandler.m in Sources */,
+				59EA52BB24FD468900AC6E8D /* WhenConditionScript.swift in Sources */,
 				4C0F9F22204ADBAF00E71B2D /* IfThenLogicEndBrick+CBXMLHandler.m in Sources */,
 				4CF0728C20D659F700F93AB5 /* PhiroSideLeftSensor.swift in Sources */,
 				AA74F0C01BC05FCE00D1E954 /* SetXBrickCell.m in Sources */,
@@ -10929,6 +10948,7 @@
 				F4E6E59A210E048700D86FE6 /* MaxFunction.swift in Sources */,
 				5936893C2021979A00FC3115 /* SoundsTableViewController+MediaLibrary.swift in Sources */,
 				592EF6E62094B3D700BD6000 /* SpriteObjectProtocol.swift in Sources */,
+				5908EBE024EE64A6002EB16E /* WhenConditionScript+Condition.swift in Sources */,
 				F4E6E5BE210E1FA400D86FE6 /* RoundFunction.swift in Sources */,
 				99EBDBFF1D5621D3008D6860 /* ChangeColorByNBrick.m in Sources */,
 				4C724E5D1B4D3E8C00E27479 /* SpriteObject+CBXMLHandler.m in Sources */,

--- a/src/Catty/Condition/WhenConditionScript+Condition.swift
+++ b/src/Catty/Condition/WhenConditionScript+Condition.swift
@@ -20,13 +20,25 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-#import "Script.h"
-#import "CBXMLNodeProtocol.h"
+extension WhenConditionScript: CBConditionProtocol {
 
-@class CBXMLContext;
-@class WhenBackgroundChangesScript;
-@class WhenConditionScript;
+    func checkCondition(formulaInterpreter: FormulaInterpreterProtocol) -> Bool {
+        let condition = formulaInterpreter.interpretBool(self.condition, for: self.object)
 
-@interface Script (CBXMLHandler) <CBXMLNodeProtocol>
+        if condition && !self.preCondition {
+            return false
+        } else if !condition && !self.preCondition {
+            self.preCondition = true
+        }
 
-@end
+        return condition
+    }
+
+    func resetCondition() {
+        self.preCondition = false
+    }
+
+    func conditionFormulas() -> [Formula] {
+        self.getFormulas()
+    }
+}

--- a/src/Catty/DataModel/Scripts/Script.h
+++ b/src/Catty/DataModel/Scripts/Script.h
@@ -31,6 +31,7 @@
 @class SpriteObject;
 @class GDataXMLElement;
 @class WhenBackgroundChangesScript;
+@class WhenConditionScript;
 
 @interface Script : NSObject <ScriptProtocol, CBMutableCopying>
 

--- a/src/Catty/DataModel/Scripts/Script.m
+++ b/src/Catty/DataModel/Scripts/Script.m
@@ -93,6 +93,10 @@
     if ([self isKindOfClass:[WhenBackgroundChangesScript class]]) {
         ((WhenBackgroundChangesScript*)copiedScript).look = ((WhenBackgroundChangesScript*)self).look;
     }
+    if ([self isKindOfClass:[WhenConditionScript class]]) {
+        ((WhenConditionScript*)copiedScript).condition = ((WhenConditionScript*)self).condition;
+    }
+    
     return copiedScript;
 }
 

--- a/src/Catty/DataModel/Scripts/WhenConditionScript.swift
+++ b/src/Catty/DataModel/Scripts/WhenConditionScript.swift
@@ -1,0 +1,97 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import Foundation
+
+@objc(WhenConditionScript)
+class WhenConditionScript: Script, BrickFormulaProtocol {
+    @objc var condition: Formula
+    @objc var preCondition: Bool
+
+    init(condition: Formula) {
+        self.condition = condition
+        self.preCondition = false
+        super.init()
+    }
+
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override public required init() {
+        self.condition = Formula(integer: 1)
+        self.preCondition = false
+        super.init()
+    }
+
+    public func category() -> kBrickCategoryType {
+        kBrickCategoryType.controlBrick
+    }
+
+    override func isAnimateable() -> Bool {
+        true
+    }
+
+    func formula(forLineNumber lineNumber: Int, andParameterNumber paramNumber: Int) -> Formula! {
+        self.condition
+    }
+
+    func getFormulas() -> [Formula]! {
+        [self.condition]
+    }
+
+    func setFormula(_ formula: Formula!, forLineNumber lineNumber: Int, andParameterNumber paramNumber: Int) {
+        self.condition = formula
+    }
+
+    func allowsStringFormula() -> Bool {
+        false
+    }
+
+    override func setDefaultValuesFor(_ spriteObject: SpriteObject!) {
+        self.condition = Formula(integer: 1)
+    }
+
+    override func description() -> String {
+        String(format: "WhenConditionScript (Formula: %@)", self.condition.getDisplayString())
+    }
+
+    override func getRequiredResources() -> Int {
+        self.condition.getRequiredResources()
+    }
+
+    @objc(mutableCopyWithContext:)
+    override func mutableCopy(with context: CBMutableCopyContext!) -> Any! {
+        guard context != nil else { fatalError("\(CBMutableCopyContext.Type.self)/" + " must not be nil!") }
+
+        let brick = WhenConditionScript.init()
+        brick.condition = self.condition
+        let updatedReference = context.updatedReference(forReference: self.condition)
+
+        if updatedReference != nil {
+            guard let updatedFormula = updatedReference as? Formula else { return brick }
+            brick.condition = updatedFormula
+        }
+
+        return brick
+    }
+}

--- a/src/Catty/Defines/LanguageTranslationDefines.h
+++ b/src/Catty/Defines/LanguageTranslationDefines.h
@@ -352,6 +352,8 @@
 #define kLocalizedTime NSLocalizedString(@"time", nil)
 #define kLocalizedTimes NSLocalizedString(@"times", nil)
 #define kLocalizedEndOfLoop NSLocalizedString(@"End of Loop", nil)
+#define kLocalizedWhen NSLocalizedString(@"When", nil)
+#define kLocalizedBecomesTrue NSLocalizedString(@"becomes true", nil)
 
 // motion bricks
 #define kLocalizedPlaceAt NSLocalizedString(@"Place at ", nil)

--- a/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
+++ b/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
@@ -352,6 +352,8 @@ let kLocalizedUntilIsTrue = NSLocalizedString("is true", comment: "")
 let kLocalizedTime = NSLocalizedString("time", comment: "")
 let kLocalizedTimes = NSLocalizedString("times", comment: "")
 let kLocalizedEndOfLoop = NSLocalizedString("End of Loop", comment: "")
+let kLocalizedWhen = NSLocalizedString("When", comment: "")
+let kLocalizedBecomesTrue = NSLocalizedString("becomes true", comment: "")
 
 // motion bricks
 let kLocalizedPlaceAt = NSLocalizedString("Place at ", comment: "")

--- a/src/Catty/FormulaEditor/ViewController/FormulaEditorViewController.m
+++ b/src/Catty/FormulaEditor/ViewController/FormulaEditorViewController.m
@@ -143,8 +143,17 @@ NS_ENUM(NSInteger, ButtonIndex) {
 {
     InternFormulaParser *internFormulaParser = [[InternFormulaParser alloc] initWithTokens:[self.internFormula getInternTokenList] andFormulaManager:(id<FormulaManagerProtocol>)self.formulaManager];
     
-    Brick *brick = (Brick*)self.brickCellData.brickCell.scriptOrBrick; // must be a brick!
-    [internFormulaParser parseFormulaForSpriteObject:brick.script.object];
+    Brick *brick = (Brick*)self.brickCellData.brickCell.scriptOrBrick;
+    SpriteObject *object;
+    
+    if ([brick isKindOfClass:[Script class]]) {
+        Script *script = (Script*)brick;
+        object = script.object;
+    } else {
+        object = brick.script.object;
+    }
+    
+    [internFormulaParser parseFormulaForSpriteObject:object];
     FormulaParserStatus formulaParserStatus = [internFormulaParser getErrorTokenIndex];
     
     if(formulaParserStatus == FORMULA_PARSER_OK) {
@@ -458,12 +467,21 @@ NS_ENUM(NSInteger, ButtonIndex) {
     if (self.internFormula != nil) {
         InternFormulaParser *internFormulaParser = [[InternFormulaParser alloc] initWithTokens:[self.internFormula getInternTokenList] andFormulaManager:(id<FormulaManagerProtocol>)self.formulaManager];
         
-        Brick *brick = (Brick*)self.brickCellData.brickCell.scriptOrBrick; // must be a brick!
-        Formula *formula = [[Formula alloc] initWithFormulaElement:[internFormulaParser parseFormulaForSpriteObject:brick.script.object]];
+        Brick *brick = (Brick*)self.brickCellData.brickCell.scriptOrBrick;
+        SpriteObject *object;
+        
+        if ([brick isKindOfClass:[Script class]]) {
+            Script *script = (Script*)brick;
+            object = script.object;
+        } else {
+            object = brick.script.object;
+        }
+        
+        Formula *formula = [[Formula alloc] initWithFormulaElement:[internFormulaParser parseFormulaForSpriteObject:object]];
         
         switch ([internFormulaParser getErrorTokenIndex]) {
             case FORMULA_PARSER_OK:
-                [self showComputeDialog:formula andSpriteObject:brick.script.object];
+                [self showComputeDialog:formula andSpriteObject:object];
                 break;
             case FORMULA_PARSER_STACK_OVERFLOW:
                 [self showFormulaTooLongView];
@@ -474,7 +492,7 @@ NS_ENUM(NSInteger, ButtonIndex) {
                     if (![brick allowsStringFormula]) {
                         [self showSyntaxErrorView];
                     } else {
-                        [self showComputeDialog:formula andSpriteObject:brick.script.object];
+                        [self showComputeDialog:formula andSpriteObject:object];
                     }
                 }
                 
@@ -635,8 +653,15 @@ NS_ENUM(NSInteger, ButtonIndex) {
         if(self.internFormula != nil) {
             InternFormulaParser *internFormulaParser = [[InternFormulaParser alloc] initWithTokens:[self.internFormula getInternTokenList] andFormulaManager:(id<FormulaManagerProtocol>)self.formulaManager];
             
-            Brick *brick = (Brick*)self.brickCellData.brickCell.scriptOrBrick; // must be a brick!
-            FormulaElement *formulaElement = [internFormulaParser parseFormulaForSpriteObject:brick.script.object];
+            Brick *brick = (Brick*)self.brickCellData.brickCell.scriptOrBrick;
+            FormulaElement *formulaElement = nil;
+            if ([brick isKindOfClass:[Script class]]) {
+                Script *script = (Script*)brick;
+                formulaElement = [internFormulaParser parseFormulaForSpriteObject:script.object];
+            } else {
+                formulaElement = [internFormulaParser parseFormulaForSpriteObject:brick.script.object];
+            }
+            
             Formula *formula = [[Formula alloc] initWithFormulaElement:formulaElement];
             switch ([internFormulaParser getErrorTokenIndex]) {
                 case FORMULA_PARSER_OK:

--- a/src/Catty/PlayerEngine/DataModel/CBScriptContext/CBScriptContext.swift
+++ b/src/Catty/PlayerEngine/DataModel/CBScriptContext/CBScriptContext.swift
@@ -44,6 +44,10 @@ protocol CBWhenBackgroundChangesScriptContextProtocol: CBScriptContextProtocol {
     var background: Look? { get }
 }
 
+protocol CBWhenConditionScriptContextProtocol: CBScriptContextProtocol {
+    var condition: Formula { get }
+}
+
 // TODO: refactor abstract class, maybe protocol extension??
 class CBScriptContext: CBScriptContextProtocol {
 
@@ -142,6 +146,32 @@ final class CBWhenScriptContext: CBScriptContext {
                    state: state,
                    instructionList: instructionList)
     }
+
+}
+
+//--------------------------------------------------------------------------------------------------
+final class CBWhenConditionScriptContext: CBScriptContext, CBWhenConditionScriptContextProtocol {
+
+    let condition: Formula
+
+    convenience init?(whenConditionScript: WhenConditionScript, spriteNode: CBSpriteNode,
+                      formulaInterpreter: FormulaInterpreterProtocol, touchManager: TouchManagerProtocol,
+                      state: CBScriptContextState) {
+        self.init(whenConditionScript: whenConditionScript, spriteNode: spriteNode, formulaInterpreter: formulaInterpreter, touchManager: touchManager, state: state, instructionList: [])
+    }
+
+    init?(whenConditionScript: WhenConditionScript, spriteNode: CBSpriteNode,
+          formulaInterpreter: FormulaInterpreterProtocol, touchManager: TouchManagerProtocol,
+          state: CBScriptContextState, instructionList: [CBInstruction]
+        ) {
+        condition = whenConditionScript.condition
+        super.init(script: whenConditionScript,
+                   spriteNode: spriteNode,
+                   formulaInterpreter: formulaInterpreter,
+                   touchManager: touchManager,
+                   state: state,
+                   instructionList: instructionList)
+        }
 
 }
 

--- a/src/Catty/PlayerEngine/DataModel/CBSpriteNode/CBSpriteNode.swift
+++ b/src/Catty/PlayerEngine/DataModel/CBSpriteNode/CBSpriteNode.swift
@@ -77,6 +77,11 @@ class CBSpriteNode: SKSpriteNode {
 
     @objc func update(_ currentTime: TimeInterval) {
         self.drawPenLine()
+
+        for script in self.spriteObject.scriptList where ((script as? WhenConditionScript) != nil) {
+            guard let stage = self.scene as? StageProtocol else { return }
+            stage.notifyWhenCondition()
+        }
     }
 
     // MARK: - Operations

--- a/src/Catty/PlayerEngine/Protocols/CBSchedulerProtocol.swift
+++ b/src/Catty/PlayerEngine/Protocols/CBSchedulerProtocol.swift
@@ -29,6 +29,7 @@ protocol CBSchedulerProtocol: AnyObject {
     func isContextScheduled(_ context: CBScriptContextProtocol) -> Bool
     func startWhenContextsOfSpriteNodeWithName(_ spriteName: String)
     func startWhenTouchDownContexts()
+    func startWhenConditionContexts()
     func startBroadcastContexts(_ broadcastContexts: [CBBroadcastScriptContextProtocol])
     func startWhenBackgroundChangesContexts()
 

--- a/src/Catty/PlayerEngine/Protocols/StageProtocol.swift
+++ b/src/Catty/PlayerEngine/Protocols/StageProtocol.swift
@@ -22,4 +22,5 @@
 
 protocol StageProtocol {
     func notifyBackgroundChange()
+    func notifyWhenCondition()
 }

--- a/src/Catty/PlayerEngine/Stage/Stage.swift
+++ b/src/Catty/PlayerEngine/Stage/Stage.swift
@@ -89,6 +89,11 @@ final class Stage: SKScene, StageProtocol {
         scheduler.startWhenBackgroundChangesContexts()
     }
 
+    func notifyWhenCondition() {
+        logger.debug("StartWhenConditionScript")
+        scheduler.startWhenConditionContexts()
+    }
+
     @objc
     @discardableResult
     func touchedWithTouch(_ touch: UITouch) -> Bool {
@@ -233,6 +238,15 @@ final class Stage: SKScene, StageProtocol {
                     if let broadcastContext = context as? CBBroadcastScriptContext {
                         broadcastHandler.subscribeBroadcastContext(broadcastContext)
                     }
+
+                case let whenConditionScript as WhenConditionScript:
+                    context = CBWhenConditionScriptContext(
+                        whenConditionScript: whenConditionScript,
+                        spriteNode: spriteNode,
+                        formulaInterpreter: formulaManager,
+                        touchManager: formulaManager.touchManager,
+                        state: .runnable)
+
                 default:
                     break
                 }

--- a/src/Catty/Setup/CatrobatSetup+Bricks.swift
+++ b/src/Catty/Setup/CatrobatSetup+Bricks.swift
@@ -34,6 +34,7 @@
             IfLogicElseBrick(),
             IfLogicEndBrick(),
             WhenScript(),
+            WhenConditionScript(),
             BroadcastBrick(),
             BroadcastWaitBrick(),
             ForeverBrick(),

--- a/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/WhenConditionScriptCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/WhenConditionScriptCell.swift
@@ -1,0 +1,61 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import Foundation
+
+@objc(WhenConditionScriptCell)
+class WhenConditionScriptCell: BrickCell, BrickCellProtocol {
+
+    public var expressionTextField: UITextField?
+    public var leftTextLabel: UILabel?
+    public var rightTextLabel: UILabel?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    static func cellHeight() -> CGFloat {
+        CGFloat(kBrickHeightControl1h)
+    }
+
+    override func brickShapeType() -> kBrickShapeType {
+        kBrickShapeType.brickShapeRoundedSmall
+    }
+
+    override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {
+        self.leftTextLabel = inlineViewSubViews[0] as? UILabel
+        self.expressionTextField = inlineViewSubViews[1] as? UITextField
+        self.rightTextLabel = inlineViewSubViews[2] as? UILabel
+    }
+
+    func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {
+        kLocalizedWhen.appending(" %@".appending(kLocalizedBecomesTrue))
+    }
+
+    override func parameters() -> [String] {
+        ["{FLOAT;range=(-inf,inf)}"]
+    }
+}

--- a/src/CattyTests/CatrobatLanguage0.992/XMLParserTests/Unit Tests/XMLParserTests0992.swift
+++ b/src/CattyTests/CatrobatLanguage0.992/XMLParserTests/Unit Tests/XMLParserTests0992.swift
@@ -365,4 +365,13 @@ class XMLParserTests0992: XMLAbstractTest {
         XCTAssertEqual(0, project.unsupportedElements.count)
         XCTAssertTrue(whenBackgroundChangesScript.isKind(of: WhenBackgroundChangesScript.self), "Invalid script type")
     }
+
+    func testWhenConditionScript() {
+        let project = self.getProjectForXML(xmlFile: "ValidProjectAllBricks0992")
+        let object = project.allObjects().first!
+        let whenConditionScript = object.scriptList.object(at: 2) as! Script
+
+         XCTAssertEqual(0, project.unsupportedElements.count)
+        XCTAssertTrue(whenConditionScript.isKind(of: WhenConditionScript.self), "Invalid script type")
+    }
 }

--- a/src/CattyTests/Mocks/StageMock.swift
+++ b/src/CattyTests/Mocks/StageMock.swift
@@ -20,13 +20,17 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-#import "Script.h"
-#import "CBXMLNodeProtocol.h"
+@testable import Pocket_Code
 
-@class CBXMLContext;
-@class WhenBackgroundChangesScript;
-@class WhenConditionScript;
+final class StageMock: SKScene, StageProtocol {
+    public var notifyBackgroundChangeWasCalled = false
+    public var notifyWhenConditionWasCalled = false
 
-@interface Script (CBXMLHandler) <CBXMLNodeProtocol>
+    func notifyBackgroundChange() {
+        self.notifyBackgroundChangeWasCalled = true
+    }
 
-@end
+    func notifyWhenCondition() {
+        self.notifyWhenConditionWasCalled = true
+    }
+}

--- a/src/CattyTests/Resources/ParserTests/Custom/ValidProjectAllBricks/ValidProjectAllBricks0992.xml
+++ b/src/CattyTests/Resources/ParserTests/Custom/ValidProjectAllBricks/ValidProjectAllBricks0992.xml
@@ -671,6 +671,16 @@
               <commentedOut>false</commentedOut>
               <look reference="../../../lookList/look"/>
             </script>
+            <script type="WhenConditionScript">
+              <brickList/>
+              <commentedOut>false</commentedOut>
+              <formulaMap>
+                <formula category="IF_CONDITION">
+                  <type>NUMBER</type>
+                  <value>1</value>
+                </formula>
+              </formulaMap>
+            </script>
           </scriptList>
           <soundList/>
           <userBricks/>

--- a/src/CattyTests/Scripts/WhenBackgroundChangesScriptTests.swift
+++ b/src/CattyTests/Scripts/WhenBackgroundChangesScriptTests.swift
@@ -24,14 +24,6 @@ import XCTest
 
 @testable import Pocket_Code
 
-class StageMock: SKScene, StageProtocol {
-    public var notifyBackgroundChangeWasCalled = false
-
-    func notifyBackgroundChange() {
-        self.notifyBackgroundChangeWasCalled = true
-    }
-}
-
 final class WhenBackgroundChangesScriptTests: XCTestCase {
 
     var project: Project!

--- a/src/CattyTests/Scripts/WhenConditionScriptTests.swift
+++ b/src/CattyTests/Scripts/WhenConditionScriptTests.swift
@@ -1,0 +1,149 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+ import XCTest
+
+ @testable import Pocket_Code
+
+ final class WhenConditionScriptTests: XCTestCase {
+
+    var project: Project!
+    var object: SpriteObject!
+    var spriteNode: CBSpriteNode!
+    var script: WhenConditionScript!
+    var formulaInterpreter: FormulaInterpreterProtocol!
+    var scene: Scene!
+    var stage: StageMock!
+
+     override func setUp() {
+        super.setUp()
+        project = ProjectMock(width: 400, andHeight: 800)
+        scene = SceneMock(name: "sceneMock")
+        scene.project = project
+        project.scene = scene
+
+        object = SpriteObject()
+        object.name = "object"
+        object.scene = scene
+
+        stage = StageMock()
+        let spriteNode = CBSpriteNodeMock(spriteObject: object)
+        spriteNode.mockedStage = stage
+        spriteNode.spriteObject = object
+
+        self.spriteNode = spriteNode
+        object.spriteNode = spriteNode
+        scene.add(object: object)
+
+        script = WhenConditionScript()
+        script.object = object
+        object.scriptList.add(script!)
+        formulaInterpreter = FormulaManager(stageSize: Util.screenSize(true), landscapeMode: false)
+    }
+
+     func testConditionOfWhenConditionScriptSimple() {
+        script.condition = Formula(float: 0)
+        XCTAssertFalse(script.checkCondition(formulaInterpreter: formulaInterpreter))
+
+        script.condition = Formula(float: 1)
+        XCTAssertTrue(script.checkCondition(formulaInterpreter: formulaInterpreter))
+    }
+
+    func testConditionOfWhenConditionScript() {
+        let userVariable = UserVariable(name: "userVariable")
+        let formulaTree = FormulaElement()
+
+        userVariable.value = "0"
+        project.userData.add(userVariable)
+
+        formulaTree.type = ElementType.OPERATOR
+        formulaTree.value = AndOperator.tag
+
+        formulaTree.rightChild = FormulaElement()
+        formulaTree.rightChild.type = ElementType.OPERATOR
+        formulaTree.rightChild.value = SmallerThanOperator.tag
+
+        formulaTree.rightChild.leftChild = FormulaElement()
+        formulaTree.rightChild.leftChild.type = ElementType.USER_VARIABLE
+        formulaTree.rightChild.leftChild.value = userVariable.name
+
+        formulaTree.rightChild.rightChild = FormulaElement()
+        formulaTree.rightChild.rightChild.type = ElementType.NUMBER
+        formulaTree.rightChild.rightChild.value = "4"
+
+        formulaTree.leftChild = FormulaElement()
+        formulaTree.leftChild.type = ElementType.OPERATOR
+        formulaTree.leftChild.value = GreaterThanOperator.tag
+
+        formulaTree.leftChild.leftChild = FormulaElement()
+        formulaTree.leftChild.leftChild.type = ElementType.USER_VARIABLE
+        formulaTree.leftChild.leftChild.value = userVariable.name
+
+        formulaTree.leftChild.rightChild = FormulaElement()
+        formulaTree.leftChild.rightChild.type = ElementType.NUMBER
+        formulaTree.leftChild.rightChild.value = "2"
+
+        let formula = Formula(formulaElement: formulaTree)!
+        script.condition = formula
+
+        userVariable.value = "0"
+        XCTAssertFalse(script.checkCondition(formulaInterpreter: formulaInterpreter))
+
+        userVariable.value = "2"
+        XCTAssertFalse(script.checkCondition(formulaInterpreter: formulaInterpreter))
+
+        userVariable.value = "3"
+        XCTAssertTrue(script.checkCondition(formulaInterpreter: formulaInterpreter))
+
+        userVariable.value = "4"
+        XCTAssertFalse(script.checkCondition(formulaInterpreter: formulaInterpreter))
+
+        userVariable.value = "5"
+        XCTAssertFalse(script.checkCondition(formulaInterpreter: formulaInterpreter))
+    }
+
+    func testMethodCallNotifyWhenCondition() {
+        XCTAssertFalse(stage.notifyWhenConditionWasCalled)
+        script.condition = Formula(integer: 1)
+        spriteNode.update(10)
+        XCTAssertTrue(stage.notifyWhenConditionWasCalled)
+    }
+
+    func testCallNotifyWhenConditionForOtherObjects() {
+        let secondObject = SpriteObject()
+        secondObject.name = "object"
+        secondObject.scene = scene
+        let spriteNode = CBSpriteNodeMock(spriteObject: secondObject)
+        spriteNode.mockedStage = stage
+
+        secondObject.spriteNode = spriteNode
+        scene.add(object: secondObject)
+        script.object = secondObject
+
+        script.condition = Formula(integer: 1)
+
+        XCTAssertFalse(stage.notifyWhenConditionWasCalled)
+
+        spriteNode.update(10)
+        XCTAssertFalse(stage.notifyWhenConditionWasCalled)
+    }
+}

--- a/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
+++ b/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
@@ -352,6 +352,8 @@ let kLocalizedUntilIsTrue = NSLocalizedString("is true", bundle: Bundle(for: Lan
 let kLocalizedTime = NSLocalizedString("time", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedTimes = NSLocalizedString("times", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedEndOfLoop = NSLocalizedString("End of Loop", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kLocalizedWhen = NSLocalizedString("When", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kLocalizedBecomesTrue = NSLocalizedString("becomes true", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 
 // motion bricks
 let kLocalizedPlaceAt = NSLocalizedString("Place at ", bundle: Bundle(for: LanguageTranslation.self), comment: "")


### PR DESCRIPTION
This Script executes all subsequent Bricks when a condition becomes true. In order to run it again later, the condition has to first become false once, and only once it becomes again true, the script will be run once more.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
