### PR TITLE
CATTY-414 Fix Copy "Go to [object]" Brick

### DIFF
--- a/src/Catty/DataModel/Bricks/Motion/GoToBrick.m
+++ b/src/Catty/DataModel/Bricks/Motion/GoToBrick.m
@@ -124,5 +124,14 @@ andParameterNumber:(NSInteger)paramNumber
     return YES;
 }
 
+- (id)mutableCopyWithContext:(CBMutableCopyContext*)context
+{
+    GoToBrick *copy = [super mutableCopyWithContext:context];
+    if(self.goToObject)
+        copy.goToObject = self.goToObject;
+    return copy;
+}
+
+
 @end
 


### PR DESCRIPTION
When copying a "Go to [object]" Brick, the copied Brick points to a different object. Instead, the copied Brick should point to the same object.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
