### PR TITLE
CATTY-360 Use SynchronizedArray in CBScheduler

### DIFF
--- a/src/Catty/DataModel/Array/SynchronizedArray.swift
+++ b/src/Catty/DataModel/Array/SynchronizedArray.swift
@@ -168,3 +168,11 @@ extension SynchronizedArray where Element: UserDataProtocol {
         }
     }
 }
+
+extension SynchronizedArray where Element: Equatable {
+    func remove(element: Element) {
+        queue.async(flags: .barrier) {
+            self.array.removeObject(element)
+        }
+    }
+}

--- a/src/CattyTests/Bricks/WaitBrickTests.swift
+++ b/src/CattyTests/Bricks/WaitBrickTests.swift
@@ -64,19 +64,19 @@ final class WaitBrickTests: XCTestCase {
         waitBrick.script = script
         let executionTime = self.measureExecutionTime(instruction: waitBrick.instruction(), expectation: nil)
         XCTAssertEqual(executionTime, duration, accuracy: 0.5, "Wrong execution time")
-        XCTAssertEqual(scheduler._activeTimers.count, 0)
+        XCTAssertEqual(scheduler.synchronizedTimerArray.count, 0)
     }
 
-    func testSchedulerSetTimer_activeTimersCountIsOne() {
+    func testSchedulerSetTimer() {
         let extendedTimer = ExtendedTimer.init(timeInterval: 2,
                                                repeats: false,
                                                execOnMainRunLoop: true,
                                                startTimerImmediately: true) { _ in }
         self.scheduler.registerTimer(extendedTimer)
-        XCTAssertEqual(scheduler._activeTimers.count, 1)
+        XCTAssertEqual(scheduler.synchronizedTimerArray.count, 1)
     }
 
-    func testSchedulerRemoveTimer_activeTimersCountIsZero() {
+    func testSchedulerRemoveTimer() {
         let extendedTimer = ExtendedTimer.init(timeInterval: 2,
                                                repeats: false,
                                                execOnMainRunLoop: true,
@@ -84,7 +84,31 @@ final class WaitBrickTests: XCTestCase {
         self.scheduler.registerTimer(extendedTimer)
         self.scheduler.removeTimer(extendedTimer)
 
-        XCTAssertEqual(scheduler._activeTimers.count, 0)
+        XCTAssertEqual(scheduler.synchronizedTimerArray.count, 0)
+    }
+
+    func testSchedulerThreadSafeArrayWithAppend() {
+        DispatchQueue.concurrentPerform(iterations: 1000) { _ in
+            let last = scheduler.synchronizedTimerArray.last ??
+            ExtendedTimer.init(timeInterval: 2,
+                               repeats: false,
+                               execOnMainRunLoop: true,
+                               startTimerImmediately: true) { _ in }
+            scheduler.synchronizedTimerArray.append(last)
+        }
+        XCTAssertEqual(1000, scheduler.synchronizedTimerArray.count)
+    }
+
+    func testSchedulerThreadSafeArrayWithRegister() {
+        DispatchQueue.concurrentPerform(iterations: 1000) { _ in
+            let last = scheduler.synchronizedTimerArray.last ??
+                    ExtendedTimer.init(timeInterval: 2,
+                                       repeats: false,
+                                       execOnMainRunLoop: true,
+                                       startTimerImmediately: true) { _ in }
+            scheduler.registerTimer(last)
+        }
+        XCTAssertEqual(1000, scheduler.synchronizedTimerArray.count)
     }
 
     func measureExecutionTime(instruction: CBInstruction, expectation: XCTestExpectation?) -> Double {

--- a/src/CattyTests/DataModel/SynchronizedArrayTests.swift
+++ b/src/CattyTests/DataModel/SynchronizedArrayTests.swift
@@ -348,4 +348,21 @@ final class SynchronizedArrayTests: XCTestCase {
         }
         XCTAssertEqual(1000, array.count)
     }
+
+    func testRemoveElement() {
+        let array = SynchronizedArray<Int>()
+
+        array.append(5)
+        array.append(6)
+        array.append(7)
+        XCTAssertEqual(3, array.count)
+
+        array.remove(element: 5)
+        XCTAssertEqual(2, array.count)
+        XCTAssertEqual(6, array[0])
+
+        array.remove(element: 6)
+        XCTAssertEqual(1, array.count)
+        XCTAssertEqual(7, array[0])
+    }
 }


### PR DESCRIPTION
Replaced _activeTimers and timerQueue with a SynchronizedArray of ExtendedTimer.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
