### PR TITLE
CATTY-412 Rename When project started

### DIFF
--- a/src/Catty/Defines/LanguageTranslationDefines.h
+++ b/src/Catty/Defines/LanguageTranslationDefines.h
@@ -330,7 +330,7 @@
 
 // control bricks
 #define kLocalizedScript NSLocalizedString(@"Script", nil)
-#define kLocalizedWhenProjectStarted NSLocalizedString(@"When project started", nil)
+#define kLocalizedWhenProjectStarted NSLocalizedString(@"When project starts", nil)
 #define kLocalizedWhenTapped NSLocalizedString(@"When tapped", nil)
 #define kLocalizedTouchDown NSLocalizedString(@"When stage is tapped", nil)
 #define kLocalizedWhenBackgroundChanges NSLocalizedString(@"When background changes to", nil)

--- a/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
+++ b/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
@@ -330,7 +330,7 @@ let kLocalizedUnsupportedElementsDescription = NSLocalizedString("Following feat
 
 // control bricks
 let kLocalizedScript = NSLocalizedString("Script", comment: "")
-let kLocalizedWhenProjectStarted = NSLocalizedString("When project started", comment: "")
+let kLocalizedWhenProjectStarted = NSLocalizedString("When project starts", comment: "")
 let kLocalizedWhenTapped = NSLocalizedString("When tapped", comment: "")
 let kLocalizedTouchDown = NSLocalizedString("When stage is tapped", comment: "")
 let kLocalizedWhenBackgroundChanges = NSLocalizedString("When background changes to", comment: "")

--- a/src/Catty/Resources/Localization/af.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/af.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/ar.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ar.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "عند تغيير الخلفية إلى";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "عند لمس الشاشة";

--- a/src/Catty/Resources/Localization/az.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/az.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/bg.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/bg.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/bn.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/bn.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "যখন ব্যাকগ্রাউন্ডে পরিবর্তন হয়";
 
 /* No comment provided by engineer. */
-"When project started" = "যখন প্রজেক্ট শুরু";
+"When project starts" = "যখন প্রজেক্ট শুরু";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "যখন পর্যায়টি টেপ করা হয়";

--- a/src/Catty/Resources/Localization/bs.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/bs.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Kada se pozadina promijeni na";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/ca.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ca.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/chr.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/chr.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/cs.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/cs.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Když se pozadí změní na";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Při dotyku obrazovky";

--- a/src/Catty/Resources/Localization/da.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/da.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/de.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/de.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Wenn der Hintergrund wechselt zu";
 
 /* No comment provided by engineer. */
-"When project started" = "Wenn Projekt gestartet";
+"When project starts" = "Wenn Projekt gestartet";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Wenn der Bildschirm berührt wird";

--- a/src/Catty/Resources/Localization/el.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/el.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Όταν το φόντο αλλάξει σε";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/en-AU.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en-AU.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/en-CA.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en-CA.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/en-GB.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en-GB.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project starts";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en.lproj/Localizable.strings
@@ -1832,7 +1832,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/es.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/es.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Cuando el fondo cambia a";
 
 /* No comment provided by engineer. */
-"When project started" = "Cuando el proyecto comience";
+"When project starts" = "Cuando el proyecto comience";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Cuando se toca la pantalla";

--- a/src/Catty/Resources/Localization/fa-AF.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/fa-AF.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/fa.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/fa.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/fi.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/fi.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/fr.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/fr.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Lorsque le fond change pour";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Lorsque l’écran est touché";

--- a/src/Catty/Resources/Localization/gl.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/gl.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/gu.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/gu.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/ha.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ha.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/he.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/he.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/hi.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/hi.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/hr.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/hr.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/hu.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/hu.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/id.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/id.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Saat latar belakang berubah";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Saat layar tersentuh";

--- a/src/Catty/Resources/Localization/ig.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ig.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/it.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/it.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Quando lo sfondo impostato a";
 
 /* No comment provided by engineer. */
-"When project started" = "Quando il progetto è iniziato";
+"When project starts" = "Quando il progetto è iniziato";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Quando lo schermo viene toccato";

--- a/src/Catty/Resources/Localization/ja.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ja.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "背景を変更した場合";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "画面にタッチした時";

--- a/src/Catty/Resources/Localization/kk.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/kk.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/kn.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/kn.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/ko.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ko.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "배경이 바뀔 때";
 
 /* No comment provided by engineer. */
-"When project started" = "프로그램을 시작할 때";
+"When project starts" = "프로그램을 시작할 때";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "화면을 터치할 때";

--- a/src/Catty/Resources/Localization/lt.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/lt.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/mk.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/mk.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/ml.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ml.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/ms.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ms.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/nl.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/nl.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/no.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/no.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Når bakgrunnen endres til";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Når skjermen berøres";

--- a/src/Catty/Resources/Localization/pl.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/pl.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Kiedy tło zmieni się na";
 
 /* No comment provided by engineer. */
-"When project started" = "Kiedy projekt startuje";
+"When project starts" = "Kiedy projekt startuje";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Kiedy dotknięto ekran";

--- a/src/Catty/Resources/Localization/ps.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ps.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/pt-BR.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/pt-BR.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/pt.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/pt.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Quando alguém toca no ecrã";

--- a/src/Catty/Resources/Localization/ro.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ro.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/ru.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ru.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Когда фон изменится на";
 
 /* No comment provided by engineer. */
-"When project started" = "При старте";
+"When project starts" = "При старте";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "При прикосновении к экрану";

--- a/src/Catty/Resources/Localization/sd.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/sd.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/si.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/si.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/sk.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/sk.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Keď sa pozadie zmení na";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Pri dotyku obrazovky";

--- a/src/Catty/Resources/Localization/sl.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/sl.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/sq.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/sq.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/sr.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/sr.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Када је фаза додирнута";

--- a/src/Catty/Resources/Localization/sv.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/sv.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/sw.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/sw.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Itakapobadilika mandharinyuma kuwa";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Wakati skrini imeguswa";

--- a/src/Catty/Resources/Localization/ta.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ta.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "பின்னணி மாறும்போது";
 
 /* No comment provided by engineer. */
-"When project started" = "திட்டம் தொடங்கியபோது";
+"When project starts" = "திட்டம் தொடங்கியபோது";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "மேடை தட்டும்போது";

--- a/src/Catty/Resources/Localization/te.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/te.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/th.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/th.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "เมื่อเวทีถูกทาบทาม";

--- a/src/Catty/Resources/Localization/tr.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/tr.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "Arka plan değiştiğinde";
 
 /* No comment provided by engineer. */
-"When project started" = "Proje başladığında";
+"When project starts" = "Proje başladığında";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "Ekrana dokunduğunda";

--- a/src/Catty/Resources/Localization/tw.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/tw.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/uk.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/uk.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/ur.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/ur.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "جب پس منظر کو تبدیل کرتا ہے";
 
 /* No comment provided by engineer. */
-"When project started" = "جب منصوبے شروع ہوگئے";
+"When project starts" = "جب منصوبے شروع ہوگئے";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "جب اسٹیج  ٹیپ کیا جاتا ہے";

--- a/src/Catty/Resources/Localization/uz.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/uz.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/vi.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/vi.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "When stage is tapped";

--- a/src/Catty/Resources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "当背景更改为";
 
 /* No comment provided by engineer. */
-"When project started" = "项目启动时";
+"When project starts" = "项目启动时";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "当屏幕被点击";

--- a/src/Catty/Resources/Localization/zh-Hant.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/zh-Hant.lproj/Localizable.strings
@@ -1817,7 +1817,7 @@
 "When background changes to" = "When background changes to";
 
 /* No comment provided by engineer. */
-"When project started" = "When project started";
+"When project starts" = "When project starts";
 
 /* No comment provided by engineer. */
 "When stage is tapped" = "當螢幕被觸碰";

--- a/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
+++ b/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
@@ -330,7 +330,7 @@ let kLocalizedUnsupportedElementsDescription = NSLocalizedString("Following feat
 
 // control bricks
 let kLocalizedScript = NSLocalizedString("Script", bundle: Bundle(for: LanguageTranslation.self), comment: "")
-let kLocalizedWhenProjectStarted = NSLocalizedString("When project started", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kLocalizedWhenProjectStarted = NSLocalizedString("When project starts", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedWhenTapped = NSLocalizedString("When tapped", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedTouchDown = NSLocalizedString("When stage is tapped", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedWhenBackgroundChanges = NSLocalizedString("When background changes to", bundle: Bundle(for: LanguageTranslation.self), comment: "")


### PR DESCRIPTION
Changed all "When project started" strings to the present tense "When project starts".

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
