### PR TITLE
CATTY-425 PaintViewControllerTests failing with iPhone SE 2nd Gen

### DIFF
--- a/src/CattyTests/ViewController/PaintViewControllerTests.swift
+++ b/src/CattyTests/ViewController/PaintViewControllerTests.swift
@@ -116,7 +116,9 @@ final class PaintViewControllerTests: XCTestCase {
         XCTAssertTrue(Double(horizontalDistanceLeftEdge - horizontalDistanceRightEdge) <= Double.epsilon)
 
         let verticalDistanceUpperEdge = controller!.helper.frame.origin.y
-        let verticalDistanceLowerEdge = controller!.scrollView.bounds.size.height - (verticalDistanceUpperEdge + controller!.helper.frame.size.height)
+
+        let boundsHeight = navigationController.toolbar.frame.origin.y - Util.statusBarHeight() - navigationController.navigationBar.frame.size.height
+        let verticalDistanceLowerEdge = boundsHeight - (verticalDistanceUpperEdge + controller!.helper.frame.size.height)
 
         XCTAssertTrue(Double(verticalDistanceUpperEdge - verticalDistanceLowerEdge) <= Double.epsilon)
     }


### PR DESCRIPTION
The testSetupZoomCenterPosition test inside the PaintViewControllerTests.swift file is failing when executing it with an iPhone SE 2nd gen.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
