### PR TITLE
CATTY-434 Fix for Jenkins failing with The file couldn’t be saved. error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,11 @@ pipeline {
         }
       }
     }
+    stage('Clear Carthage temporary items') {
+      steps {
+        sh 'rm -rf ${TMPDIR}/TemporaryItems/*carthage*'
+      }
+    }
     stage('Prepare') {
       steps {
         sh 'make init'


### PR DESCRIPTION
The "The file couldn’t be saved." error is related to the temporary Carthage cache. In order to solve this problem, the Carthage temporary items need to be removed therefore a new stage called "Clear Carthage temporary items" was added.
This new stage should now remove the temporary Carthage cache on every Jenkins test start.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [X] Include the name of the Jira ticket in the PR’s title
- [X] Verify that the Jira ticket is in the status *Ready for Development*
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Stick to the project’s git workflow (rebase and squash your commits)
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed
- [X] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
