### PR TITLE
CATTY-447 Fix lane "test_reports"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,8 +52,7 @@ pipeline {
       archiveArtifacts(artifacts: 'src/fastlane/builds/', allowEmptyArchive: true)
       archiveArtifacts(artifacts: 'src/fastlane/Install.html', allowEmptyArchive: true)
       archiveArtifacts(artifacts: 'src/fastlane/Adhoc.plist', allowEmptyArchive: true)
-      sh 'cd src && fastlane test_reports'
-      junit testResults: 'src/fastlane/test_output/TestSummaries.xml', allowEmptyResults: true
+      junit testResults: 'src/fastlane/test_output/report.junit', allowEmptyResults: true
     }
   }
 }

--- a/src/fastlane/Fastfile
+++ b/src/fastlane/Fastfile
@@ -120,22 +120,14 @@ platform :ios do
       project: File.absolute_path('../Catty.xcodeproj'),
       try_count: 3,
       fail_build: false,
+      collate_reports: true,
+      output_types: "junit",
       scheme: $catty_schemes["debug"],
       testrun_completed_block: test_run_block
     )
     unless result[:failed_testcount].zero?
       UI.message("There are #{result[:failed_testcount]} legitimate failing tests")
     end
-  end
-
-  desc "Collate all test reports"
-  lane :test_reports do
-    collate_junit_reports(
-      reports: ["./fastlane/test_output/results-BluetoothHelperTests/report.junit",
-                "./fastlane/test_output/results-Catty Tests/report.junit",
-                "./fastlane/test_output/results-Catty UITests/report.junit"],
-      collated_report: './fastlane/test_output/TestSummaries.xml'
-    )
   end
 
   ##########################################################################


### PR DESCRIPTION
Collate reports at multi_scan directly.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
