### PR TITLE
CATTY-444 Remove "saved" notification when adding and deleting Bricks

### DIFF
--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickManager/BrickInsertManager.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickManager/BrickInsertManager.m
@@ -284,7 +284,7 @@
         [targetScript.brickList insertObject:loopEndBrick atIndex:insertionIndex==0?1:insertionIndex];
     }
     brick.animateInsertBrick = NO;
-    [object.scene.project saveToDiskWithNotification:YES];
+    [object.scene.project saveToDiskWithNotification:NO];
 }
 
 -(Brick*)checkForeverBrickInsideLogicBricks:(Script*)targetScript andIndexPath:(NSIndexPath*)path

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
@@ -938,7 +938,7 @@ willBeginDraggingItemAtIndexPath:(NSIndexPath*)indexPath
         self.batchUpdateMutex = NO;
         self.placeHolderView.hidden = (self.object.scriptList.count != 0);
         [self reloadData];
-        [self.object.scene.project saveToDiskWithNotification:YES];
+        [self.object.scene.project saveToDiskWithNotification:NO];
         [self setEditing:NO animated:NO];
     }];
 


### PR DESCRIPTION
Since the user assumes that the project is saved anyways, the "saved" notification should be removed when adding new and deleting existing Bricks.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
