### PR TITLE
CATTY-465 Remove Swift Compiler Warning For SoundTest

### DIFF
--- a/src/CattyTests/DataModel/SoundTest.swift
+++ b/src/CattyTests/DataModel/SoundTest.swift
@@ -60,7 +60,6 @@ final class SoundTest: XCTestCase {
        }
 
        func testInitWithName() {
-           let bundle = Bundle(for: type(of: self))
            let param1 = "testSoundFile"
            let param2 = "testSound"
            let sound = Sound(name: param1, fileName: param2)


### PR DESCRIPTION
Test shows warning: Initialization of immutable value 'bundle' was never used; consider replacing with assignment to '_' or removing it

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
