### PR TITLE
CATTY-440 Round border for Looks and Object Preview Images

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -1227,6 +1227,7 @@
 		92FF32BE1A24E2F400093DA7 /* BaseTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 92FF32511A24E2F400093DA7 /* BaseTransition.m */; };
 		92FF32BF1A24E2F400093DA7 /* BrickTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 92FF32531A24E2F400093DA7 /* BrickTransition.m */; };
 		92FF32C31A24E33B00093DA7 /* iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 92FF32C21A24E33B00093DA7 /* iPhone.storyboard */; };
+		97D015912553392A00B6967D /* RoundedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D0158E2553392A00B6967D /* RoundedImageView.swift */; };
 		99B2C36B1D884C1300736769 /* FlashBrick+CBXMLHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 99B2C36A1D884C1300736769 /* FlashBrick+CBXMLHandler.m */; };
 		99B2C3701D884D2900736769 /* FlashBrick.m in Sources */ = {isa = PBXBuildFile; fileRef = 99B2C36F1D884D2900736769 /* FlashBrick.m */; };
 		99B2C3731D884E8A00736769 /* FlashBrickCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 99B2C3721D884E8A00736769 /* FlashBrickCell.m */; };
@@ -3248,6 +3249,7 @@
 		92FF32C21A24E33B00093DA7 /* iPhone.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = iPhone.storyboard; sourceTree = "<group>"; };
 		95088280A879E5F515D4569E /* fa-AF */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = "fa-AF"; path = "fa-AF.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		95C607797206029F5B454A53 /* sw */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = sw; path = sw.lproj/Localizable.strings; sourceTree = "<group>"; };
+		97D0158E2553392A00B6967D /* RoundedImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RoundedImageView.swift; path = Catty/Views/Custom/TableView/Cell/RoundedImageView.swift; sourceTree = SOURCE_ROOT; };
 		98738650BC99C8766A159B17 /* ko */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9990BB6C1D89D89A0088357A /* BrickStaticChoiceProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BrickStaticChoiceProtocol.h; sourceTree = "<group>"; };
 		99B2C3691D884C1300736769 /* FlashBrick+CBXMLHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "FlashBrick+CBXMLHandler.h"; path = "Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/IO/FlashBrick+CBXMLHandler.h"; sourceTree = SOURCE_ROOT; };
@@ -8280,6 +8282,7 @@
 			children = (
 				92FF32391A24E2F400093DA7 /* BaseCell */,
 				92FF323C1A24E2F400093DA7 /* CatrobatImageCell.h */,
+				97D0158E2553392A00B6967D /* RoundedImageView.swift */,
 				92FF32401A24E2F400093DA7 /* ContinueImage */,
 				92FF32431A24E2F400093DA7 /* DarkBlueGradient */,
 			);
@@ -11085,6 +11088,7 @@
 				9218B20E1CC4AB75007B4C60 /* LineTool.m in Sources */,
 				F45AF703212960D4000F88A6 /* FacePositionYSensor.swift in Sources */,
 				AAAF22841BC0CA0F0076F11E /* SetXBrick+Instruction.swift in Sources */,
+				97D015912553392A00B6967D /* RoundedImageView.swift in Sources */,
 				181CC10724B750AF004A783E /* CBPosition.swift in Sources */,
 				AA74EFF91BC05B5F00D1E954 /* SetTransparencyBrick.m in Sources */,
 				186E99192488F74500627E36 /* PenUpBrick+Instruction.swift in Sources */,

--- a/src/Catty/Defines/UIDefines.h
+++ b/src/Catty/Defines/UIDefines.h
@@ -81,8 +81,6 @@ static NSString *const kUserInfoSound = @"UserInfoSound";
 #define kHandleImageHeight 15.0f
 #define kHandleImageWidth 40.0f
 #define kOffsetTopBrickSelectionView 70.0f
-#define kPreviewImageCornerRadius 10.0
-#define kPreviewImageBorderWidth 1.0f
 
 //BDKNotifyHUD
 #define kBDKNotifyHUDDestinationOpacity 0.3f

--- a/src/Catty/Defines/UIDefines.swift
+++ b/src/Catty/Defines/UIDefines.swift
@@ -23,7 +23,8 @@
 @objc
 class UIDefines: NSObject {
     @objc static let previewImageSize = CGSize(width: Int(kPreviewThumbnailWidth), height: Int(kPreviewThumbnailHeight))
+    static let previewImageCornerRadius = 10.0
+    static let previewImageBorderWidth = 1.0
+
     static let defaultScreenshots = ["catrobat", "elephant", "lynx", "panda", "pingu", "racoon"]
-    static let kPreviewImageCornerRadius = 10.0
-    static let kPreviewImageBorderWidth = 1.0
 }

--- a/src/Catty/Storyboard+XIB/iPhone.storyboard
+++ b/src/Catty/Storyboard+XIB/iPhone.storyboard
@@ -34,13 +34,6 @@
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="sXS-1D-zap" secondAttribute="height" multiplier="1:1" id="3aV-Q9-bTD"/>
                                             </constraints>
-                                            <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="0"/>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.borderWidth" value="1"/>
-                                                <userDefinedRuntimeAttribute type="color" keyPath="layer.borderUIColor">
-                                                    <color key="value" red="0.094117647060000004" green="0.64705882349999999" blue="0.71764705880000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </userDefinedRuntimeAttribute>
-                                            </userDefinedRuntimeAttributes>
                                         </imageView>
                                     </subviews>
                                     <constraints>
@@ -70,18 +63,11 @@
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </label>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="zIT-af-eRb">
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="zIT-af-eRb" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
                                             <rect key="frame" x="28" y="16" width="47" height="47"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="zIT-af-eRb" secondAttribute="height" multiplier="1:1" id="pzJ-dd-ayv"/>
                                             </constraints>
-                                            <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="0"/>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.borderWidth" value="1"/>
-                                                <userDefinedRuntimeAttribute type="color" keyPath="layer.borderUIColor">
-                                                    <color key="value" red="0.094117647060000004" green="0.64705882349999999" blue="0.71764705880000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </userDefinedRuntimeAttribute>
-                                            </userDefinedRuntimeAttributes>
                                         </imageView>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bw7-J9-Vvq">
                                             <rect key="frame" x="98" y="53.5" width="31" height="14.5"/>
@@ -350,13 +336,6 @@
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="naL-Va-LMI" secondAttribute="height" multiplier="1:1" id="hND-WX-PX7"/>
                                             </constraints>
-                                            <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="0"/>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.borderWidth" value="1"/>
-                                                <userDefinedRuntimeAttribute type="color" keyPath="layer.borderUIColor">
-                                                    <color key="value" red="0.094117647060000004" green="0.64705882349999999" blue="0.71764705880000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </userDefinedRuntimeAttribute>
-                                            </userDefinedRuntimeAttributes>
                                         </imageView>
                                     </subviews>
                                     <constraints>
@@ -385,13 +364,6 @@
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="7nz-m2-X1L" secondAttribute="height" multiplier="1:1" id="k7a-cW-C1g"/>
                                             </constraints>
-                                            <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="0"/>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.borderWidth" value="1"/>
-                                                <userDefinedRuntimeAttribute type="color" keyPath="layer.borderUIColor">
-                                                    <color key="value" red="0.094117647060000004" green="0.64705882349999999" blue="0.71764705880000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </userDefinedRuntimeAttribute>
-                                            </userDefinedRuntimeAttributes>
                                         </imageView>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gbo-P5-yTN">
                                             <rect key="frame" x="98" y="53.5" width="31" height="14.5"/>
@@ -735,18 +707,11 @@
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </label>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="8MG-W9-ZPZ">
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="8MG-W9-ZPZ" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
                                             <rect key="frame" x="28" y="16" width="47" height="47"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="8MG-W9-ZPZ" secondAttribute="height" multiplier="1:1" id="3M9-HQ-PIf"/>
                                             </constraints>
-                                            <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="0"/>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.borderWidth" value="1"/>
-                                                <userDefinedRuntimeAttribute type="color" keyPath="layer.borderUIColor">
-                                                    <color key="value" red="0.094117647060000004" green="0.64705882349999999" blue="0.71764705880000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </userDefinedRuntimeAttribute>
-                                            </userDefinedRuntimeAttributes>
                                         </imageView>
                                     </subviews>
                                     <constraints>
@@ -794,18 +759,11 @@
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="GFa-PX-63P">
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="GFa-PX-63P" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
                                             <rect key="frame" x="28" y="16" width="47" height="47"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="GFa-PX-63P" secondAttribute="height" multiplier="1:1" id="d2b-5Z-x3Y"/>
                                             </constraints>
-                                            <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="0"/>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.borderWidth" value="1"/>
-                                                <userDefinedRuntimeAttribute type="color" keyPath="layer.borderUIColor">
-                                                    <color key="value" red="0.094117647060000004" green="0.64705882349999999" blue="0.71764705880000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </userDefinedRuntimeAttribute>
-                                            </userDefinedRuntimeAttributes>
                                         </imageView>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aJP-8Q-FUU">
                                             <rect key="frame" x="139" y="36" width="31" height="14"/>
@@ -962,13 +920,6 @@
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="642-Kc-jVe" secondAttribute="height" multiplier="1:1" id="0aC-HZ-I7y"/>
                                             </constraints>
-                                            <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="0"/>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.borderWidth" value="1"/>
-                                                <userDefinedRuntimeAttribute type="color" keyPath="layer.borderUIColor">
-                                                    <color key="value" red="0.094117647060000004" green="0.64705882349999999" blue="0.71764705880000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </userDefinedRuntimeAttribute>
-                                            </userDefinedRuntimeAttributes>
                                         </imageView>
                                     </subviews>
                                     <constraints>
@@ -998,18 +949,11 @@
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </label>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="jDK-Dy-lHE">
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="jDK-Dy-lHE" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
                                             <rect key="frame" x="28" y="16" width="47" height="47"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="jDK-Dy-lHE" secondAttribute="height" multiplier="1:1" id="kWt-i8-RLg"/>
                                             </constraints>
-                                            <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="0"/>
-                                                <userDefinedRuntimeAttribute type="string" keyPath="layer.borderWidth" value="1"/>
-                                                <userDefinedRuntimeAttribute type="color" keyPath="layer.borderUIColor">
-                                                    <color key="value" red="0.094117647058823528" green="0.6470588235294118" blue="0.71764705882352942" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </userDefinedRuntimeAttribute>
-                                            </userDefinedRuntimeAttributes>
                                         </imageView>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FN1-0S-nvN">
                                             <rect key="frame" x="98" y="53.5" width="31" height="14.5"/>
@@ -1304,18 +1248,11 @@
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </label>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="idW-ZC-ZwS">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="idW-ZC-ZwS" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
                                                     <rect key="frame" x="27" y="16" width="47" height="47"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="idW-ZC-ZwS" secondAttribute="height" multiplier="1:1" id="K30-w2-8td"/>
                                                     </constraints>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="0"/>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="layer.borderWidth" value="1"/>
-                                                        <userDefinedRuntimeAttribute type="color" keyPath="layer.borderUIColor">
-                                                            <color key="value" red="0.094117647060000004" green="0.64705882349999999" blue="0.71764705880000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                    </userDefinedRuntimeAttributes>
                                                 </imageView>
                                             </subviews>
                                             <constraints>
@@ -1440,7 +1377,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="146"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="49q-B8-MBG" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="49q-B8-MBG">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="146"/>
                                         </imageView>
                                     </subviews>
@@ -1555,13 +1492,6 @@
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="mCK-b7-9dt" secondAttribute="height" multiplier="1:1" id="TNJ-xK-4Co"/>
                                                     </constraints>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="layer.cornerRadius" value="0"/>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="layer.borderWidth" value="1"/>
-                                                        <userDefinedRuntimeAttribute type="color" keyPath="layer.borderUIColor">
-                                                            <color key="value" red="0.094117647060000004" green="0.64705882349999999" blue="0.71764705880000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                    </userDefinedRuntimeAttributes>
                                                 </imageView>
                                             </subviews>
                                             <constraints>

--- a/src/Catty/Storyboard+XIB/iPhone.storyboard
+++ b/src/Catty/Storyboard+XIB/iPhone.storyboard
@@ -29,7 +29,7 @@
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </label>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="sXS-1D-zap">
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="sXS-1D-zap" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
                                             <rect key="frame" x="28" y="16" width="47" height="47"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="sXS-1D-zap" secondAttribute="height" multiplier="1:1" id="3aV-Q9-bTD"/>
@@ -558,7 +558,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="348" height="125"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView userInteractionEnabled="NO" tag="11" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kWN-vS-ZVh">
+                                        <imageView userInteractionEnabled="NO" tag="11" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kWN-vS-ZVh" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
                                             <rect key="frame" x="31" y="41" width="43" height="43"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="50" id="RYh-0E-U5O"/>
@@ -957,7 +957,7 @@
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </label>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="642-Kc-jVe">
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="642-Kc-jVe" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
                                             <rect key="frame" x="28" y="16" width="47" height="47"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="642-Kc-jVe" secondAttribute="height" multiplier="1:1" id="0aC-HZ-I7y"/>
@@ -1440,7 +1440,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="146"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="49q-B8-MBG">
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="49q-B8-MBG" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="146"/>
                                         </imageView>
                                     </subviews>
@@ -1550,7 +1550,7 @@
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </label>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="mCK-b7-9dt">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" tag="11" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="mCK-b7-9dt" customClass="RoundedImageView" customModule="Pocket_Code" customModuleProvider="target">
                                                     <rect key="frame" x="27" y="16" width="47" height="47"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="mCK-b7-9dt" secondAttribute="height" multiplier="1:1" id="TNJ-xK-4Co"/>
@@ -2244,7 +2244,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="O7z-Si-jt2"/>
+        <segue reference="5UD-6W-Ykq"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="appsettings" width="21.333333969116211" height="21.333333969116211"/>

--- a/src/Catty/ViewController/CatrobatTableViewController/CatrobatTableViewController.m
+++ b/src/Catty/ViewController/CatrobatTableViewController/CatrobatTableViewController.m
@@ -323,10 +323,6 @@ NS_ENUM(NSInteger, ViewControllerIndex) {
         subtitleLabel.text = [self.cells objectAtIndex:indexPath.row];
         
         cell.iconImageView.image = [UIImage imageWithColor:UIColor.whiteColor];
-        [cell.iconImageView.layer setBorderColor: [[UIColor medium] CGColor]];
-        [cell.iconImageView.layer setBorderWidth: kPreviewImageBorderWidth];
-        cell.iconImageView.layer.cornerRadius = kPreviewImageCornerRadius;
-        cell.iconImageView.clipsToBounds = true;
         [cell setNeedsLayout];
     } else {
         cell.titleLabel.text = [self.cells objectAtIndex:indexPath.row];

--- a/src/Catty/ViewController/Download/ChartProjects/ChartProjectCell.swift
+++ b/src/Catty/ViewController/Download/ChartProjects/ChartProjectCell.swift
@@ -48,10 +48,6 @@ class ChartProjectCell: UITableViewCell {
 
     func updateTable() {
         chartProjectImage?.image = chartImage
-        chartProjectImage?.layer.borderColor = UIColor.medium.cgColor
-        chartProjectImage?.layer.borderWidth = CGFloat(kPreviewImageBorderWidth)
-        chartProjectImage?.layer.cornerRadius = CGFloat(kPreviewImageCornerRadius)
-        chartProjectImage?.clipsToBounds = true
 
         chartProjectTitle?.text = chartTitle
         chartProjectTitle.textColor = UIColor.globalTint

--- a/src/Catty/ViewController/Download/SearchStore/SearchStoreCell.swift
+++ b/src/Catty/ViewController/Download/SearchStore/SearchStoreCell.swift
@@ -48,10 +48,6 @@ class SearchStoreCell: UITableViewCell {
 
     func updateTable() {
         searchProjectImage?.image = searchImage
-        searchProjectImage?.layer.borderColor = UIColor.medium.cgColor
-        searchProjectImage?.layer.borderWidth = CGFloat(kPreviewImageBorderWidth)
-        searchProjectImage?.layer.cornerRadius = CGFloat(kPreviewImageCornerRadius)
-        searchProjectImage?.clipsToBounds = true
 
         searchProjectTitle?.text = searchTitle
         searchProjectTitle.textColor = UIColor.globalTint

--- a/src/Catty/ViewController/Projects/MyProjectsViewController.m
+++ b/src/Catty/ViewController/Projects/MyProjectsViewController.m
@@ -456,10 +456,6 @@
     cell.iconImageView.contentMode = UIViewContentModeScaleAspectFit;
     cell.iconImageView.image = nil;
     cell.indexPath = indexPath;
-    [cell.iconImageView.layer setBorderColor: [[UIColor medium] CGColor]];
-    [cell.iconImageView.layer setBorderWidth: kPreviewImageBorderWidth];
-    cell.iconImageView.layer.cornerRadius = kPreviewImageCornerRadius;
-    cell.iconImageView.clipsToBounds = true;
     [cell setNeedsLayout];
     
     CBFileManager *fileManager = [CBFileManager sharedManager];

--- a/src/Catty/Views/Custom/TableView/Cell/RoundedImageView.swift
+++ b/src/Catty/Views/Custom/TableView/Cell/RoundedImageView.swift
@@ -19,11 +19,12 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-
-@objc
-class UIDefines: NSObject {
-    @objc static let previewImageSize = CGSize(width: Int(kPreviewThumbnailWidth), height: Int(kPreviewThumbnailHeight))
-    static let defaultScreenshots = ["catrobat", "elephant", "lynx", "panda", "pingu", "racoon"]
-    static let kPreviewImageCornerRadius = 10.0
-    static let kPreviewImageBorderWidth = 1.0
+@objc class RoundedImageView: UIImageView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.layer.borderWidth = CGFloat(UIDefines.kPreviewImageBorderWidth)
+        self.layer.borderColor = UIColor.medium.cgColor
+        self.layer.cornerRadius = CGFloat(UIDefines.kPreviewImageCornerRadius)
+        self.clipsToBounds = true
+    }
 }

--- a/src/Catty/Views/Custom/TableView/Cell/RoundedImageView.swift
+++ b/src/Catty/Views/Custom/TableView/Cell/RoundedImageView.swift
@@ -19,12 +19,14 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-@objc class RoundedImageView: UIImageView {
+
+class RoundedImageView: UIImageView {
+
     override func layoutSubviews() {
         super.layoutSubviews()
-        self.layer.borderWidth = CGFloat(UIDefines.kPreviewImageBorderWidth)
+        self.layer.borderWidth = CGFloat(UIDefines.previewImageBorderWidth)
         self.layer.borderColor = UIColor.medium.cgColor
-        self.layer.cornerRadius = CGFloat(UIDefines.kPreviewImageCornerRadius)
+        self.layer.cornerRadius = CGFloat(UIDefines.previewImageCornerRadius)
         self.clipsToBounds = true
     }
 }


### PR DESCRIPTION
The preview images for Objects and Looks (as well as Backgrounds) should be rounded in the same way as the preview images for projects

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
