### PR TITLE
CATTY-439 Implement SetLookByIndexBrick

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -1644,6 +1644,11 @@
 		E592D1562539DD6A00B9F288 /* ArduinoSendDigitalValueBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592D1552539DD6A00B9F288 /* ArduinoSendDigitalValueBrickTests.swift */; };
 		E592D15A2539E16400B9F288 /* ArduinoSendPWMValueBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592D1592539E16400B9F288 /* ArduinoSendPWMValueBrickTests.swift */; };
 		E592D15C2539E1E300B9F288 /* IfThenLogicBeginBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592D15B2539E1E300B9F288 /* IfThenLogicBeginBrickTests.swift */; };
+		E5E1E5AA25780DA100D2F1BC /* SetLookByIndexBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E1E5A925780DA100D2F1BC /* SetLookByIndexBrick.swift */; };
+		E5E1E5AE25780E3200D2F1BC /* SetLookByIndexBrickCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E1E5AD25780E3200D2F1BC /* SetLookByIndexBrickCell.swift */; };
+		E5E1E5B025780F6500D2F1BC /* SetLookByIndexBrick+Instruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E1E5AF25780F6500D2F1BC /* SetLookByIndexBrick+Instruction.swift */; };
+		E5E1E5B2257810E300D2F1BC /* SetLookByIndexBrick+CBXMLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E1E5B1257810E300D2F1BC /* SetLookByIndexBrick+CBXMLHandler.swift */; };
+		E5E1E5B42578117400D2F1BC /* SetLookByIndexBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E1E5B32578117400D2F1BC /* SetLookByIndexBrickTests.swift */; };
 		F411560320E7732D00E2F254 /* InternFormula+KeyboardAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F411560220E7732D00E2F254 /* InternFormula+KeyboardAdapter.swift */; };
 		F4201CF220D795DB0030181B /* DateWeekdaySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4201CF120D795DB0030181B /* DateWeekdaySensor.swift */; };
 		F4201CF920D79CA80030181B /* TimeHourSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4201CF820D79CA80030181B /* TimeHourSensor.swift */; };
@@ -3894,6 +3899,11 @@
 		E592D1552539DD6A00B9F288 /* ArduinoSendDigitalValueBrickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArduinoSendDigitalValueBrickTests.swift; sourceTree = "<group>"; };
 		E592D1592539E16400B9F288 /* ArduinoSendPWMValueBrickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArduinoSendPWMValueBrickTests.swift; sourceTree = "<group>"; };
 		E592D15B2539E1E300B9F288 /* IfThenLogicBeginBrickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IfThenLogicBeginBrickTests.swift; sourceTree = "<group>"; };
+		E5E1E5A925780DA100D2F1BC /* SetLookByIndexBrick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetLookByIndexBrick.swift; sourceTree = "<group>"; };
+		E5E1E5AD25780E3200D2F1BC /* SetLookByIndexBrickCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetLookByIndexBrickCell.swift; sourceTree = "<group>"; };
+		E5E1E5AF25780F6500D2F1BC /* SetLookByIndexBrick+Instruction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SetLookByIndexBrick+Instruction.swift"; sourceTree = "<group>"; };
+		E5E1E5B1257810E300D2F1BC /* SetLookByIndexBrick+CBXMLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SetLookByIndexBrick+CBXMLHandler.swift"; sourceTree = "<group>"; };
+		E5E1E5B32578117400D2F1BC /* SetLookByIndexBrickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetLookByIndexBrickTests.swift; sourceTree = "<group>"; };
 		EACB63B95D9C0A7F1388E4F3 /* id */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/Localizable.strings; sourceTree = "<group>"; };
 		EC696D21025B1BA13FAA0039 /* he */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/Localizable.strings; sourceTree = "<group>"; };
 		ED43A997870B76068912C26D /* pt-BR */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -5907,6 +5917,7 @@
 				4C0F9F6C204BD1A300E71B2D /* ThinkBubbleBrick+CBXMLHandler.m */,
 				4C0F9F6A204BD1A200E71B2D /* ThinkForBubbleBrick+CBXMLHandler.h */,
 				4C0F9F6D204BD1A300E71B2D /* ThinkForBubbleBrick+CBXMLHandler.m */,
+				E5E1E5B1257810E300D2F1BC /* SetLookByIndexBrick+CBXMLHandler.swift */,
 			);
 			name = Look;
 			path = LookBricks;
@@ -6685,6 +6696,7 @@
 				E579F117253DCC65009107C8 /* ThinkForBubbleBrickTests.swift */,
 				E579F119253DCD90009107C8 /* ChangeXByNBrickTests.swift */,
 				E579F11B253DCE2C009107C8 /* ChangeYByNBrickTests.swift */,
+				E5E1E5B32578117400D2F1BC /* SetLookByIndexBrickTests.swift */,
 			);
 			path = Bricks;
 			sourceTree = "<group>";
@@ -8730,6 +8742,7 @@
 				AAF6D9D71BC0BAF300686849 /* ShowBrick+Instruction.swift */,
 				4C0F9F7E204BD1F700E71B2D /* ThinkBubbleBrick+Instruction.swift */,
 				4C0F9F7D204BD1F700E71B2D /* ThinkForBubbleBrick+Instruction.swift */,
+				E5E1E5AF25780F6500D2F1BC /* SetLookByIndexBrick+Instruction.swift */,
 			);
 			name = Look;
 			sourceTree = "<group>";
@@ -8849,6 +8862,7 @@
 				4C0F9F3F204ADC6600E71B2D /* ThinkBubbleBrick.m */,
 				4C0F9F40204ADC6600E71B2D /* ThinkForBubbleBrick.h */,
 				4C0F9F3E204ADC6600E71B2D /* ThinkForBubbleBrick.m */,
+				E5E1E5A925780DA100D2F1BC /* SetLookByIndexBrick.swift */,
 			);
 			path = Look;
 			sourceTree = "<group>";
@@ -9088,6 +9102,7 @@
 				4C0F9FA2204BD2C200E71B2D /* ThinkBubbleBrickCell.m */,
 				4C0F9FA4204BD2C200E71B2D /* ThinkForBubbleBrickCell.h */,
 				4C0F9FA1204BD2C100E71B2D /* ThinkForBubbleBrickCell.m */,
+				E5E1E5AD25780E3200D2F1BC /* SetLookByIndexBrickCell.swift */,
 			);
 			path = Look;
 			sourceTree = "<group>";
@@ -10611,6 +10626,7 @@
 				4C3A5CAB21D3B967008FD83F /* SmallerThanOperatorTest.swift in Sources */,
 				4C822653213FA7A400F3D750 /* ObjectDoubleSensorMock.swift in Sources */,
 				9EBCBD872329BD700074C2D9 /* PointInDirectionBrickTests.swift in Sources */,
+				E5E1E5B42578117400D2F1BC /* SetLookByIndexBrickTests.swift in Sources */,
 				E592D1562539DD6A00B9F288 /* ArduinoSendDigitalValueBrickTests.swift in Sources */,
 				4C822691213FBB8300F3D750 /* MultiFingerTouchedFunctionTests.swift in Sources */,
 				4CF8277424F1172E006E562A /* StoryboardMock.swift in Sources */,
@@ -11085,6 +11101,7 @@
 				92FF31491A24DEB300093DA7 /* BaseCollectionViewController.m in Sources */,
 				4647D55A23D8AF9F001A67F6 /* PrivacyPolicyViewController.swift in Sources */,
 				46D0516324F8147F00A79155 /* SetRotationStyleBrick+CBXMLHandler.swift in Sources */,
+				E5E1E5AE25780E3200D2F1BC /* SetLookByIndexBrickCell.swift in Sources */,
 				BA987D0D2194E647002DAA05 /* WaitUntilBrick+Condition.swift in Sources */,
 				59EA52B424FCD1E800AC6E8D /* WhenBackgroundChangesScript.swift in Sources */,
 				92D56C321BF202E700A54750 /* ArduinoHelper.swift in Sources */,
@@ -11327,6 +11344,7 @@
 				4C0F9F7A204BD1E300E71B2D /* SayBubbleBrick+Instruction.swift in Sources */,
 				9E2C2D862325673C004B66C6 /* AudioEngine.swift in Sources */,
 				6FAD028624C838E700C50710 /* UploadCategoryViewController.swift in Sources */,
+				E5E1E5B2257810E300D2F1BC /* SetLookByIndexBrick+CBXMLHandler.swift in Sources */,
 				186AA3442482DDD5001E38FD /* PenDownBrick+Instruction.swift in Sources */,
 				18E83F812493C32C003295DA /* PenClearBrick+Instruction.swift in Sources */,
 				5EF590BA2192D81F00C19F12 /* DoubleExtension.swift in Sources */,
@@ -11380,6 +11398,7 @@
 				9E2AEA52239888C100CDF58F /* PlaySoundAndWaitBrick+Instruction.swift in Sources */,
 				92DFB0191A38949E00FA9B0F /* InternToExternGenerator.m in Sources */,
 				AA74EEE31BC057B900D1E954 /* NoteBrick+CBXMLHandler.m in Sources */,
+				E5E1E5B025780F6500D2F1BC /* SetLookByIndexBrick+Instruction.swift in Sources */,
 				4CF0729A20D66C4800F93AB5 /* BackgroundNumberSensor.swift in Sources */,
 				6F4B2FB72466704500B5F0ED /* ProjectMigrator.swift in Sources */,
 				4C724E5A1B4D3E8C00E27479 /* Project+CBXMLHandler.m in Sources */,
@@ -11387,6 +11406,7 @@
 				6FB09D2324A29F1E009C69A0 /* StoreProjectUploader.swift in Sources */,
 				92FF30FB1A24DCAA00093DA7 /* InternFormulaParserException.m in Sources */,
 				4C1C8B14213FE76B003B3AA4 /* ChartProjectCell.swift in Sources */,
+				E5E1E5AA25780DA100D2F1BC /* SetLookByIndexBrick.swift in Sources */,
 				4CF072A820D6710F00F93AB5 /* FingerXSensor.swift in Sources */,
 				4CE3D68B2107A89B00005629 /* FaceDetectionManager.swift in Sources */,
 				AA74EFF71BC05B5F00D1E954 /* SetLookBrick.m in Sources */,

--- a/src/Catty/DataModel/Bricks/Look/SetLookByIndexBrick.swift
+++ b/src/Catty/DataModel/Bricks/Look/SetLookByIndexBrick.swift
@@ -1,0 +1,76 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+@objc(SetLookByIndexBrick)
+
+@objcMembers class SetLookByIndexBrick: Brick, BrickProtocol, BrickFormulaProtocol {
+
+    var lookIndex: Formula?
+
+    override required init() {
+        super.init()
+    }
+
+    func category() -> kBrickCategoryType {
+        kBrickCategoryType.lookBrick
+    }
+
+    override class func description() -> String {
+        "SetLookByIndexBrick"
+    }
+
+    override func getRequiredResources() -> Int {
+        ResourceType.noResources.rawValue
+    }
+
+    override func brickCell() -> BrickCellProtocol.Type! {
+        SetLookByIndexBrickCell.self as BrickCellProtocol.Type
+    }
+
+    func formula(forLineNumber lineNumber: Int, andParameterNumber paramNumber: Int) -> Formula! {
+        self.lookIndex
+    }
+
+    func setFormula(_ formula: Formula!, forLineNumber lineNumber: Int, andParameterNumber paramNumber: Int) {
+        self.lookIndex = formula
+    }
+
+    func getFormulas() -> [Formula]! {
+        [lookIndex!]
+    }
+
+    override func setDefaultValuesFor(_ spriteObject: SpriteObject!) {
+        self.lookIndex = Formula(integer: kBackgroundObjects)
+    }
+
+    func allowsStringFormula() -> Bool {
+        false
+    }
+
+    override func isDisabledForBackground() -> Bool {
+        true
+    }
+
+    func pathForLook(look: Look?) -> String? {
+        look?.path(for: script.object.scene)
+    }
+}

--- a/src/Catty/Defines/LanguageTranslationDefines.h
+++ b/src/Catty/Defines/LanguageTranslationDefines.h
@@ -424,6 +424,7 @@
 #define kLocalizedAndStoreWrittenAnswerIn NSLocalizedString(@"and store written answer in ", nil)
 #define kLocalizedDefaultAskBrickQuestion NSLocalizedString(@"What's your name?", nil)
 #define kLocalizedAskBrickAnswer NSLocalizedString(@"Your answer", nil)
+#define kLocalizedSwitchToLookWithNumber NSLocalizedString(@"Switch to look with number", nil)
 
 // pen bricks
 #define kLocalizedPenDown NSLocalizedString(@"Pen down", nil)

--- a/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
+++ b/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
@@ -424,6 +424,7 @@ let kLocalizedAsk = NSLocalizedString("Ask ", comment: "")
 let kLocalizedAndStoreWrittenAnswerIn = NSLocalizedString("and store written answer in ", comment: "")
 let kLocalizedDefaultAskBrickQuestion = NSLocalizedString("What's your name?", comment: "")
 let kLocalizedAskBrickAnswer = NSLocalizedString("Your answer", comment: "")
+let kLocalizedSwitchToLookWithNumber = NSLocalizedString("Switch to look with number", comment: "")
 
 // pen bricks
 let kLocalizedPenDown = NSLocalizedString("Pen down", comment: "")

--- a/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/LookBricks/SetLookByIndexBrick+CBXMLHandler.swift
+++ b/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/LookBricks/SetLookByIndexBrick+CBXMLHandler.swift
@@ -1,0 +1,42 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+extension SetLookByIndexBrick: CBXMLNodeProtocol {
+
+    static func parse(from xmlElement: GDataXMLElement, with context: CBXMLParserContext) -> Self {
+        CBXMLParserHelper.validate(xmlElement, forNumberOfChildNodes: 1, andFormulaListWithTotalNumberOfFormulas: 1)
+        let formula = CBXMLParserHelper.formula(in: xmlElement, forCategoryName: "LOOK_INDEX", with: context)
+        let brick = self.init()
+        brick.lookIndex = formula
+        return brick
+    }
+
+    func xmlElement(with context: CBXMLSerializerContext) -> GDataXMLElement? {
+        let brick = super.xmlElement(for: "SetLookByIndexBrick", with: context)
+        let formulaList = GDataXMLElement(name: "formulaList", context: context)
+        let formula = self.lookIndex?.xmlElement(with: context)
+        formula?.addAttribute(GDataXMLElement(name: "category", stringValue: "LOOK_INDEX", context: nil))
+        formulaList?.addChild(formula, context: context)
+        brick?.addChild(formulaList, context: context)
+        return brick
+    }
+}

--- a/src/Catty/PlayerEngine/DataModel/CBSpriteNode/CBSpriteNode.swift
+++ b/src/Catty/PlayerEngine/DataModel/CBSpriteNode/CBSpriteNode.swift
@@ -168,6 +168,10 @@ class CBSpriteNode: SKSpriteNode {
         return spriteObject.lookList[index] as? Look
     }
 
+    @objc func getLookList() -> NSMutableArray? {
+        spriteObject.lookList
+    }
+
     @objc func changeLook(_ look: Look?) {
         guard let look = look,
             let filePathForLook = look.path(for: spriteObject.scene),

--- a/src/Catty/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en.lproj/Localizable.strings
@@ -1592,6 +1592,9 @@
 "Switch to look" = "Switch to look";
 
 /* No comment provided by engineer. */
+"Switch to look with number" = "Switch to look with number";
+
+/* No comment provided by engineer. */
 "Syntax Error!" = "Syntax Error!";
 
 /* No comment provided by engineer. */

--- a/src/Catty/SetLookByIndexBrick+Instruction.swift
+++ b/src/Catty/SetLookByIndexBrick+Instruction.swift
@@ -1,0 +1,60 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+extension SetLookByIndexBrick: CBInstructionProtocol {
+
+    func instruction() -> CBInstruction {
+        .action { context in SKAction.run(self.actionBlock(context.formulaInterpreter)) }
+    }
+
+    func actionBlock(_ formulaInterpreter: FormulaInterpreterProtocol) -> () -> Void {
+        guard let object = self.script?.object,
+            let spriteNode = object.spriteNode,
+            let formula = self.lookIndex,
+            let lookList = spriteNode.getLookList()
+            else { fatalError("This should never happen!") }
+
+        return {
+            let lookCount = lookList.count
+            let lookIndex = formulaInterpreter.interpretInteger(formula, for: object)
+            if  lookIndex < 1 || lookIndex > lookCount {
+                return
+            }
+
+            let cache = RuntimeImageCache.shared()
+            let lookAtIndex = lookList.object(at: lookIndex - 1) as? Look
+            var image = cache?.cachedImage(forPath: self.pathForLook(look: lookAtIndex))
+
+            if image == nil {
+                cache?.loadImageFromDisk(withPath: self.pathForLook(look: lookAtIndex))
+                if let look = self.pathForLook(look: lookAtIndex) {
+                    guard let imageFromDisk = UIImage(contentsOfFile: look) else { return }
+                    image = imageFromDisk
+                } else {
+                    return
+                }
+            }
+            spriteNode.currentLook = lookAtIndex
+            spriteNode.executeFilter(image)
+        }
+    }
+}

--- a/src/Catty/Setup/CatrobatSetup+Bricks.swift
+++ b/src/Catty/Setup/CatrobatSetup+Bricks.swift
@@ -66,8 +66,9 @@
             SetRotationStyleBrick(),
             // look bricks
             HideBrick(),
-            SetLookBrick(),
             ShowBrick(),
+            SetLookBrick(),
+            SetLookByIndexBrick(),
             SetSizeToBrick(),
             SetTransparencyBrick(),
             NextLookBrick(),

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetLookByIndexBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetLookByIndexBrickCell.swift
@@ -1,0 +1,52 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+class SetLookByIndexBrickCell: BrickCell, BrickCellProtocol {
+
+    var textLabel: UILabel?
+    var textField: UITextField?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    static func cellHeight() -> CGFloat {
+        CGFloat(kBrickHeight1h)
+    }
+
+    func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {
+        kLocalizedSwitchToLookWithNumber + " %@"
+    }
+
+    override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {
+        self.textLabel = inlineViewSubViews[0] as? UILabel
+        self.textField = inlineViewSubViews[1] as? UITextField
+    }
+
+    override func parameters() -> [String]! {
+        NSArray.init(objects: "{INTEGER;range=(0,inf)}") as? [String]
+    }
+}

--- a/src/CattyTests/Bricks/SetLookByIndexBrickTests.swift
+++ b/src/CattyTests/Bricks/SetLookByIndexBrickTests.swift
@@ -1,0 +1,138 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+@testable import Pocket_Code
+
+final class SetLookByIndexBrickTest: XCTestCase {
+
+    var project: Project!
+    var spriteObject: SpriteObject!
+    var spriteNode: CBSpriteNode!
+    var script: Script!
+    var brick: SetLookByIndexBrick!
+    var formulaInterpreter: FormulaInterpreterProtocol!
+
+    var look: Look!
+    var look2: Look!
+    var look3: Look!
+    var look4: Look!
+
+    override func setUp() {
+        project = ProjectManager.createProject(name: "setLookByIndexTest", projectId: "1")
+        spriteObject = SpriteObject()
+        spriteObject.scene = project.scene
+        spriteObject.name = "SpriteObjectName"
+
+        spriteNode = CBSpriteNode(spriteObject: spriteObject)
+        spriteObject.spriteNode = spriteNode
+
+        script = Script()
+        script.object = spriteObject
+
+        formulaInterpreter = FormulaManager(stageSize: Util.screenSize(true), landscapeMode: false)
+
+        let bundle = Bundle(for: type(of: self))
+        let filePath = bundle.path(forResource: "test.png", ofType: nil)
+        let imageData = UIImage(contentsOfFile: filePath!)!.pngData()
+
+        do {
+            look = Look(name: "test", filePath: "test.png")
+            try imageData?.write(to: URL(fileURLWithPath: spriteObject.scene.imagesPath()! + "/test.png"))
+            look2 = Look(name: "test2", filePath: "test2.png")
+            try imageData?.write(to: URL(fileURLWithPath: spriteObject.scene.imagesPath()! + "/test2.png"))
+            look3 = Look(name: "test3", filePath: "test3.png")
+            try imageData?.write(to: URL(fileURLWithPath: spriteObject.scene.imagesPath()! + "/test3.png"))
+            look4 = Look(name: "test4", filePath: "invalid.png")
+        } catch {
+            XCTFail("Error when writing image data")
+        }
+
+        brick = SetLookByIndexBrick()
+        brick.script = script
+
+        spriteObject.lookList.add(look!)
+        spriteObject.lookList.add(look2!)
+        spriteObject.lookList.add(look3!)
+        spriteObject.spriteNode.currentLook = look
+        spriteObject.spriteNode.currentUIImageLook = UIImage(contentsOfFile: filePath!)
+    }
+
+    func testSetLookByValidIndex() {
+        brick.lookIndex = Formula(integer: 3)
+
+        var action = brick.actionBlock(formulaInterpreter)
+        action()
+        XCTAssertEqual(spriteNode.currentLook, look3, "setLookByIndex look was not set correctly")
+
+        brick.lookIndex = Formula(integer: 2)
+        action = brick.actionBlock(formulaInterpreter)
+        action()
+        XCTAssertEqual(spriteNode.currentLook, look2, "setLookByIndex look was not set correctly")
+
+        brick.lookIndex = Formula(integer: 1)
+        action = brick.actionBlock(formulaInterpreter)
+        action()
+        XCTAssertEqual(spriteNode.currentLook, look, "setLookByIndex look was not set correctly")
+    }
+
+    func testSetLookByInvalidIndex() {
+        brick.lookIndex = Formula(integer: 3)
+
+        var action = brick.actionBlock(formulaInterpreter)
+        action()
+        XCTAssertEqual(spriteNode.currentLook, look3, "setLookByIndex look was not set correctly")
+
+        brick.lookIndex = Formula(integer: 0)
+        action = brick.actionBlock(formulaInterpreter)
+        action()
+        XCTAssertEqual(spriteNode.currentLook, look3, "setLookByIndex look was not set correctly")
+
+        brick.lookIndex = Formula(integer: 5)
+        action = brick.actionBlock(formulaInterpreter)
+        action()
+        XCTAssertEqual(spriteNode.currentLook, look3, "setLookByIndex look was not set correctly")
+    }
+
+    func testSetLookByInvalidImagePath() {
+        brick.lookIndex = Formula(integer: 3)
+
+        var action = brick.actionBlock(formulaInterpreter)
+        action()
+        XCTAssertEqual(spriteNode.currentLook, look3, "setLookByIndex look was not set correctly")
+
+        brick.lookIndex = Formula(integer: 4)
+        action = brick.actionBlock(formulaInterpreter)
+        action()
+        XCTAssertEqual(spriteNode.currentLook, look3, "setLookByIndex look was not set correctly")
+    }
+
+    func testMutableCopy() {
+        let brick = SetLookByIndexBrick()
+
+        let copiedBrick: SetLookByIndexBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! SetLookByIndexBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+    }
+}

--- a/src/CattyTests/Resources/ParserTests/Custom/ValidProjectAllBricks/ValidProjectAllBricks0991.xml
+++ b/src/CattyTests/Resources/ParserTests/Custom/ValidProjectAllBricks/ValidProjectAllBricks0991.xml
@@ -247,6 +247,15 @@
                       <brick type="NextLookBrick">
                           <commentedOut>false</commentedOut>
                       </brick>
+                      <brick type="SetLookByIndexBrick">
+                        <commentedOut>false</commentedOut>
+                        <formulaList>
+                          <formula category="LOOK_INDEX">
+                            <type>NUMBER</type>
+                            <value>1</value>
+                          </formula>
+                        </formulaList>
+                      </brick>
                       <brick type="SetSizeToBrick">
                         <commentedOut>false</commentedOut>
                         <formulaList>

--- a/src/CattyTests/Resources/ParserTests/Custom/ValidProjectAllBricks/ValidProjectAllBricks0992.xml
+++ b/src/CattyTests/Resources/ParserTests/Custom/ValidProjectAllBricks/ValidProjectAllBricks0992.xml
@@ -250,6 +250,15 @@
                           <brick type="NextLookBrick">
                             <commentedOut>false</commentedOut>
                           </brick>
+                          <brick type="SetLookByIndexBrick">
+                            <commentedOut>false</commentedOut>
+                            <formulaList>
+                              <formula category="LOOK_INDEX">
+                                <type>NUMBER</type>
+                                <value>1</value>
+                              </formula>
+                            </formulaList>
+                          </brick>
                           <brick type="SetSizeToBrick">
                             <commentedOut>false</commentedOut>
                             <formulaList>

--- a/src/CattyTests/Resources/ParserTests/Custom/ValidProjectAllBricks/ValidProjectAllBricks0993.xml
+++ b/src/CattyTests/Resources/ParserTests/Custom/ValidProjectAllBricks/ValidProjectAllBricks0993.xml
@@ -250,6 +250,15 @@
                           <brick type="NextLookBrick">
                             <commentedOut>false</commentedOut>
                           </brick>
+                          <brick type="SetLookByIndexBrick">
+                            <commentedOut>false</commentedOut>
+                            <formulaList>
+                              <formula category="LOOK_INDEX">
+                                <type>NUMBER</type>
+                                <value>1</value>
+                              </formula>
+                            </formulaList>
+                          </brick>
                           <brick type="SetSizeToBrick">
                             <commentedOut>false</commentedOut>
                             <formulaList>

--- a/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
+++ b/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
@@ -424,6 +424,7 @@ let kLocalizedAsk = NSLocalizedString("Ask ", bundle: Bundle(for: LanguageTransl
 let kLocalizedAndStoreWrittenAnswerIn = NSLocalizedString("and store written answer in ", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedDefaultAskBrickQuestion = NSLocalizedString("What's your name?", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedAskBrickAnswer = NSLocalizedString("Your answer", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kLocalizedSwitchToLookWithNumber = NSLocalizedString("Switch to look with number", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 
 // pen bricks
 let kLocalizedPenDown = NSLocalizedString("Pen down", bundle: Bundle(for: LanguageTranslation.self), comment: "")


### PR DESCRIPTION
Implemented a new Brick called "SetLookByIndexBrick". This Brick changes the Look of the current SpriteObject to a look identified by a given number.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [X] Include the name of the Jira ticket in the PR’s title
- [X] Verify that the Jira ticket is in the status *Ready for Development*
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Stick to the project’s git workflow (rebase and squash your commits)
- [X] Verify that your changes do not have any conflicts with the base branch
- [X] After the PR, verify that all CI checks have passed
- [X] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
