### PR TITLE
CATTY-251 Extension for URLSession

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -1260,6 +1260,8 @@
 		92FF32C31A24E33B00093DA7 /* iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 92FF32C21A24E33B00093DA7 /* iPhone.storyboard */; };
 		97B1FCFF2577BCD700E9C446 /* DisabledBricks_0993.xml in Resources */ = {isa = PBXBuildFile; fileRef = 4C3285D92546CDF200C31F9D /* DisabledBricks_0993.xml */; };
 		97D015912553392A00B6967D /* RoundedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D0158E2553392A00B6967D /* RoundedImageView.swift */; };
+		97D97BAB257AC141001FF344 /* URLSessionMultipartExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D97BAA257AC141001FF344 /* URLSessionMultipartExtension.swift */; };
+		97D97BB0257AC735001FF344 /* URLSessionMultipartExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D97BAE257AC6DD001FF344 /* URLSessionMultipartExtensionTests.swift */; };
 		99B2C36B1D884C1300736769 /* FlashBrick+CBXMLHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 99B2C36A1D884C1300736769 /* FlashBrick+CBXMLHandler.m */; };
 		99B2C3701D884D2900736769 /* FlashBrick.m in Sources */ = {isa = PBXBuildFile; fileRef = 99B2C36F1D884D2900736769 /* FlashBrick.m */; };
 		99B2C3731D884E8A00736769 /* FlashBrickCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 99B2C3721D884E8A00736769 /* FlashBrickCell.m */; };
@@ -3409,6 +3411,8 @@
 		95088280A879E5F515D4569E /* fa-AF */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = "fa-AF"; path = "fa-AF.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		95C607797206029F5B454A53 /* sw */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = sw; path = sw.lproj/Localizable.strings; sourceTree = "<group>"; };
 		97D0158E2553392A00B6967D /* RoundedImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RoundedImageView.swift; path = Catty/Views/Custom/TableView/Cell/RoundedImageView.swift; sourceTree = SOURCE_ROOT; };
+		97D97BAA257AC141001FF344 /* URLSessionMultipartExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMultipartExtension.swift; sourceTree = "<group>"; };
+		97D97BAE257AC6DD001FF344 /* URLSessionMultipartExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMultipartExtensionTests.swift; sourceTree = "<group>"; };
 		97FD56903AF79540DDE45F42 /* tl */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = tl; path = tl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		98738650BC99C8766A159B17 /* ko */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9990BB6C1D89D89A0088357A /* BrickStaticChoiceProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BrickStaticChoiceProtocol.h; sourceTree = "<group>"; };
@@ -8001,6 +8005,7 @@
 				222A693D247EA490004BE434 /* UIDeviceExtension.swift */,
 				2219ED89251745EA00EBA379 /* NSMutableArrayExtension.swift */,
 				184CA798249E839A00D3668B /* CBFileManagerExtension.swift */,
+				97D97BAA257AC141001FF344 /* URLSessionMultipartExtension.swift */,
 			);
 			name = Extensions;
 			path = "Extension&Delegate&Protocol/Extensions";
@@ -10180,6 +10185,7 @@
 				1858252A24D1A5E300092407 /* UIColorExtensionTests.swift */,
 				4CB562FB24EA95C40000A5A9 /* UIViewControllerExtensionTests.swift */,
 				2219ED92251DDB7E00EBA379 /* NSMutableArrayExtensionTests.swift */,
+				97D97BAE257AC6DD001FF344 /* URLSessionMultipartExtensionTests.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -11525,6 +11531,7 @@
 				46F1754E24C46837006B2ACA /* ScriptCollectionViewControllerTests.swift in Sources */,
 				4C82265B213FA7A400F3D750 /* ObjectStringSensorMock.swift in Sources */,
 				440B1D59250FE6B10041CC7D /* AskBrickTests.swift in Sources */,
+				97D97BB0257AC735001FF344 /* URLSessionMultipartExtensionTests.swift in Sources */,
 				9E4D2386232AE9E5009D0C3C /* GoNStepsBackBrickTests.swift in Sources */,
 				4CEB22751B95E4BC00B3BE2F /* BrickInsertManagerLogicTests.m in Sources */,
 				4C82265D213FA7A400F3D750 /* FingerYSensorTest.swift in Sources */,
@@ -12010,6 +12017,7 @@
 				4647D55A23D8AF9F001A67F6 /* PrivacyPolicyViewController.swift in Sources */,
 				46D0516324F8147F00A79155 /* SetRotationStyleBrick+CBXMLHandler.swift in Sources */,
 				BA987D0D2194E647002DAA05 /* WaitUntilBrick+Condition.swift in Sources */,
+				97D97BAB257AC141001FF344 /* URLSessionMultipartExtension.swift in Sources */,
 				59EA52B424FCD1E800AC6E8D /* WhenBackgroundChangesScript.swift in Sources */,
 				92D56C321BF202E700A54750 /* ArduinoHelper.swift in Sources */,
 				AAAF22881BC0CFC00076F11E /* TurnLeftBrick+Instruction.swift in Sources */,

--- a/src/Catty/Extension&Delegate&Protocol/Extensions/URLSessionMultipartExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/URLSessionMultipartExtension.swift
@@ -1,0 +1,105 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+extension URLSession {
+
+    static var httpBoundary = "---------------------------98598263596598246508247098291---------------------------"
+
+    public func multipartUploadTask(with url: URL, from formData: [FormData], attachmentData: [AttachmentData],
+                                    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+
+        var body = Data()
+
+        for parameter in formData {
+            setFormDataParameter(parameter, forHTTPBody: &body)
+        }
+
+        for attachment in attachmentData {
+            setAttachmentParameter(attachment, forHTTPBody: &body)
+        }
+
+        if let anEncoding = "--\(URLSession.httpBoundary)--\r\n".data(using: .utf8) {
+            body.append(anEncoding)
+        }
+
+        request.httpBody = body
+        let postLength = String(format: "%lu", UInt(body.count))
+        request.addValue(postLength, forHTTPHeaderField: "Content-Length")
+
+        let task = self.dataTask(with: request, completionHandler: completionHandler)
+        return task
+    }
+
+    private func setFormDataParameter(_ formData: FormData, forHTTPBody body: inout Data) {
+        let data = formData.value.data(using: .utf8)
+        if let anEncoding = "--\(URLSession.httpBoundary)\r\n".data(using: .utf8) {
+            body.append(anEncoding)
+        }
+        let parameterString = "Content-Disposition: form-data; name=\"\(formData.name)\"\r\n\r\n"
+        if let anEncoding = parameterString.data(using: .utf8) {
+            body.append(anEncoding)
+        }
+        if let aData = data {
+            body.append(aData)
+        }
+        if let anEncoding = "\r\n".data(using: .utf8) {
+            body.append(anEncoding)
+        }
+    }
+
+    private func setAttachmentParameter(_ attachmentData: AttachmentData, forHTTPBody body: inout Data) {
+        if let anEncoding = "--\(URLSession.httpBoundary)\r\n".data(using: .utf8) {
+            body.append(anEncoding)
+        }
+
+        var parameterString = "Content-Disposition: attachment; name=\"\(attachmentData.name)\""
+        if let filename = attachmentData.filename {
+            parameterString += "; filename=\"" + filename + "\""
+        }
+        parameterString += " \r\n"
+
+        if let anEncoding = parameterString.data(using: .utf8) {
+            body.append(anEncoding)
+        }
+        if let anEncoding = "Content-Type: application/octet-stream\r\n\r\n".data(using: .utf8) {
+            body.append(anEncoding)
+        }
+        body.append(attachmentData.data)
+        if let anEncoding = "\r\n".data(using: .utf8) {
+            body.append(anEncoding)
+        }
+    }
+}
+
+public struct FormData {
+    let name: String
+    let value: String
+}
+
+public struct AttachmentData {
+    let name: String
+    let data: Data
+    let filename: String?
+}

--- a/src/Catty/Extension&Delegate&Protocol/Extensions/URLSessionMultipartExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/URLSessionMultipartExtension.swift
@@ -30,6 +30,9 @@ extension URLSession {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
 
+        let contentType = "multipart/form-data; boundary=\(type(of: self).httpBoundary)"
+        request.addValue(contentType, forHTTPHeaderField: "Content-Type")
+
         var body = Data()
 
         for parameter in formData {

--- a/src/CattyTests/URLSessionMultipartExtensionTests.swift
+++ b/src/CattyTests/URLSessionMultipartExtensionTests.swift
@@ -1,0 +1,130 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+@testable import Pocket_Code
+
+final class URLSessionMultipartExtensionTests: XCTestCase {
+
+    var urlSession: URLSession!
+    var url: URL!
+    let uploadParameterTag = "upload"
+    let projectNameTag = "projectTitle"
+    let projectDescriptionTag = "projectDescription"
+    var expectedZippedProjectData: Data!
+
+    override func setUp() {
+        self.urlSession = URLSession.shared
+        self.url = URL(string: NetworkDefines.uploadUrl)!
+        self.expectedZippedProjectData = "zippedProjectData".data(using: .utf8)
+    }
+
+    func testMultipartUploadTask() {
+        let projectName = "testProjectName"
+        let projectDescription = "testProjectDescription"
+        let filename = "testFilename.zip"
+
+        let formData = [FormData(name: projectNameTag, value: projectName),
+                        FormData(name: projectDescriptionTag, value: projectDescription)]
+
+        let attachmentData = [AttachmentData(name: uploadParameterTag, data: expectedZippedProjectData, filename: filename)]
+
+        let expectedMinimumSize = projectNameTag.count + projectName.count + projectDescriptionTag.count +
+            projectDescription.count + uploadParameterTag.count + expectedZippedProjectData.count + filename.count +
+            URLSession.httpBoundary.count * 4
+
+        let task = self.urlSession!.multipartUploadTask(with: url,
+                                                        from: formData,
+                                                        attachmentData: attachmentData,
+                                                        completionHandler: { data, response, error in
+                                                            XCTAssertNotNil(data)
+                                                            XCTAssertNotNil(response)
+                                                            XCTAssertNil(error)
+        })
+
+        XCTAssertEqual("POST", task.originalRequest?.httpMethod)
+        XCTAssertTrue(Int(task.originalRequest!.allHTTPHeaderFields!["Content-Length"]!)! >= expectedMinimumSize)
+
+        let request = String(decoding: task.originalRequest!.httpBody!, as: UTF8.self)
+
+        XCTAssertEqual(4, request.components(separatedBy: URLSession.httpBoundary).count - 1)
+        XCTAssertTrue(request.contains(projectNameTag))
+        XCTAssertTrue(request.contains(projectName))
+        XCTAssertTrue(request.contains(projectDescriptionTag))
+        XCTAssertTrue(request.contains(projectDescription))
+        XCTAssertTrue(request.contains(uploadParameterTag))
+        XCTAssertTrue(request.contains("filename=\"" + filename + "\""))
+        XCTAssertTrue(request.contains(String(decoding: expectedZippedProjectData, as: UTF8.self)))
+    }
+
+    func testMultipartUploadTaskWithAttachmentWithoutFilename() {
+        let projectName = "testProjectName"
+
+        let formData = [FormData(name: projectNameTag, value: projectName)]
+        let attachmentData = [AttachmentData(name: uploadParameterTag, data: expectedZippedProjectData, filename: nil)]
+
+        let task = self.urlSession!.multipartUploadTask(with: url,
+                                                        from: formData,
+                                                        attachmentData: attachmentData,
+                                                        completionHandler: { data, response, error in
+                                                            XCTAssertNotNil(data)
+                                                            XCTAssertNotNil(response)
+                                                            XCTAssertNil(error)
+        })
+
+        XCTAssertEqual("POST", task.originalRequest?.httpMethod)
+
+        let request = String(decoding: task.originalRequest!.httpBody!, as: UTF8.self)
+
+        XCTAssertEqual(3, request.components(separatedBy: URLSession.httpBoundary).count - 1)
+        XCTAssertTrue(request.contains(projectNameTag))
+        XCTAssertTrue(request.contains(projectName))
+        XCTAssertTrue(request.contains(uploadParameterTag))
+        XCTAssertFalse(request.contains("filename=\""))
+        XCTAssertTrue(request.contains(String(decoding: expectedZippedProjectData, as: UTF8.self)))
+    }
+
+    func testMultipartUploadTaskWithoutAttachments() {
+        let projectName = "testProjectName"
+
+        let formData = [FormData(name: projectNameTag, value: projectName)]
+
+        let task = self.urlSession!.multipartUploadTask(with: url,
+                                                        from: formData,
+                                                        attachmentData: [],
+                                                        completionHandler: { data, response, error in
+                                                            XCTAssertNotNil(data)
+                                                            XCTAssertNotNil(response)
+                                                            XCTAssertNil(error)
+        })
+
+        XCTAssertEqual("POST", task.originalRequest?.httpMethod)
+
+        let request = String(decoding: task.originalRequest!.httpBody!, as: UTF8.self)
+
+        XCTAssertEqual(2, request.components(separatedBy: URLSession.httpBoundary).count - 1)
+        XCTAssertTrue(request.contains(projectNameTag))
+        XCTAssertTrue(request.contains(projectName))
+        XCTAssertFalse(request.contains("filename=\""))
+    }
+}


### PR DESCRIPTION
Add an extension for the URLSession (Catty/Extensions.../Extensions/URLSessionMultipartExtension.swift) providing an multipart/form-data upload task:

open func multipartUploadTask(with url: URL, from formData: [String: String]?, attachmentData: [String: Data]?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionUploadTask

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
