### PR TITLE
CATTY-489 Ask Brick crashes on empty userVariable

### DIFF
--- a/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/LookBricks/AskBrick+CBXMLHandler.swift
+++ b/src/Catty/Parser&Serialializer/New Parser & Serializer/XMLHandler/Bricks/LookBricks/AskBrick+CBXMLHandler.swift
@@ -22,14 +22,17 @@
 
 extension AskBrick: CBXMLNodeProtocol {
     static func parse(from xmlElement: GDataXMLElement, with context: CBXMLParserContext) -> Self {
-        CBXMLParserHelper.validate(xmlElement, forNumberOfChildNodes: 2, andFormulaListWithTotalNumberOfFormulas: 1)
-        let formula = CBXMLParserHelper.formula(in: xmlElement, forCategoryName: "ASK_QUESTION", with: context)
-        let xmlVariable = xmlElement.child(withElementName: "userVariable")
-        let userVariable = context.parse(from: xmlVariable, withClass: UserVariable.self)
+        CBXMLParserHelper.validate(xmlElement, forFormulaListWithTotalNumberOfFormulas: 1)
 
         let brick = self.init()
+        let formula = CBXMLParserHelper.formula(in: xmlElement, forCategoryName: "ASK_QUESTION", with: context)
         brick.question = formula
-        brick.userVariable = userVariable as? UserVariable
+
+        let xmlVariable = xmlElement.child(withElementName: "userVariable")
+        if xmlVariable != nil {
+            let userVariable = context.parse(from: xmlVariable, withClass: UserVariable.self)
+            brick.userVariable = userVariable as? UserVariable
+        }
 
         return brick
     }

--- a/src/Catty/PlayerEngine/Instructions/Look/AskBrick+Instruction.swift
+++ b/src/Catty/PlayerEngine/Instructions/Look/AskBrick+Instruction.swift
@@ -47,8 +47,7 @@ extension AskBrick: CBInstructionProtocol {
     }
 
     func callbackSubmit(with input: String, scheduler: CBSchedulerProtocol) {
-        guard let userVariable = self.userVariable else { fatalError("Unexpected found nil.") }
-        if input.isNotEmpty {
+        if let userVariable = self.userVariable, input.isNotEmpty {
             userVariable.value = input
         }
         scheduler.resume()

--- a/src/CattyTests/Bricks/AskBrickTests.swift
+++ b/src/CattyTests/Bricks/AskBrickTests.swift
@@ -98,6 +98,20 @@ final class AskBrickTests: XCTestCase {
         XCTAssertEqual(variableBefore, variableAfter)
     }
 
+    func testAnswerNoUserVariable() {
+        brick.userVariable = nil
+
+        switch brick.instruction() {
+        case let .waitExecClosure(closure):
+            closure(context, scheduler)
+            brick.callbackSubmit(with: "an answer", scheduler: scheduler)
+        default:
+            XCTFail("Fatal Error")
+        }
+
+        XCTAssertEqual(brick.userVariable, nil)
+    }
+
     func testSchedulerPaused() {
         let variableBefore = brick.userVariable?.value as? String
 


### PR DESCRIPTION
 If you execute the askBrick without a userVariable, Catty crashes.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
