### PR TITLE
CATTY-493 Fix potential bugs in StagePresenterViewController

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -797,6 +797,7 @@
 		4CB2CFA61D7AD7E7009F3034 /* SetColorBrick+CBXMLHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CB2CFA51D7AD7E7009F3034 /* SetColorBrick+CBXMLHandler.m */; };
 		4CB2CFAB1D7AD86D009F3034 /* SetColorBrickCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CB2CFAA1D7AD86D009F3034 /* SetColorBrickCell.m */; };
 		4CB2CFAE1D7ADA1D009F3034 /* SetColorBrick+Instruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB2CFA71D7AD833009F3034 /* SetColorBrick+Instruction.swift */; };
+		4CB3E0A125ADEFFD007F4365 /* StagePresenterViewControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB3E0A025ADEFFD007F4365 /* StagePresenterViewControllerMock.swift */; };
 		4CB412202198635900FC4594 /* UserDataContainerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB4121D2198635900FC4594 /* UserDataContainerTest.swift */; };
 		4CB4FE061B95DF2900431757 /* BrickInsertManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CB4FE031B95DF2900431757 /* BrickInsertManager.m */; };
 		4CB4FE071B95DF2900431757 /* BrickMoveManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CB4FE051B95DF2900431757 /* BrickMoveManager.m */; };
@@ -2747,6 +2748,7 @@
 		4CB2CFA71D7AD833009F3034 /* SetColorBrick+Instruction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "SetColorBrick+Instruction.swift"; path = "PlayerEngine/Instructions/Look/SetColorBrick+Instruction.swift"; sourceTree = "<group>"; };
 		4CB2CFA91D7AD86D009F3034 /* SetColorBrickCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SetColorBrickCell.h; sourceTree = "<group>"; };
 		4CB2CFAA1D7AD86D009F3034 /* SetColorBrickCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SetColorBrickCell.m; sourceTree = "<group>"; };
+		4CB3E0A025ADEFFD007F4365 /* StagePresenterViewControllerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StagePresenterViewControllerMock.swift; sourceTree = "<group>"; };
 		4CB4121D2198635900FC4594 /* UserDataContainerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDataContainerTest.swift; sourceTree = "<group>"; };
 		4CB4FE021B95DF2900431757 /* BrickInsertManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BrickInsertManager.h; sourceTree = "<group>"; };
 		4CB4FE031B95DF2900431757 /* BrickInsertManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BrickInsertManager.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -7222,6 +7224,7 @@
 				4CF8277124F11541006E562A /* ScriptCollectionViewControllerMock.swift */,
 				5973F243202EF37600A4CED9 /* SoundsLibraryCollectionViewDataSourceDelegateMock.swift */,
 				4C1C8B15213FE7F1003B3AA4 /* StoreProjectDownloaderMock.swift */,
+				4CB3E0A025ADEFFD007F4365 /* StagePresenterViewControllerMock.swift */,
 				4CF8277324F1172D006E562A /* StoryboardMock.swift */,
 				4C7182E023EEF47500195BC7 /* UICollectionViewMock.swift */,
 				4CBF5F9D21AF1D390079C834 /* UIGestureRecognizerMock.swift */,
@@ -11423,6 +11426,7 @@
 				9ECDCB132328578F00EBDA63 /* HideBrickTests.swift in Sources */,
 				4C82265C213FA7A400F3D750 /* FingerXSensorTest.swift in Sources */,
 				2219ED93251DDB7E00EBA379 /* NSMutableArrayExtensionTests.swift in Sources */,
+				4CB3E0A125ADEFFD007F4365 /* StagePresenterViewControllerMock.swift in Sources */,
 				9E2D47C72328428100917D92 /* ChangeColorByNBrickTests.swift in Sources */,
 				4C2CBB4725A5AA8400C1C143 /* XMLParserObjectTests093.swift in Sources */,
 				D3CF986223FD23E40076F366 /* ScriptCollectionViewControllerDisableTests.swift in Sources */,

--- a/src/Catty/ViewController/BluetoothDeviceSelection/BluetoothDevicesTableViewController.swift
+++ b/src/Catty/ViewController/BluetoothDeviceSelection/BluetoothDevicesTableViewController.swift
@@ -165,7 +165,7 @@ class BluetoothDevicesTableViewController: UITableViewController {
         delegate!.rightButton.isEnabled = false
         DispatchQueue.main.async {
             self.loadingView?.hide()
-            self.stagePresenterVC.checkResourcesAndPushViewControllerTo(navigationController: self.navigationController!)
+            self.stagePresenterVC.checkResourcesAndPushViewController(to: self.navigationController!)
         }
     }
 

--- a/src/CattyTests/Mocks/StagePresenterViewControllerMock.swift
+++ b/src/CattyTests/Mocks/StagePresenterViewControllerMock.swift
@@ -1,0 +1,37 @@
+/**
+ *  Copyright (C) 2010-2020 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+@testable import Pocket_Code
+
+class StagePresenterViewControllerMock: StagePresenterViewController {
+
+    var showLoadingViewCalls = 0
+    var hideLoadingViewCalls = 0
+
+    override func showLoadingView() {
+        showLoadingViewCalls += 1
+    }
+
+    override func hideLoadingView() {
+        hideLoadingViewCalls += 1
+    }
+}


### PR DESCRIPTION
Crashlytics reports several crashes in StagePresenterViewControllerResourcesExtension line #34. The force unwrapping could be a potential cause for this crash. Thus, remove the force-unwrapping and display an error message in case the project can not be loaded (use kLocalizedInvalidZip). 
Another potential error source could be that the formula manager and thus location managers and similar are initialized not from the main thread which is bad practice according to Apple. Hence, move the formulaManager initialization and the readyToStart variable down into the main thread dispatch queue.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
