### PR TITLE
CATTY-131 AudioPlayerIntegrationTests fail occasionally

### DIFF
--- a/src/CattyTests/PlayerEngine/AudioEngine/IntegrationTests/AudioPlayerIntegrationTests.swift
+++ b/src/CattyTests/PlayerEngine/AudioEngine/IntegrationTests/AudioPlayerIntegrationTests.swift
@@ -44,7 +44,7 @@ final class AudioPlayerIntegrationTests: AudioEngineAbstractTest {
         let recordedTape = self.runAndRecord(duration: 3, stage: stage, muted: true)
 
         let similarity = calculateSimilarity(tape: recordedTape, referenceHash: referenceSimHash)
-        expect(similarity) >= 0.8
+        expect(similarity) >= 0.85
     }
 
     func testPlaySoundSameSoundTwiceFromDifferentObjectsExpectSameSoundsToPlaySimultaneously() {
@@ -88,7 +88,7 @@ final class AudioPlayerIntegrationTests: AudioEngineAbstractTest {
         let recordedTape = self.runAndRecord(duration: 4, stage: stage, muted: true)
 
         let similarity = calculateSimilarity(tape: recordedTape, referenceHash: referenceSimHash)
-        expect(similarity) >= 0.85
+        expect(similarity) >= 0.75
     }
 
     func testPlaySoundAndWaitExpectScriptToContinueWhenSoundFinished() {
@@ -99,6 +99,6 @@ final class AudioPlayerIntegrationTests: AudioEngineAbstractTest {
         let recordedTape = self.runAndRecord(duration: 3, stage: stage, muted: true)
 
         let similarity = calculateSimilarity(tape: recordedTape, referenceHash: referenceSimHash)
-        expect(similarity) >= 0.85
+        expect(similarity) >= 0.75
     }
 }


### PR DESCRIPTION
Adapt occasionally failing AudioPlayerIntegrationTests
Change assertion values to highest lower-bound.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
