### PR TITLE
CATTY-499 Unknown formula type leads to crash

### DIFF
--- a/src/Catty/DataModel/Formula/FormulaElement.h
+++ b/src/Catty/DataModel/Formula/FormulaElement.h
@@ -33,7 +33,8 @@ typedef NS_CLOSED_ENUM(NSInteger, ElementType) {
     USER_VARIABLE,
     USER_LIST,
     BRACKET,
-    STRING
+    STRING,
+    UNKNOWN_TYPE,
 };
 
 typedef NS_ENUM(NSInteger, IdempotenceState) {
@@ -49,7 +50,8 @@ typedef NS_ENUM(NSInteger, IdempotenceState) {
 @"USER_VARIABLE"            : @(USER_VARIABLE),\
 @"USER_LIST"            : @(USER_LIST),\
 @"BRACKET"        : @(BRACKET),\
-@"STRING"                 : @(STRING)\
+@"STRING"                 : @(STRING),\
+@"UNKNOWN_TYPE"                 : @(UNKNOWN_TYPE)\
 }
 
 #define kstringElementTypeDict @{\
@@ -60,7 +62,8 @@ typedef NS_ENUM(NSInteger, IdempotenceState) {
 @(USER_VARIABLE)            : @"USER_VARIABLE",\
 @(USER_LIST)            : @"USER_LIST",\
 @(BRACKET)       : @"BRACKET",\
-@(STRING)                 : @"STRING"\
+@(STRING)                 : @"STRING",\
+@(UNKNOWN_TYPE)                 : @"UNKNOWN_TYPE"\
 }
 
 @interface FormulaElement : NSObject<CBMutableCopying>

--- a/src/Catty/DataModel/Formula/FormulaElement.m
+++ b/src/Catty/DataModel/Formula/FormulaElement.m
@@ -124,8 +124,7 @@
     if (elementType) {
         return (ElementType)elementType.integerValue;
     }
-    NSError(@"Unknown Type: %@", type);
-    return -1;
+    return UNKNOWN_TYPE;
 }
 
 - (NSString*)stringForElementType:(ElementType)type

--- a/src/Catty/PlayerEngine/Formula/FormulaManager+Interpreter.swift
+++ b/src/Catty/PlayerEngine/Formula/FormulaManager+Interpreter.swift
@@ -158,6 +158,8 @@ extension FormulaManager {
         }
 
         switch formulaElement.type {
+        case .UNKNOWN_TYPE:
+            result = 0 as AnyObject
         case .OPERATOR:
             result = interpretOperator(formulaElement, for: spriteObject)
         case .FUNCTION:

--- a/src/CattyTests/Parser & Serialization/CatrobatLanguage0.93/Unit Tests/XMLParserFormulaTests093.swift
+++ b/src/CattyTests/Parser & Serialization/CatrobatLanguage0.93/Unit Tests/XMLParserFormulaTests093.swift
@@ -53,4 +53,20 @@ class XMLParserFormulaTests093: XMLAbstractTest {
         // formula value should be: (1 * (-2)) + (3 / 4) = -1,25
         XCTAssertEqual(self.formulaManager.interpretDouble(formula!, for: SpriteObject()), -1.25, accuracy: 0.00001, "Formula not correctly parsed")
     }
+
+    func testUnknownType() {
+        let document = self.getXMLDocumentForPath(xmlPath: self.getPathForXML(xmlFile: "ValidFormulaList"))
+        let brickElement = self.getXMLElementsForXPath(document, xPath: "//program/objectList/object[4]/scriptList/script[1]/brickList/brick[4]")
+        XCTAssertEqual(brickElement!.count, 1)
+
+        let brickXMLElement = brickElement!.first
+        let brick = self.parserContext!.parse(from: brickXMLElement, withClass: WaitBrick.self as? CBXMLNodeProtocol.Type) as! Brick
+
+        XCTAssertTrue(brick.isKind(of: WaitBrick.self), "Invalid brick class")
+
+        let waitBrick = brick as! WaitBrick
+        let formula = waitBrick.timeToWaitInSeconds
+
+        XCTAssertEqual(ElementType.UNKNOWN_TYPE, formula.formulaTree.type)
+    }
 }

--- a/src/CattyTests/PlayerEngine/Formula/FormulaManagerInterpreterTests.swift
+++ b/src/CattyTests/PlayerEngine/Formula/FormulaManagerInterpreterTests.swift
@@ -785,4 +785,10 @@ final class FormulaManagerInterpreterTests: XCTestCase {
         formula = Formula(formulaElement: element)!
         XCTAssertEqual("12.3 testValue", interpreter.interpretString(formula, for: object))
     }
+
+    func testUnknownType() {
+        let formulaElement = FormulaElement(elementType: ElementType.UNKNOWN_TYPE, value: "unknown")!
+        let formula = Formula(formulaElement: formulaElement)!
+        XCTAssertEqual(0, interpreter.interpretDouble(formula, for: object))
+    }
 }

--- a/src/CattyTests/Resources/ParserTests/Custom/Misc/ValidFormulaList.xml
+++ b/src/CattyTests/Resources/ParserTests/Custom/Misc/ValidFormulaList.xml
@@ -88,21 +88,21 @@
                             <userVariable>random to</userVariable>
                         </brick>
                         <brick type="SpeakBrick">
-                          <commentedOut>false</commentedOut>
-                          <formulaList>
-                            <formula category="SPEAK">
-                              <leftChild>
-                                <type>STRING</type>
-                                <value> an? ([^ .]+)</value>
-                              </leftChild>
-                              <rightChild>
-                                <type>STRING</type>
-                                <value>I am a panda</value>
-                              </rightChild>
-                              <type>FUNCTION</type>
-                              <value>REGEX</value>
-                            </formula>
-                          </formulaList>
+                            <commentedOut>false</commentedOut>
+                            <formulaList>
+                                <formula category="SPEAK">
+                                    <leftChild>
+                                        <type>STRING</type>
+                                        <value> an? ([^ .]+)</value>
+                                    </leftChild>
+                                    <rightChild>
+                                        <type>STRING</type>
+                                        <value>I am a panda</value>
+                                    </rightChild>
+                                    <type>FUNCTION</type>
+                                    <value>REGEX</value>
+                                </formula>
+                            </formulaList>
                         </brick>
                     </brickList>
                     <commentedOut>false</commentedOut>
@@ -514,6 +514,15 @@
                                     </rightChild>
                                     <type>OPERATOR</type>
                                     <value>MINUS</value>
+                                </formula>
+                            </formulaList>
+                        </brick>
+                        <brick type="WaitBrick">
+                            <commentedOut>false</commentedOut>
+                            <formulaList>
+                                <formula category="TIME_TO_WAIT_IN_SECONDS">
+                                    <type>UNKNOWN_TYPE</type>
+                                    <value>1</value>
                                 </formula>
                             </formulaList>
                         </brick>


### PR DESCRIPTION
 Certain projects contain formula types which are not supported by Catty yet (e.g., the collision detection which will be introduced soon). As a result Catty crashes in FormulaManager+Interpreter.swift line 175.
Reason for this is that unknown formulas are parsed with an invalid type (-1), see elementTypeForString. Instead of returning the invalid value -1, a new ElementType should be created and called UNKNOWN.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
