### PR TITLE
CATTY-500 Do not output content of XML file while parsing

### DIFF
--- a/src/Catty/Parser&Serialializer/New Parser & Serializer/Serializer/CBXMLSerializer.m
+++ b/src/Catty/Parser&Serialializer/New Parser & Serializer/Serializer/CBXMLSerializer.m
@@ -84,8 +84,6 @@
         GDataXMLDocument *document = [[self class] xmlDocumentForProject:project];
         NSString *xmlString = [NSString stringWithFormat:@"%@\n%@", kCatrobatHeaderXMLDeclaration,
                                [document.rootElement XMLStringPrettyPrinted:YES]];
-
-        NSDebug(@"Generated XML output:\n%@", xmlString);
         NSError *error = nil;
 
         if (! [xmlString writeToFile:self.xmlPath atomically:YES encoding:NSUTF8StringEncoding error:&error]) {

--- a/src/CattyTests/Parser & Serialization/CatrobatLanguage0.993/XMLSerializerTests/XMLSerializerTests.swift
+++ b/src/CattyTests/Parser & Serialization/CatrobatLanguage0.993/XMLSerializerTests/XMLSerializerTests.swift
@@ -145,7 +145,6 @@ final class XMLSerializerTests: XMLAbstractTest {
             XCTFail("xmlElement is nil")
             return
         }
-        print("XML Element: \(xmlElement)")
         let equal = self.isXMLElement(xmlElement: xmlElement, equalToXMLElementForXPath: xmlElementPath, inProjectForXML: "ValidProjectAllBricks0991")
         XCTAssertTrue(equal, "XMLElement invalid!")
     }
@@ -160,7 +159,6 @@ final class XMLSerializerTests: XMLAbstractTest {
             XCTFail("xmlElement is nil")
             return
         }
-        print("XML Element: \(xmlElement)")
         let equal = self.isXMLElement(xmlElement: xmlElement, equalToXMLElementForXPath: xmlElementPath, inProjectForXML: "ValidProjectAllBricks0991")
         XCTAssertTrue(equal, "XMLElement invalid!")
 
@@ -176,7 +174,6 @@ final class XMLSerializerTests: XMLAbstractTest {
             XCTFail("xmlElement is nil")
             return
         }
-        print("XML Element: \(xmlElement)")
         let equal = self.isXMLElement(xmlElement: xmlElement, equalToXMLElementForXPath: xmlElementPath, inProjectForXML: "ValidProjectAllBricks0991")
         XCTAssertTrue(equal, "XMLElement invalid!")
     }
@@ -191,7 +188,6 @@ final class XMLSerializerTests: XMLAbstractTest {
             XCTFail("xmlElement is nil")
             return
         }
-        print("XML Element: \(xmlElement)")
         let equal = self.isXMLElement(xmlElement: xmlElement, equalToXMLElementForXPath: xmlElementPath, inProjectForXML: "AddItemToUserListBrick0993")
         XCTAssertTrue(equal, "XMLElement invalid!")
     }
@@ -206,7 +202,6 @@ final class XMLSerializerTests: XMLAbstractTest {
             XCTFail("xmlElement is nil")
             return
         }
-        print("XML Element: \(xmlElement)")
         let equal = self.isXMLElement(xmlElement: xmlElement, equalToXMLElementForXPath: xmlElementPath, inProjectForXML: "UserVariables_0993")
         XCTAssertTrue(equal, "XMLElement invalid!")
     }


### PR DESCRIPTION
When starting Catty in Xcode, the content of the XML file to be parsed is output on the console.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
