### PR TITLE
CATTY-506 Merge EmbroideryStreams

### DIFF
--- a/src/Catty/Embroidery/EmbroideryStream.swift
+++ b/src/Catty/Embroidery/EmbroideryStream.swift
@@ -55,6 +55,21 @@ class EmbroideryStream: Collection {
         size *= screenRatio
     }
 
+    init(streams: [EmbroideryStream], withName name: String? = nil) {
+        self.name = name
+        self.nextStitchIsColorChange = false
+        size = SpriteKitDefines.defaultCatrobatStitchingSize * EmbroideryDefines.sizeConversionFactor
+
+        for stream in streams {
+            let syncArrayEnumerated = stream.stitches.enumerated()
+
+            for (_, value1) in syncArrayEnumerated {
+                self.append(value1)
+            }
+            self.addColorChange()
+        }
+    }
+
     subscript(index: IndexType) -> Stitch {
         guard let stitch = stitches[index] else {
             fatalError("Array index out of bounds")

--- a/src/CattyTests/Embroidery/EmbroideryDSTServiceTests.swift
+++ b/src/CattyTests/Embroidery/EmbroideryDSTServiceTests.swift
@@ -58,4 +58,25 @@ final class EmbroideryDSTServiceTests: XCTestCase {
         let out = DSTService.generateOutput(embroideryStream: stream)
         XCTAssertEqual(out, reference)
     }
+
+    func testGenerateInitWithStreams() {
+        let bundlePath = Bundle(for: type(of: self)).path(forResource: "color_change", ofType: "dst")
+        let reference = try? Data(contentsOf: URL(fileURLWithPath: bundlePath!))
+
+        let DSTService = EmbroideryDSTService()
+
+        let stream = EmbroideryStream(projectWidth: width, projectHeight: height)
+        stream.add(Stitch(atPosition: CGPoint(x: 0, y: 0)))
+        stream.add(Stitch(atPosition: CGPoint(x: 250, y: 0)))
+
+        let streamTwo = EmbroideryStream(projectWidth: width, projectHeight: height)
+        streamTwo.add(Stitch(atPosition: CGPoint(x: 0, y: 0)))
+        streamTwo.add(Stitch(atPosition: CGPoint(x: 0, y: 250)))
+
+        let streamArray = [stream, streamTwo]
+        let mergedStream = EmbroideryStream(streams: streamArray)
+
+        let out = DSTService.generateOutput(embroideryStream: mergedStream)
+        XCTAssertEqual(out, reference)
+    }
 }

--- a/src/CattyTests/Embroidery/EmbroideryStreamTests.swift
+++ b/src/CattyTests/Embroidery/EmbroideryStreamTests.swift
@@ -218,4 +218,30 @@ final class EmbroideryStreamTests: XCTestCase {
         let creatorDiagonalPixel = deviceDiagonalPixel * embroideryStream.size / self.defaultSize
         XCTAssertEqual(creatorDiagonalPixel, defaultCreatorDiagonalPixel, accuracy: 0.01)
     }
+
+    func testInitWithStreams() {
+        let stream = EmbroideryStream(projectWidth: width, projectHeight: height)
+        stream.add(Stitch(atPosition: CGPoint(x: 0, y: 0)))
+        stream.add(Stitch(atPosition: CGPoint(x: 10, y: 0)))
+        stream.add(Stitch(atPosition: CGPoint(x: 0, y: 0)))
+        stream.add(Stitch(atPosition: CGPoint(x: 10, y: 0)))
+
+        let streamTwo = EmbroideryStream(projectWidth: width, projectHeight: height)
+        streamTwo.add(Stitch(atPosition: CGPoint(x: 0, y: 0)))
+        streamTwo.add(Stitch(atPosition: CGPoint(x: 5, y: 0)))
+        streamTwo.add(Stitch(atPosition: CGPoint(x: 0, y: 0)))
+        streamTwo.add(Stitch(atPosition: CGPoint(x: 5, y: 0)))
+
+        let streamArray = [stream, streamTwo]
+        let mergedStream = EmbroideryStream(streams: streamArray)
+        XCTAssertEqual(mergedStream.stitches.count, 8)
+        XCTAssertFalse(mergedStream.stitches[0]!.isColorChange)
+        XCTAssertFalse(mergedStream.stitches[1]!.isColorChange)
+        XCTAssertFalse(mergedStream.stitches[2]!.isColorChange)
+        XCTAssertFalse(mergedStream.stitches[3]!.isColorChange)
+        XCTAssertTrue(mergedStream.stitches[4]!.isColorChange)
+        XCTAssertFalse(mergedStream.stitches[5]!.isColorChange)
+        XCTAssertFalse(mergedStream.stitches[6]!.isColorChange)
+        XCTAssertFalse(mergedStream.stitches[7]!.isColorChange)
+    }
 }


### PR DESCRIPTION
The EmbroideryStream should get a new initializer which allows to merge several EmbroideryStreams into one:

init(streams: [EmbroideryStream])
Every stitch in each stream should be added using the (private) appendStitch method, thus without interpolation. After each EmbroideryStream there should be a color change.

The example color_change.dst file (already included in Catty) was created with the following input (see this example project for details):

EmbroideryStream(stitch (0, 0), stitch(250, 0))
EmbroideryStream(stitch (0, 0), stitch(0, 250))
Add unit tests and integration tests (i.e., using the color_change.dst file) and ensure that a color change happens between the two streams.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
