### PR TITLE
CATTY-516 Remove deprecated TODO and FIXME

### DIFF
--- a/src/Catty/BluetoothHelper/BluetoothHelper/Components/Peripheral.swift
+++ b/src/Catty/BluetoothHelper/BluetoothHelper/Components/Peripheral.swift
@@ -23,7 +23,6 @@
 import CoreBluetooth
 import UIKit
 
-// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
 // Consider refactoring the code to use the non-optional operators.
 private func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     switch (lhs, rhs) {
@@ -36,7 +35,6 @@ private func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     }
 }
 
-// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
 // Consider refactoring the code to use the non-optional operators.
 private func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     switch (lhs, rhs) {

--- a/src/Catty/Helpers/Firmata/Firmata.swift
+++ b/src/Catty/Helpers/Firmata/Firmata.swift
@@ -197,7 +197,7 @@ class Firmata: FirmataProtocol {
      */
     func servoConfig(_ pin: UInt8, minPulse: UInt8, maxPulse: UInt8) {
         let data0: UInt8 = kSTART_SYSEX
-        let data1: UInt8 = kSERVO_CONFIG //TODO: check with PIN
+        let data1: UInt8 = kSERVO_CONFIG
         let data2: UInt8 = pin
         let data3: UInt8 = minPulse & 0x7F
         let data4: UInt8 = minPulse >> 7
@@ -740,8 +740,6 @@ class Firmata: FirmataProtocol {
         //        [ports insertObject:[NSNumber numberWithUnsignedChar:value<<(pin % 8)] atIndex:port];
         //    }
 
-        //   TODO:
-        //    [peripheralDelegate didUpdatePin:pin currentMode:(PINMODE)currentMode value:value];
     }
 
     /* analog mapping response

--- a/src/Catty/PlayerEngine/CBCustomTypes.swift
+++ b/src/Catty/PlayerEngine/CBCustomTypes.swift
@@ -100,7 +100,6 @@ enum CBBroadcastType: String {
 }
 
 // MARK: - Protocol extensions
-// TODO: simplify and remove duplicate...
 extension Collection where Iterator.Element == CBScriptContextProtocol {
 
     func contains(_ e: Iterator.Element) -> Bool {


### PR DESCRIPTION
Remove the deprecated TODO comments in Firmata.swift and CBCustomerTypes.swift, as well as the irrelevant FIXME comments of Peripheral.swift.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
