### PR TITLE
CATTY-512 Add missing tests for Formula mutableCopy

### DIFF
--- a/src/CattyTests/Formula/FormulaTest.swift
+++ b/src/CattyTests/Formula/FormulaTest.swift
@@ -180,4 +180,32 @@ final class FormulaTest: XCTestCase {
         formula = Formula(formulaElement: parseTree)!
         XCTAssertFalse(formula.isSingularNumber())
     }
+
+    func testMutableCopy() {
+        let parent = FormulaElement(double: 1.0)!
+        let leftChild = FormulaElement(double: 2.0)!
+        let rightChild = FormulaElement(double: 3.0)!
+        let leftChild2 = FormulaElement(double: 4.0)!
+        let rightChild2 = FormulaElement(double: 5.0)!
+
+        leftChild.parent = parent
+        parent.leftChild = leftChild
+        leftChild.leftChild = leftChild2
+        leftChild2.parent = leftChild
+
+        rightChild.parent = parent
+        parent.rightChild = rightChild
+        rightChild.rightChild = rightChild2
+        rightChild2.parent = rightChild
+
+        let formula = Formula(formulaElement: parent)!
+        let copiedFormula = formula.mutableCopy(with: CBMutableCopyContext()) as! Formula
+
+        XCTAssertTrue(formula.isEqual(to: copiedFormula))
+        XCTAssertFalse(formula.formulaTree === copiedFormula.formulaTree)
+
+        copiedFormula.formulaTree.rightChild.value = "6.0"
+
+        XCTAssertFalse(copiedFormula.formulaTree.rightChild.value.isEqual(formula.formulaTree.rightChild.value))
+    }
 }


### PR DESCRIPTION
Add missing tests for the mutable copy functionality of the Formula. Add those tests to FormulaTest.swift and make sure to test it with a formula tree having several levels of left and right children.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
