### PR TITLE
CATTY-207 Add tests for mutable copy (part 4)

### DIFF
--- a/src/CattyTests/Bricks/SetXBrickTests.swift
+++ b/src/CattyTests/Bricks/SetXBrickTests.swift
@@ -98,4 +98,15 @@ final class SetXBrickTests: AbstractBrickTest {
 
         XCTAssertEqual(brick.xPosition, formulas?[0])
     }
+
+    func testMutableCopy() {
+        brick.xPosition = Formula(double: 2.0)
+
+        let copiedBrick: SetXBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! SetXBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.xPosition.isEqual(to: copiedBrick.xPosition))
+        XCTAssertFalse(brick.xPosition === copiedBrick.xPosition)
+    }
 }

--- a/src/CattyTests/Bricks/SetYBrickTests.swift
+++ b/src/CattyTests/Bricks/SetYBrickTests.swift
@@ -98,4 +98,15 @@ final class SetYBrickTests: AbstractBrickTest {
 
         XCTAssertEqual(brick.yPosition, formulas?[0])
     }
+
+    func testMutableCopy() {
+        brick.yPosition = Formula(double: 2.0)
+
+        let copiedBrick: SetYBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! SetYBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.yPosition.isEqual(to: copiedBrick.yPosition))
+        XCTAssertFalse(brick.yPosition === copiedBrick.yPosition)
+    }
 }

--- a/src/CattyTests/Bricks/ShowBrickTests.swift
+++ b/src/CattyTests/Bricks/ShowBrickTests.swift
@@ -47,4 +47,13 @@ final class ShowBrickTests: AbstractBrickTest {
 
         XCTAssertFalse(spriteNode.isHidden, "ShowBrick is not correctly calculated")
     }
+
+    func testMutableCopy() {
+        let brick = ShowBrick()
+
+        let copiedBrick: ShowBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! ShowBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+    }
 }

--- a/src/CattyTests/Bricks/ShowTextBrickTests.swift
+++ b/src/CattyTests/Bricks/ShowTextBrickTests.swift
@@ -126,4 +126,19 @@ final class ShowTextBrickTests: XCTestCase {
         XCTAssertEqual(brick.xFormula, formulas?[0])
         XCTAssertEqual(brick.yFormula, formulas?[1])
     }
+
+    func testMutableCopy() {
+        let brick = ShowTextBrick()
+        brick.script = script
+        brick.xFormula = Formula(integer: 1)
+        brick.yFormula = Formula(integer: 2)
+        brick.userVariable = UserVariable(name: "test")
+
+        let copiedBrick: ShowTextBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! ShowTextBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.xFormula.isEqual(to: copiedBrick.xFormula))
+        XCTAssertFalse(brick.xFormula === copiedBrick.xFormula)
+    }
 }

--- a/src/CattyTests/Bricks/TurnLeftBrickTests.swift
+++ b/src/CattyTests/Bricks/TurnLeftBrickTests.swift
@@ -77,4 +77,16 @@ final class TurnLeftBrickTests: AbstractBrickTest {
 
         XCTAssertEqual(brick.degrees, formulas?[0])
     }
+
+    func testMutableCopy() {
+        let brick = TurnLeftBrick()
+        brick.degrees = Formula(double: 2)
+
+        let copiedBrick: TurnLeftBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! TurnLeftBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.degrees.isEqual(to: copiedBrick.degrees))
+        XCTAssertFalse(brick.degrees === copiedBrick.degrees)
+    }
 }

--- a/src/CattyTests/Bricks/TurnRightBrickTests.swift
+++ b/src/CattyTests/Bricks/TurnRightBrickTests.swift
@@ -113,4 +113,16 @@ final class TurnRightBrickTests: AbstractBrickTest {
 
         XCTAssertEqual(brick.degrees, formulas?[0])
     }
+
+    func testMutableCopy() {
+        initialiseTestData()
+        brick.degrees = Formula(double: 2.0)
+
+        let copiedBrick: TurnRightBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! TurnRightBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.degrees.isEqual(to: copiedBrick.degrees))
+        XCTAssertFalse(brick.degrees === copiedBrick.degrees)
+    }
 }

--- a/src/CattyTests/Bricks/VibrationBrickTests.swift
+++ b/src/CattyTests/Bricks/VibrationBrickTests.swift
@@ -93,4 +93,16 @@ final class VibrationBrickTests: XCTestCase {
 
         XCTAssertEqual(brick.durationInSeconds, formulas?[0])
     }
+
+    func testMutableCopy() {
+        let brick = VibrationBrick()
+        brick.durationInSeconds = Formula(double: 2)
+
+        let copiedBrick: VibrationBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! VibrationBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.durationInSeconds.isEqual(to: copiedBrick.durationInSeconds))
+        XCTAssertFalse(brick.durationInSeconds === copiedBrick.durationInSeconds)
+    }
 }

--- a/src/CattyTests/Bricks/WaitBrickTests.swift
+++ b/src/CattyTests/Bricks/WaitBrickTests.swift
@@ -156,4 +156,15 @@ final class WaitBrickTests: XCTestCase {
         XCTAssertFalse(waitBrick.timeToWaitInSeconds.isEqual(to: Formula(float: 1)))
     }
 
+    func testMutableCopy() {
+        let brick = WaitBrick()
+        brick.timeToWaitInSeconds = Formula(double: 2)
+
+        let copiedBrick: WaitBrick = brick.mutableCopy(with: CBMutableCopyContext(), andErrorReporting: true) as! WaitBrick
+
+        XCTAssertTrue(brick.isEqual(to: copiedBrick))
+        XCTAssertFalse(brick === copiedBrick)
+        XCTAssertTrue(brick.timeToWaitInSeconds.isEqual(to: copiedBrick.timeToWaitInSeconds))
+        XCTAssertFalse(brick.timeToWaitInSeconds === copiedBrick.timeToWaitInSeconds)
+    }
 }


### PR DESCRIPTION
The mutableCopyWithContext method of the Bricks create a deep copy of a Brick which is used when copying a Brick in the "Script view" in Pocket Code.
Add a test for this method for the following Bricks (have a look at the RepeatBrickTests class):

- SetXBrick
- SetYBrick
- ShowTextBrick
- ShowBrick
- TurnLeftBrick
- TurnRightBrick
- VibrationBrick
- WaitBrick

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
