### PR TITLE
CATTY-445 Variable width for Formula fields

### DIFF
--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellFormulaData.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellFormulaData.m
@@ -53,24 +53,14 @@
         [self setTitle:[formula getDisplayString] forState:UIControlStateNormal];
         
         [self sizeToFit];
-        if (self.frame.size.width >= kBrickInputFieldMaxWidth) {
-            self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, kBrickInputFieldMaxWidth, self.frame.size.height);
-            self.titleLabel.frame = CGRectMake(self.titleLabel.frame.origin.x, self.titleLabel.frame.origin.y, kBrickInputFieldMaxWidth, self.titleLabel.frame.size.height);
+        if (self.frame.size.width >= brickCell.maxInputFormulaFrameLength) {
+            self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, brickCell.maxInputFormulaFrameLength, self.frame.size.height);
+            self.titleLabel.frame = CGRectMake(self.titleLabel.frame.origin.x, self.titleLabel.frame.origin.y, brickCell.maxInputFormulaFrameLength, self.titleLabel.frame.size.height);
             self.titleLabel.numberOfLines = 1;
-            [self.titleLabel setAdjustsFontSizeToFitWidth:YES];
             self.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-            self.titleLabel.minimumScaleFactor = 10./self.titleLabel.font.pointSize;
-        } else if ([brickCell isKindOfClass:[PlaceAtBrickCell class]] || [brickCell isKindOfClass:[GlideToBrickCell class]]) {
-            if (self.frame.size.width > [Util screenWidth]/SPACE_DISTRIBUTE_VALUE) {
-                CGRect labelFrame = self.frame;
-                labelFrame.size.width = [Util screenWidth]/SPACE_DISTRIBUTE_VALUE;
-                self.frame = labelFrame;
-            }
         } else {
             self.titleLabel.numberOfLines = 1;
             self.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-            [self.titleLabel setAdjustsFontSizeToFitWidth:YES];
-            self.titleLabel.minimumScaleFactor = 11./self.titleLabel.font.pointSize;
         }
         
         CGRect labelFrame = self.frame;
@@ -84,14 +74,8 @@
     return self;
 }
 
-#define FORMULA_MAX_LENGTH 15
-
 - (void)setTitle:(NSString *)title forState:(UIControlState)state
 {
-    if([title length] > FORMULA_MAX_LENGTH) {
-        title = [NSString stringWithFormat:@"%@...", [title substringToIndex:FORMULA_MAX_LENGTH]];
-    }
-    
     title = [NSString stringWithFormat:@" %@ ", title];
     [super setTitle:title forState:state];
 }

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/BrickCell.h
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/BrickCell.h
@@ -46,6 +46,7 @@
 @property (nonatomic, strong) NSArray *brickCategoryColors;
 @property (nonatomic) BOOL enabled;
 @property (nonatomic) BOOL isInserting;
+@property (nonatomic) CGFloat maxInputFormulaFrameLength;
 
 @property (nonatomic, strong) SelectButton *selectButton;
 
@@ -60,6 +61,7 @@
 - (void)insertAnimate:(BOOL)animate;
 - (void)setupBrickCell;
 - (void)setupBrickCellinSelectionView:(BOOL)inSelectionView inBackground:(BOOL)inBackground;
+- (void)calcMaxInputFormulaFrameLength: (NSArray*) partLabels WithFrame:(CGRect)frame WithParams:(NSArray*)params;
 
 - (id<BrickCellDataProtocol>)dataSubviewForLineNumber:(NSInteger)line andParameterNumber:(NSInteger)parameter;
 - (id<BrickCellDataProtocol>)dataSubviewWithType:(Class)className;

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/BrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/BrickCell.m
@@ -64,6 +64,7 @@
         self.opaque = NO;
         self.clipsToBounds = NO;
         self.isInserting = NO;
+        self.maxInputFormulaFrameLength = 0;
     }
     return self;
 }
@@ -298,6 +299,30 @@
     return subviews;
 }
 
+- (void)calcMaxInputFormulaFrameLength: (NSArray*) partLabels WithFrame:(CGRect)frame WithParams:(NSArray*)params
+{
+    NSUInteger formulaCounter = 0;
+    
+    for (NSString* afterLabelParam in params) {
+        if ([afterLabelParam rangeOfString:@"FLOAT"].location != NSNotFound || [afterLabelParam rangeOfString:@"INT"].location != NSNotFound) {
+            formulaCounter++;
+        }
+    }
+    
+    if(!formulaCounter)
+        return;
+    
+    NSString* labelTitle = @"";
+    
+    for (NSString* partLabelTitle in partLabels) {
+        labelTitle = [labelTitle stringByAppendingString:partLabelTitle];
+    }
+    
+    UILabel* textLabel = [UIUtil newDefaultBrickLabelWithFrame:frame AndText:labelTitle andRemainingSpace:frame.size.width];
+    
+    self.maxInputFormulaFrameLength = (frame.size.width - ((NSInteger)textLabel.frame.size.width + kBrickInputFieldLeftMargin * [partLabels count]) - kBrickTextFieldFontSize) / formulaCounter;
+}
+
 - (NSMutableArray*)inlineViewSubviewsOfLabel:(NSString*)labelTitle WithParams:(NSArray*)params WithFrame:(CGRect)frame ForLineNumber:(NSInteger)lineNumber
 {
     CGRect remainingFrame = frame;
@@ -315,6 +340,8 @@
     NSUInteger totalNumberOfSubViews = totalNumberOfPartLabels + totalNumberOfParams;
     NSMutableArray *subviews = [NSMutableArray arrayWithCapacity:totalNumberOfSubViews];
     NSInteger counter = 0;
+    [self calcMaxInputFormulaFrameLength:partLabels WithFrame:frame WithParams:params];
+    
     for (NSString *partLabelTitle in partLabels) {
         if (partLabelTitle.length) {
             UILabel *textLabel = [UIUtil newDefaultBrickLabelWithFrame:remainingFrame AndText:partLabelTitle andRemainingSpace:remainingFrame.size.width];

--- a/src/CattyTests/Views/BrickCells/Data/BrickCellFormulaDataTests.swift
+++ b/src/CattyTests/Views/BrickCells/Data/BrickCellFormulaDataTests.swift
@@ -35,4 +35,49 @@ final class BrickCellFormulaDataTests: XCTestCase {
 
         expect(formulaData.save(formula)).to(postNotifications(contain(expectedNotification)))
     }
+
+    func testCalcMaxInputFormulaFrameLengthWithOneFormula() {
+        let brickCell = BrickCell()
+        brickCell.maxInputFormulaFrameLength = 0
+
+        let partLabels = ["x: ", "y: ", ""]
+        let frame = CGRect(origin: CGPoint(x: 0, y: 30), size: CGSize(width: 321, height: 30))
+        let params = ["{FLOAT;range=(-inf,inf)}", ""]
+
+        XCTAssertEqual(brickCell.maxInputFormulaFrameLength, 0)
+
+        brickCell.calcMaxInputFormulaFrameLength(partLabels, withFrame: frame, withParams: params)
+
+        XCTAssertEqual(brickCell.maxInputFormulaFrameLength, 259, accuracy: 0.1)
+    }
+
+    func testCalcMaxInputFormulaFrameLengthWithTwoFormula() {
+        let brickCell = BrickCell()
+        brickCell.maxInputFormulaFrameLength = 0
+
+        let partLabels = ["x: ", "y: ", ""]
+        let frame = CGRect(origin: CGPoint(x: 0, y: 30), size: CGSize(width: 321, height: 30))
+        let params = ["{FLOAT;range=(-inf,inf)}", "{INT;range=(-inf,inf)}"]
+
+        XCTAssertEqual(brickCell.maxInputFormulaFrameLength, 0)
+
+        brickCell.calcMaxInputFormulaFrameLength(partLabels, withFrame: frame, withParams: params)
+
+        XCTAssertEqual(brickCell.maxInputFormulaFrameLength, 129.5, accuracy: 0.1)
+    }
+
+    func testCalcMaxInputFormulaFrameLengthWithoutFormula() {
+        let brickCell = BrickCell()
+        brickCell.maxInputFormulaFrameLength = 0
+
+        let partLabels = ["x: ", "y: ", ""]
+        let frame = CGRect(origin: CGPoint(x: 0, y: 30), size: CGSize(width: 321, height: 30))
+        let params = ["", ""]
+
+        XCTAssertEqual(brickCell.maxInputFormulaFrameLength, 0)
+
+        brickCell.calcMaxInputFormulaFrameLength(partLabels, withFrame: frame, withParams: params)
+
+        XCTAssertEqual(brickCell.maxInputFormulaFrameLength, 0)
+    }
 }


### PR DESCRIPTION
To make better use of the space, the formula fields should have a variable width, meaning that they should use up all the space which (a) is available and (b) they need in order to display as many characters as possible. The limit of course is the very right of the screen or, in case there are several parameters, the next parameter. In the event of several formula parameters per line, then this should be equally distributed between those parameters.
This should not only apply to the above Brick but to all Bricks having Formulas. In case this is too much change at once, we can also split this story up for every Brick category (i.e., in that case stick only to the Look category).

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
