### PR TITLE
CATTY-514 Wrong Brick color for Bricks of a disabled extensions

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -1694,6 +1694,7 @@
 		BCFED6F62113188700BE57BF /* MyFirstProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFED6F52113188700BE57BF /* MyFirstProjectTests.swift */; };
 		BCFED6F8211318A100BE57BF /* ProjectTVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFED6F7211318A100BE57BF /* ProjectTVCTests.swift */; };
 		C6A06BEC1EC8CA4C0000C656 /* AlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FC8B8C0B21945B560F7272 /* AlertController.swift */; };
+		C8CD7DD425E63D0A0018C655 /* BrickCategoryOverviewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8CD7DD325E63D0A0018C655 /* BrickCategoryOverviewControllerTests.swift */; };
 		CA02C5E71B14386900233FB0 /* CBSpriteNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA02C5E61B14386900233FB0 /* CBSpriteNode.swift */; };
 		CA2D44431B12305400A3B53D /* Swell.plist in Resources */ = {isa = PBXBuildFile; fileRef = CA2D44421B12305400A3B53D /* Swell.plist */; };
 		CA2D44441B1231F900A3B53D /* Swell.plist in Resources */ = {isa = PBXBuildFile; fileRef = CA2D44421B12305400A3B53D /* Swell.plist */; };
@@ -4119,6 +4120,7 @@
 		BCFED6F7211318A100BE57BF /* ProjectTVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTVCTests.swift; sourceTree = "<group>"; };
 		C286B2695528549DC9B2916D /* af */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = af; path = af.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C42D117BCEADFF7368CA3159 /* bn */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/Localizable.strings; sourceTree = "<group>"; };
+		C8CD7DD325E63D0A0018C655 /* BrickCategoryOverviewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrickCategoryOverviewControllerTests.swift; sourceTree = "<group>"; };
 		CA02C5E61B14386900233FB0 /* CBSpriteNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CBSpriteNode.swift; path = PlayerEngine/DataModel/CBSpriteNode/CBSpriteNode.swift; sourceTree = "<group>"; };
 		CA2D44421B12305400A3B53D /* Swell.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Swell.plist; sourceTree = "<group>"; };
 		CA2D44451B123B7E00A3B53D /* Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
@@ -5807,6 +5809,7 @@
 				4C4B4CE523EEA6BF0054C861 /* BaseTableViewControllerTests.swift */,
 				46F1754D24C46837006B2ACA /* ScriptCollectionViewControllerTests.swift */,
 				4C7182DE23EEF21800195BC7 /* BrickCategoryViewControllerTests.swift */,
+				C8CD7DD325E63D0A0018C655 /* BrickCategoryOverviewControllerTests.swift */,
 				4CAEB26B23F3F8BC00DB31BB /* CatrobatTableViewControllerTests.swift */,
 				4C4B4CDE23EE98C80054C861 /* CustomAlertControllerTests.swift */,
 				4C7182E223EF0AEB00195BC7 /* FormulaEditorViewControllerTests.swift */,
@@ -11842,6 +11845,7 @@
 				4C5AEEF522F6F33A00280F8B /* IfLogicBeginBrickCellTests.swift in Sources */,
 				9E1444F6228B531400104F77 /* ExtendedTimerTests.swift in Sources */,
 				4C822682213FA7A400F3D750 /* PhiroSensorTest.swift in Sources */,
+				C8CD7DD425E63D0A0018C655 /* BrickCategoryOverviewControllerTests.swift in Sources */,
 				4C822669213FA7A400F3D750 /* TimeMinuteSensorTest.swift in Sources */,
 				46B94F9725791507007E5ABE /* StitchBrickTests.swift in Sources */,
 				4CEB22731B95E4BC00B3BE2F /* BrickInsertManagerAbstractTest.m in Sources */,

--- a/src/Catty/DataModel/Bricks/Category/BrickCategory.swift
+++ b/src/Catty/DataModel/Bricks/Category/BrickCategory.swift
@@ -26,12 +26,14 @@
     @objc public let name: String
     @objc public let color: UIColor
     @objc public let strokeColor: UIColor
+    @objc public let enabled: Bool
 
-    init(type: kBrickCategoryType, name: String, color: UIColor, strokeColor: UIColor) {
+    init(type: kBrickCategoryType, name: String, color: UIColor, strokeColor: UIColor, enabled: Bool) {
         self.type = type
         self.name = name
         self.color = color
         self.strokeColor = strokeColor
+        self.enabled = enabled
     }
 
     @objc public func colorDisabled() -> UIColor {

--- a/src/Catty/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en.lproj/Localizable.strings
@@ -512,9 +512,6 @@
 "Download" = "Download";
 
 /* No comment provided by engineer. */
-"Download successful" = "Download successful";
-
-/* No comment provided by engineer. */
 "Downloads" = "Downloads";
 
 /* No comment provided by engineer. */
@@ -1154,9 +1151,6 @@
 "not available. Continue anyway?" = "not available. Continue anyway?";
 
 /* No comment provided by engineer. */
-"Not enough free memory to download this project. Please delete some of your projects" = "Not enough free memory to download this project. Please delete some of your projects";
-
-/* No comment provided by engineer. */
 "Not enough Memory" = "Not enough Memory";
 
 /* No comment provided by engineer. */
@@ -1734,9 +1728,6 @@
 
 /* No comment provided by engineer. */
 "The recent projects cannot be loaded" = "The recent projects cannot be loaded";
-
-/* No comment provided by engineer. */
-"The requested project can not be found. Please choose a different one." = "The requested project can not be found. Please choose a different one.";
 
 /* No comment provided by engineer. */
 "The requested project can not be loaded. Please try again later." = "The requested project can not be loaded. Please try again later.";

--- a/src/Catty/Setup/CatrobatSetup+Bricks.swift
+++ b/src/Catty/Setup/CatrobatSetup+Bricks.swift
@@ -134,65 +134,74 @@
 
     @objc public static func registeredBrickCategories() -> [BrickCategory] {
         var categories = [
+            BrickCategory(type: kBrickCategoryType.embroideryBrick,
+                          name: kLocalizedCategoryEmbroidery,
+                          color: UIColor.embroideryBrickPink,
+                          strokeColor: UIColor.embroideryBrickStroke,
+                          enabled: isEmbroideryEnabled()),
+
+            BrickCategory(type: kBrickCategoryType.arduinoBrick,
+                          name: kLocalizedCategoryArduino,
+                          color: UIColor.arduinoBrick,
+                          strokeColor: UIColor.arduinoBrickStroke,
+                          enabled: isArduinoEnabled()),
+
             BrickCategory(type: kBrickCategoryType.eventBrick,
                           name: kLocalizedCategoryEvent,
                           color: UIColor.eventBrick,
-                          strokeColor: UIColor.eventBrickStroke),
+                          strokeColor: UIColor.eventBrickStroke,
+                          enabled: true),
 
             BrickCategory(type: kBrickCategoryType.controlBrick,
                           name: kLocalizedCategoryControl,
                           color: UIColor.controlBrickOrange,
-                          strokeColor: UIColor.controlBrickStroke),
+                          strokeColor: UIColor.controlBrickStroke,
+                          enabled: true),
 
             BrickCategory(type: kBrickCategoryType.motionBrick,
                           name: kLocalizedCategoryMotion,
                           color: UIColor.motionBrickBlue,
-                          strokeColor: UIColor.motionBrickStroke),
+                          strokeColor: UIColor.motionBrickStroke,
+                          enabled: true),
 
             BrickCategory(type: kBrickCategoryType.lookBrick,
                           name: kLocalizedCategoryLook,
                           color: UIColor.lookBrickGreen,
-                          strokeColor: UIColor.lookBrickStroke),
+                          strokeColor: UIColor.lookBrickStroke,
+                          enabled: true),
 
             BrickCategory(type: kBrickCategoryType.penBrick,
                           name: kLocalizedCategoryPen,
                           color: UIColor.penBrickGreen,
-                          strokeColor: UIColor.penBrickStroke),
+                          strokeColor: UIColor.penBrickStroke,
+                          enabled: true),
 
             BrickCategory(type: kBrickCategoryType.soundBrick,
                           name: kLocalizedCategorySound,
                           color: UIColor.soundBrickViolet,
-                          strokeColor: UIColor.soundBrickStroke),
+                          strokeColor: UIColor.soundBrickStroke,
+                          enabled: true),
 
             BrickCategory(type: kBrickCategoryType.dataBrick,
                           name: kLocalizedCategoryData,
                           color: UIColor.variableBrickRed,
-                          strokeColor: UIColor.variableBrickStroke)
+                          strokeColor: UIColor.variableBrickStroke,
+                          enabled: true)
         ]
 
         if isPhiroEnabled() {
             categories.prepend(BrickCategory(type: kBrickCategoryType.phiroBrick,
                                              name: kLocalizedCategoryPhiro,
                                              color: UIColor.phiroBrick,
-                                             strokeColor: UIColor.phiroBrickStroke))
-        }
-        if isArduinoEnabled() {
-            categories.prepend(BrickCategory(type: kBrickCategoryType.arduinoBrick,
-                                             name: kLocalizedCategoryArduino,
-                                             color: UIColor.arduinoBrick,
-                                             strokeColor: UIColor.arduinoBrickStroke))
-        }
-        if isEmbroideryEnabled() {
-            categories.prepend(BrickCategory(type: kBrickCategoryType.embroideryBrick,
-                                             name: kLocalizedCategoryEmbroidery,
-                                             color: UIColor.embroideryBrickPink,
-                                             strokeColor: UIColor.embroideryBrickStroke))
+                                             strokeColor: UIColor.phiroBrickStroke,
+                                             enabled: isPhiroEnabled()))
         }
         if isFavouritesCategoryAvailable() {
             categories.prepend(BrickCategory(type: kBrickCategoryType.favouriteBricks,
                                              name: kLocalizedCategoryFrequentlyUsed,
                                              color: UIColor.frequentlyUsedBricks,
-                                             strokeColor: UIColor.frequentlyUsedBricksStroke))
+                                             strokeColor: UIColor.frequentlyUsedBricksStroke,
+                                             enabled: isFavouritesCategoryAvailable()))
         }
 
         return categories

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryOverviewController.swift
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryOverviewController.swift
@@ -32,6 +32,10 @@ import UIKit
     @objc(init:) init(scriptCollectionViewController: ScriptCollectionViewController) {
         self.scriptCollectionViewController = scriptCollectionViewController
         categegoriesBricks = CatrobatSetup.self.registeredBrickCategories()
+
+        for category in categegoriesBricks where category.enabled == false {
+            categegoriesBricks.removeObject(category)
+        }
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -127,5 +131,4 @@ import UIKit
             presentingViewController?.dismiss(animated: true)
         }
     }
-
 }

--- a/src/CattyTests/Bricks/BrickCategoryTest.swift
+++ b/src/CattyTests/Bricks/BrickCategoryTest.swift
@@ -36,7 +36,8 @@ final class BrickCategoryTest: XCTestCase {
         let category = BrickCategory(type: kBrickCategoryType.controlBrick,
                                      name: kLocalizedCategoryControl,
                                      color: UIColor.controlBrickOrange,
-                                     strokeColor: UIColor.controlBrickStroke)
+                                     strokeColor: UIColor.controlBrickStroke,
+                                     enabled: true)
 
         XCTAssertEqual(expectedDisabledColor, category.colorDisabled())
     }
@@ -51,7 +52,8 @@ final class BrickCategoryTest: XCTestCase {
         let category = BrickCategory(type: kBrickCategoryType.controlBrick,
                                      name: kLocalizedCategoryControl,
                                      color: UIColor.controlBrickOrange,
-                                     strokeColor: UIColor.controlBrickStroke)
+                                     strokeColor: UIColor.controlBrickStroke,
+                                     enabled: true)
 
         XCTAssertEqual(expectedDisabledStrokeColor, category.strokeColorDisabled())
     }

--- a/src/CattyTests/Setup/CatrobatSetupTests.swift
+++ b/src/CattyTests/Setup/CatrobatSetupTests.swift
@@ -47,21 +47,24 @@ final class CatrobatSetupTests: XCTestCase {
         UserDefaults.standard.set(false, forKey: kUseArduinoBricks)
         UserDefaults.standard.set(false, forKey: kUseEmbroideryBricks)
 
-        let categories = CatrobatSetup.registeredBrickCategories()
+        var categories = CatrobatSetup.registeredBrickCategories()
 
         UserDefaults.standard.set(true, forKey: kUsePhiroBricks)
 
         let categoriesPhiroEnabled = CatrobatSetup.registeredBrickCategories()
-        XCTAssertTrue(categoriesPhiroEnabled.count > categories.count)
+        XCTAssertEqual(categoriesPhiroEnabled.count, categories.count + 1)
+
+        for category in categories where category.name == kLocalizedCategoryEmbroidery || category.name == kLocalizedCategoryArduino {
+            XCTAssertEqual(category.enabled, false)
+        }
 
         UserDefaults.standard.set(true, forKey: kUseArduinoBricks)
-
-        let categoriesArduinoEnabled = CatrobatSetup.registeredBrickCategories()
-        XCTAssertTrue(categoriesArduinoEnabled.count > categoriesPhiroEnabled.count)
-
         UserDefaults.standard.set(true, forKey: kUseEmbroideryBricks)
 
-        let categoriesEmbroideryEnabled = CatrobatSetup.registeredBrickCategories()
-        XCTAssertTrue(categoriesEmbroideryEnabled.count > categoriesArduinoEnabled.count)
+        categories = CatrobatSetup.registeredBrickCategories()
+
+        for category in categories where category.name == kLocalizedCategoryEmbroidery || category.name == kLocalizedCategoryArduino {
+            XCTAssertEqual(category.enabled, true)
+        }
     }
 }

--- a/src/CattyTests/ViewController/BrickCategoryOverviewControllerTests.swift
+++ b/src/CattyTests/ViewController/BrickCategoryOverviewControllerTests.swift
@@ -1,0 +1,44 @@
+/**
+ *  Copyright (C) 2010-2021 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+@testable import Pocket_Code
+
+final class BrickCategoryOverviewControllerTest: XCTestCase {
+
+    func testDisplayEnabledCategories () {
+        UserDefaults.standard.set(false, forKey: kUseArduinoBricks)
+        UserDefaults.standard.set(false, forKey: kUseEmbroideryBricks)
+
+        let scriptCollectionViewController = ScriptCollectionViewController()
+        var overview = BrickCategoryOverviewController(scriptCollectionViewController: scriptCollectionViewController)
+
+        let count = overview.categegoriesBricks.count
+        UserDefaults.standard.set(true, forKey: kUseArduinoBricks)
+        UserDefaults.standard.set(true, forKey: kUseEmbroideryBricks)
+
+        overview = BrickCategoryOverviewController(scriptCollectionViewController: scriptCollectionViewController)
+
+        XCTAssertEqual(count, overview.categegoriesBricks.count - 2)
+    }
+}

--- a/src/CattyTests/ViewController/BrickCategoryViewControllerTests.swift
+++ b/src/CattyTests/ViewController/BrickCategoryViewControllerTests.swift
@@ -34,7 +34,7 @@ final class BrickCategoryViewControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let brickCategory = BrickCategory(type: kBrickCategoryType.controlBrick, name: "testCategory", color: UIColor.clear, strokeColor: UIColor.clear)
+        let brickCategory = BrickCategory(type: kBrickCategoryType.controlBrick, name: "testCategory", color: UIColor.clear, strokeColor: UIColor.clear, enabled: true)
         let spiteObject = SpriteObject()
 
         controller = BrickCategoryViewController(brickCategory: brickCategory, andObject: spiteObject)


### PR DESCRIPTION
When opening a project with a Brick of a currently disabled extension (e.g., Arduino or later also Embroidery), the Brick is displayed in black. Instead the Brick should always be displayed in its actual color.
Probably that's because the category is not added at the BrickSetup. From a user point of view, this behavior should not change, meaning the category should be disabled for the user (maybe added but hidden?).

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
