### PR TITLE
CATTY-528 Fix occasional testFormulaEditorSave failure

### DIFF
--- a/src/CattyUITests/FormulaEditorTests.swift
+++ b/src/CattyUITests/FormulaEditorTests.swift
@@ -59,7 +59,7 @@ class FormulaEditorTests: XCTestCase {
             XCTFail("Script Collection View is not updated with the changed formula")
         }
 
-        XCTWaiter().wait(for: [XCTNSNotificationExpectation(name: NSNotification.Name(rawValue: "Wait for project to be saved"))], timeout: 4)
+        XCTWaiter().wait(for: [XCTNSNotificationExpectation(name: NSNotification.Name(rawValue: "Wait for project to be saved"))], timeout: 10)
 
         app.navigationBars.buttons[kLocalizedMole + " 1"].tap()
         app.navigationBars.buttons[kLocalizedMyFirstProject].tap()


### PR DESCRIPTION
Fix occasional testFormulaEditorSave failure by increasing the wait time.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
