### PR TITLE
CATTY-523 Convert Util methods to Swift 2/3

### DIFF
--- a/src/Catty/Extension&Delegate&Protocol/Extensions/UIViewController/CatrobatTableViewControllerExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/UIViewController/CatrobatTableViewControllerExtension.swift
@@ -43,7 +43,7 @@ import Foundation
 
     @nonobjc func openURL(url: URL, storeProjectDownloader: StoreProjectDownloaderProtocol) {
         guard let projectId = CatrobatTableViewController.catrobatProjectIdFromURL(url: url) else {
-            Util.alert(withText: kLocalizedInvalidURLGiven)
+            Util.alert(text: kLocalizedInvalidURLGiven)
             return
         }
         self.showLoadingView()
@@ -52,11 +52,11 @@ import Foundation
             self.hideLoadingView()
 
             guard error == nil else {
-                Util.alert(withText: kLocalizedUnableToLoadProject)
+                Util.alert(text: kLocalizedUnableToLoadProject)
                 return
             }
             guard let storeProject = project else {
-                Util.alert(withText: kLocalizedInvalidZip)
+                Util.alert(text: kLocalizedInvalidZip)
                 return
             }
             let catrobatProject = storeProject.toCatrobatProject()

--- a/src/Catty/Extension&Delegate&Protocol/Extensions/UIViewController/ProjectDetailStoreViewControllerDownloadExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/UIViewController/ProjectDetailStoreViewControllerDownloadExtension.swift
@@ -36,7 +36,7 @@ extension ProjectDetailStoreViewController {
                     case .unexpectedError, .timeout:
                         Util.defaultAlertForNetworkError()
                     case .parse(error: _), .request(error: _, statusCode: _):
-                        Util.alert(withText: kLocalizedInvalidZip)
+                        Util.alert(text: kLocalizedInvalidZip)
                     }
 
                     self.resetDownloadStatus()

--- a/src/Catty/Extension&Delegate&Protocol/Extensions/UIViewController/ProjectDetailStoreViewControllerReportExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/UIViewController/ProjectDetailStoreViewControllerReportExtension.swift
@@ -26,7 +26,7 @@ import Foundation
 extension ProjectDetailStoreViewController {
     func reportProject() {
         guard UserDefaults.standard.bool(forKey: NetworkDefines.kUserIsLoggedIn) else {
-            Util.alert(withText: kLocalizedLoginToReport)
+            Util.alert(text: kLocalizedLoginToReport)
             return
         }
 
@@ -35,7 +35,7 @@ extension ProjectDetailStoreViewController {
             .addDefaultActionWithTitle(kLocalizedOK, handler: {report in
                 let isValidInput = self.validateInput(input: report)
                 guard isValidInput.valid else {
-                    Util.alert(withText: isValidInput.localizedMessage)
+                    Util.alert(text: isValidInput.localizedMessage!)
                     return
                 }
                 self.sendReport(message: report)
@@ -53,13 +53,13 @@ extension ProjectDetailStoreViewController {
                     Util.defaultAlertForNetworkError()
                     self.hideLoadingView()
                 } else {
-                    Util.alert(withText: kLocalizedProjectNotReported)
+                    Util.alert(text: kLocalizedProjectNotReported)
                 }
                 return
             }
 
             DispatchQueue.main.async(execute: {
-                Util.alert(withText: kLocalizedReportedProject)
+                Util.alert(text: kLocalizedReportedProject)
             })
         })
     }

--- a/src/Catty/Extension&Delegate&Protocol/Extensions/UIViewController/UIViewControllerExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/UIViewController/UIViewControllerExtension.swift
@@ -47,18 +47,18 @@ extension UIViewController {
 
     @nonobjc func openProjectDetails(url: URL, storeProjectDownloader: StoreProjectDownloaderProtocol) {
         guard let projectId = url.catrobatProjectId() else {
-            Util.alert(withText: kLocalizedInvalidURLGiven)
+            Util.alert(text: kLocalizedInvalidURLGiven)
             return
         }
 
         storeProjectDownloader.fetchProjectDetails(for: projectId, completion: {project, error in
 
             guard error == nil else {
-                Util.alert(withText: kLocalizedUnableToLoadProject)
+                Util.alert(text: kLocalizedUnableToLoadProject)
                 return
             }
             guard let storeProject = project else {
-                Util.alert(withText: kLocalizedInvalidZip)
+                Util.alert(text: kLocalizedInvalidZip)
                 return
             }
             let catrobatProject = storeProject.toCatrobatProject()

--- a/src/Catty/Helpers/Bluetooth/BluetoothService.swift
+++ b/src/Catty/Helpers/Bluetooth/BluetoothService.swift
@@ -262,21 +262,21 @@ open class BluetoothService: NSObject {
         if let manager = self.selectionManager {
             manager.deviceNotResponding()
         }
-        Util.alert(withTitle: klocalizedBluetoothConnectionFailed, andText: klocalizedBluetoothNotResponding)
+        Util.alert(title: klocalizedBluetoothConnectionFailed, text: klocalizedBluetoothNotResponding)
     }
 
     func giveUpFailure() {
         if let manager = self.selectionManager {
             manager.giveUpConnectionToDevice()
         }
-        Util.alert(withTitle: klocalizedBluetoothConnectionLost, andText: klocalizedBluetoothDisconnected)
+        Util.alert(title: klocalizedBluetoothConnectionLost, text: klocalizedBluetoothDisconnected)
     }
 
     func connectionFailure() {
         if let manager = self.selectionManager {
             manager.deviceFailedConnection()
         }
-        Util.alert(withTitle: klocalizedBluetoothConnectionFailed, andText: klocalizedBluetoothCannotConnect)
+        Util.alert(title: klocalizedBluetoothConnectionFailed, text: klocalizedBluetoothCannotConnect)
     }
 
     //    func setPhiroDevice(peripheral:Peripheral){

--- a/src/Catty/Helpers/Util/Util.h
+++ b/src/Catty/Helpers/Util/Util.h
@@ -55,10 +55,6 @@ if (__functor) __functor(__VA_ARGS__);  \
 
 + (UIViewController* _Nonnull)topmostViewController;
 
-+ (void)alertWithText:(NSString* _Nullable)text;
-
-+ (void)alertWithTitle:(NSString* _Nullable)title andText:(NSString* _Nullable)text;
-
 + (void)askUserForVariableNameAndPerformAction:(SEL _Nullable)action
                                         target:(id _Nullable)target
                                    promptTitle:(NSString* _Nullable)title
@@ -115,10 +111,6 @@ if (__functor) __functor(__VA_ARGS__);  \
 
 + (NSString* _Nullable)uniqueName:(NSString* _Nullable)nameToCheck existingNames:(NSArray* _Nullable)existingNames;
 
-+ (void)showNotificationWithMessage:(NSString* _Nullable)message;
-
-+ (void)showNotificationForSaveAction;
-
 + (CGFloat)detectCBLanguageVersionFromXMLWithPath:(NSString* _Nullable)xmlPath;
 
 + (double)radiansToDegree:(double)rad;
@@ -138,10 +130,6 @@ if (__functor) __functor(__VA_ARGS__);  \
 + (NSMutableOrderedSet* _Nullable)allMessagesForProject:(Project* _Nonnull)project;
 
 + (BOOL)isNetworkError:(NSError* _Nullable)error;
-
-+ (void)defaultAlertForNetworkError;
-
-+ (void)defaultAlertForUnknownError;
 
 + (NSDictionary* _Nullable)getBrickInsertionDictionaryFromUserDefaults;
 

--- a/src/Catty/Helpers/Util/Util.m
+++ b/src/Catty/Helpers/Util/Util.m
@@ -73,19 +73,6 @@
     return [self topViewControllerInViewController:ROOTVIEW];
 }
 
-+ (void)alertWithText:(NSString*)text
-{
-    [Util alertWithTitle:kLocalizedPocketCode andText:text];
-}
-
-+ (void)alertWithTitle:(NSString *)title andText:(NSString *)text
-{
-    [[[[AlertControllerBuilder alertWithTitle:title message:text]
-     addCancelActionWithTitle:kLocalizedOK handler:nil]
-     build]
-     showWithController:[Util topmostViewController]];
-}
-
 + (CATransition*)getPushCATransition
 {
     CATransition *transition = [CATransition animation];
@@ -135,7 +122,7 @@
     } else {
         return [InputValidationResult validInput];
     }
-    
+
     NSAssert(invalidNameMessage != nil, @"This case should already be handled");
     return [InputValidationResult invalidInputWithLocalizedMessage:invalidNameMessage];
 }
@@ -206,7 +193,7 @@
      }]
      valueValidator:^InputValidationResult *(NSString *name) {
          InputValidationResult *result = [self validationResultWithName:name minLength:minInputLength maxlength:maxInputLength];
-         
+
          if (!result.valid) {
              return result;
          }
@@ -278,7 +265,7 @@
          } else {
              return [InputValidationResult validInput];
          }
-         
+
          NSAssert(invalidNameMessage != nil, @"This case should already be handled");
          return [InputValidationResult invalidInputWithLocalizedMessage:invalidNameMessage];
      }] build]
@@ -427,30 +414,30 @@
 {
     unsigned count;
     objc_property_t *properties = class_copyPropertyList([instance class], &count);
-    
+
     NSMutableDictionary *propertiesDictionary = [NSMutableDictionary new];
-    
+
     unsigned i;
     for (i = 0; i < count; i++)
     {
         objc_property_t property = properties[i];
-        
+
         NSString *name = [NSString stringWithUTF8String:property_getName(property)];
-        
+
         // TODO use introspection
         if ([name isEqualToString:@"hash"] || [name isEqualToString:@"superclass"]
             || [name isEqualToString:@"description"] || [name isEqualToString:@"debugDescription"]
             || [name isEqualToString:@"brickCategoryType"] || [name isEqualToString:@"brickType"]) {
             continue;
         }
-        
+
         NSObject *currentProperty = [instance valueForKey:name];
         if(currentProperty != nil)
             [propertiesDictionary setValue:currentProperty forKey:name];
     }
-    
+
     free(properties);
-    
+
     return propertiesDictionary;
 }
 
@@ -458,7 +445,7 @@
 {
     NSString *sceneNumberAsString = [NSString stringWithFormat:@" %@",  @(sceneNumber)];
     NSString *sceneNameForSceneNumber = [kLocalizedScene stringByAppendingString:sceneNumberAsString];
-    
+
     return sceneNameForSceneNumber;
 }
 
@@ -547,28 +534,6 @@
     return error && error.code != kCFURLErrorCancelled;
 }
 
-+ (void)defaultAlertForNetworkError
-{
-    if ([NSThread isMainThread]) {
-        [[self class] alertWithText:kLocalizedErrorInternetConnection];
-    } else {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [Util defaultAlertForNetworkError];
-        });
-    }
-}
-
-+ (void)defaultAlertForUnknownError
-{
-    if ([NSThread isMainThread]) {
-        [[self class] alertWithText:kLocalizedErrorUnknown];
-    } else {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [Util defaultAlertForUnknownError];
-        });
-    }
-}
-
 #pragma mark - brick statistics
 
 + (NSDictionary*)getBrickInsertionDictionaryFromUserDefaults
@@ -627,7 +592,7 @@
                                      return NSOrderedAscending;
                                  }
                              }];
-    
+
     NSUInteger count = ([sortedBricks count] >= N) ? N : [sortedBricks count];
     NSRange range;
     range.location = 0;
@@ -675,36 +640,6 @@
     string = [string stringByReplacingOccurrencesOfString:@"%3C" withString:@"<"];
     string = [string stringByReplacingOccurrencesOfString:@"%3E" withString:@">"];
     return string;
-}
-
-+ (void)showNotificationWithMessage:(NSString *)message
-{
-    BDKNotifyHUD *notficicationHud = [BDKNotifyHUD notifyHUDWithImage:nil text:message];
-    UIViewController *vc = [Util topmostViewController];
-    
-    notficicationHud.destinationOpacity = kBDKNotifyHUDDestinationOpacity;
-    notficicationHud.center = CGPointMake(vc.view.center.x, vc.view.center.y);
-    
-    [vc.view addSubview:notficicationHud];
-    [notficicationHud presentWithDuration:kBDKNotifyHUDPresentationDuration
-                                    speed:kBDKNotifyHUDPresentationSpeed
-                                   inView:vc.view
-                               completion:^{ [notficicationHud removeFromSuperview]; }];
-}
-
-+ (void)showNotificationForSaveAction {
-    BDKNotifyHUD *hud = [BDKNotifyHUD notifyHUDWithImage:[UIImage imageNamed:kBDKNotifyHUDCheckmarkImageName] text:kLocalizedSaved];
-    UIViewController *vc = [Util topmostViewController];
-    
-    hud.destinationOpacity = kBDKNotifyHUDDestinationOpacity;
-    hud.center = CGPointMake(vc.view.center.x, vc.view.center.y + kBDKNotifyHUDCenterOffsetY);
-    hud.tag = kSavedViewTag;
-    
-    [vc.view addSubview:hud];
-    [hud presentWithDuration:kBDKNotifyHUDPresentationDuration
-                       speed:kBDKNotifyHUDPresentationSpeed
-                      inView:vc.view
-                  completion:^{ [hud removeFromSuperview]; }];
 }
 
 + (void)openUrlExternal:(NSURL*)url

--- a/src/Catty/Helpers/Util/Util.swift
+++ b/src/Catty/Helpers/Util/Util.swift
@@ -50,6 +50,18 @@ func synchronized(lock: AnyObject, closure: () -> Void) {
         return appBuildVersion
     }
 
+    @objc(alertWithText:)
+    class func alert(text: String) {
+        alert(title: kLocalizedPocketCode, text: text)
+    }
+
+    @objc(alertWithTitle:andText:)
+    class func alert(title: String, text: String) {
+        AlertControllerBuilder.alert(title: title, message: text)
+            .addCancelAction(title: kLocalizedOK, handler: nil)
+            .build().showWithController(Util.topmostViewController())
+    }
+
     class func catrobatLanguageVersion() -> String {
         let catrobatLanguageVersion = Bundle.main.infoDictionary?["CatrobatLanguageVersion"] as! String
         return catrobatLanguageVersion
@@ -70,6 +82,26 @@ func synchronized(lock: AnyObject, closure: () -> Void) {
         return deviceName
     }
 
+    class func defaultAlertForNetworkError() {
+        if Thread.isMainThread {
+            alert(text: kLocalizedErrorInternetConnection)
+        } else {
+            DispatchQueue.main.async(execute: {
+                Util.defaultAlertForNetworkError()
+            })
+        }
+    }
+
+    class func defaultAlertForUnknownError() {
+        if Thread.isMainThread {
+            alert(text: kLocalizedErrorUnknown)
+        } else {
+            DispatchQueue.main.async(execute: {
+                Util.defaultAlertForUnknownError()
+            })
+        }
+    }
+
     class func platformName() -> String? {
         let platformName = Bundle.main.infoDictionary?["CatrobatPlatformName"] as? String
         return platformName
@@ -88,6 +120,7 @@ func synchronized(lock: AnyObject, closure: () -> Void) {
         let platformVersionWithPatch = "\(major).\(minor).\(patch)" as String
         return platformVersionWithPatch
     }
+
     class func platformVersionWithoutPatch() -> String {
         let os = self.platformVersion()
         let major = String(format: "%ld", os.majorVersion)
@@ -131,5 +164,51 @@ func synchronized(lock: AnyObject, closure: () -> Void) {
     class func statusBarHeight() -> CGFloat {
         let statusBarSize = UIApplication.shared.statusBarFrame.size
         return min(statusBarSize.width, statusBarSize.height)
+    }
+
+    class func showNotification(withMessage message: String?) {
+        guard let hud = BDKNotifyHUD(image: nil, text: message) else {
+            return
+        }
+
+        let vc = Util.topmostViewController()
+        if vc.view == nil {
+            return
+        }
+
+        hud.destinationOpacity = CGFloat(kBDKNotifyHUDDestinationOpacity)
+        hud.center = CGPoint(x: vc.view.center.x, y: vc.view.center.y)
+
+        vc.view.addSubview(hud)
+        hud.present(withDuration: CGFloat(kBDKNotifyHUDPresentationDuration),
+                    speed: CGFloat(kBDKNotifyHUDPresentationSpeed),
+                    in: vc.view,
+                    completion: {
+                        hud.removeFromSuperview()
+                    })
+    }
+
+    class func showNotificationForSaveAction() {
+        guard let hud = BDKNotifyHUD(image: UIImage(named: kBDKNotifyHUDCheckmarkImageName), text: kLocalizedSaved) else {
+            return
+        }
+
+        let vc = Util.topmostViewController()
+        if vc.view == nil {
+            return
+        }
+
+        hud.destinationOpacity = CGFloat(kBDKNotifyHUDDestinationOpacity)
+        hud.center = CGPoint(x: vc.view.center.x,
+                             y: vc.view.center.y + CGFloat(kBDKNotifyHUDCenterOffsetY))
+        hud.tag = Int(kSavedViewTag)
+
+        vc.view.addSubview(hud)
+        hud.present(withDuration: CGFloat(kBDKNotifyHUDPresentationDuration),
+                    speed: CGFloat(kBDKNotifyHUDPresentationSpeed),
+                    in: vc.view,
+                    completion: {
+                        hud.removeFromSuperview()
+                    })
     }
 }

--- a/src/Catty/ViewController/BluetoothDeviceSelection/BluetoothDevicesTableViewController.swift
+++ b/src/Catty/ViewController/BluetoothDeviceSelection/BluetoothDevicesTableViewController.swift
@@ -76,7 +76,7 @@ class BluetoothDevicesTableViewController: UITableViewController {
             if deviceArray[0] == BluetoothDeviceID.phiro.rawValue {
                 guard let _ = BluetoothService.sharedInstance().selectionManager else {
                     DispatchQueue.main.async {
-                        Util.alert(withTitle: klocalizedBluetoothConnectionNotPossible, andText: klocalizedBluetoothConnectionTryResetting )
+                        Util.alert(title: klocalizedBluetoothConnectionNotPossible, text: klocalizedBluetoothConnectionTryResetting )
                         self.delegate?.dismissAndDisconnect()
                     }
                     return
@@ -85,7 +85,7 @@ class BluetoothDevicesTableViewController: UITableViewController {
             } else if deviceArray[0] == BluetoothDeviceID.arduino.rawValue {
                 guard let _ = BluetoothService.sharedInstance().selectionManager else {
                     DispatchQueue.main.async {
-                        Util.alert(withTitle: klocalizedBluetoothConnectionNotPossible, andText: klocalizedBluetoothConnectionTryResetting)
+                        Util.alert(title: klocalizedBluetoothConnectionNotPossible, text: klocalizedBluetoothConnectionTryResetting)
                         self.delegate?.dismissAndDisconnect()
                     }
                     return

--- a/src/Catty/ViewController/CatrobatTableViewController/SettingsTableViewController.swift
+++ b/src/Catty/ViewController/CatrobatTableViewController/SettingsTableViewController.swift
@@ -196,7 +196,7 @@ class SettingsTableViewController: BOTableViewController {
     }
 
     fileprivate func presentAlertController(withTitle title: String?, message: String?) {
-        Util.alert(withTitle: title, andText: message)
+        Util.alert(title: title!, text: message!)
     }
 
     fileprivate func openRateUsURL() {
@@ -213,12 +213,12 @@ class SettingsTableViewController: BOTableViewController {
 
     fileprivate func disconnect() {
         BluetoothService.sharedInstance().disconnect()
-        Util.alert(withText: kLocalizedDisconnectBluetoothDevices)
+        Util.alert(text: kLocalizedDisconnectBluetoothDevices)
     }
 
     fileprivate func removeKnownDevices() {
         BluetoothService.sharedInstance().removeKnownDevices()
-        Util.alert(withText: kLocalizedRemovedKnownBluetoothDevices)
+        Util.alert(text: kLocalizedRemovedKnownBluetoothDevices)
     }
 
     fileprivate func logoutUser() {

--- a/src/Catty/ViewController/PrivacyPolicy/PrivacyPolicyViewController.swift
+++ b/src/Catty/ViewController/PrivacyPolicy/PrivacyPolicyViewController.swift
@@ -48,7 +48,7 @@ class PrivacyPolicyViewController: UIViewController {
     }
 
     @IBAction private func disagreeButtonAction(_ sender: UIButton) {
-        Util.alert(withText: kLocalizedPrivacyPolicyDenyText)
+        Util.alert(text: kLocalizedPrivacyPolicyDenyText)
     }
 
     @IBAction private func acceptButtonAction(_ sender: UIButton) {

--- a/src/Catty/ViewController/Stage/StagePresenterViewControllerResourcesExtension.swift
+++ b/src/Catty/ViewController/Stage/StagePresenterViewControllerResourcesExtension.swift
@@ -34,7 +34,7 @@ import CoreBluetooth
             guard let project = Project.init(loadingInfo: Util.lastUsedProjectLoadingInfo()) else {
                 DispatchQueue.main.async {
                     self.hideLoadingView()
-                    Util.alert(withText: kLocalizedInvalidZip)
+                    Util.alert(text: kLocalizedInvalidZip)
                 }
                 return
             }
@@ -136,9 +136,9 @@ import CoreBluetooth
                 top?.present(navController, animated: true)
 
             } else if CentralManager.sharedInstance.state == ManagerState.poweredOff {
-                Util.alert(withText: kLocalizedBluetoothPoweredOff)
+                Util.alert(text: kLocalizedBluetoothPoweredOff)
             } else {
-                Util.alert(withText: kLocalizedBluetoothNotAvailable)
+                Util.alert(text: kLocalizedBluetoothNotAvailable)
             }
         }
     }

--- a/src/Catty/ViewController/Upload/UploadViewController.swift
+++ b/src/Catty/ViewController/Upload/UploadViewController.swift
@@ -372,7 +372,7 @@ class UploadViewController: UIViewController, UploadCategoryViewControllerDelega
 
     @objc func checkProjectAction() {
         if projectNameTextField.text!.isEmpty {
-            Util.alert(withText: kLocalizedUploadProjectNecessary)
+            Util.alert(text: kLocalizedUploadProjectNecessary)
             return
         }
 
@@ -415,7 +415,7 @@ class UploadViewController: UIViewController, UploadCategoryViewControllerDelega
                                     case .unexpectedError, .timeout:
                                         Util.defaultAlertForNetworkError()
                                     case .zippingError, .invalidProject, .request:
-                                        Util.alert(withText: kLocalizedUploadProblem)
+                                        Util.alert(text: kLocalizedUploadProblem)
                                     case .authenticationFailed:
                                         UserDefaults.standard.set(false, forKey: NetworkDefines.kUserIsLoggedIn)
 


### PR DESCRIPTION
CATTY-523 Convert Util methods to Swift 2/3

The following methods of Util.m (and Util.h) have been converted Swift (Util.swift):
alertWithText
alertWithTitle
defaultAlertForNetworkError
defaultAlertForUnknownError
showNotificationWithMessage
showNotificationForSaveAction

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
