### PR TITLE
CATTY-518: App crash when computing "direction" in FE

### DIFF
--- a/src/Catty/PlayerEngine/Sensors/Object/RotationSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Object/RotationSensor.swift
@@ -61,6 +61,7 @@
 
     // raw value is in radians, standardized value is in degrees
     @objc static func convertToStandardized(rawValue: Double, for spriteObject: SpriteObject) -> Double {
+        guard let _ = spriteObject.spriteNode else { return self.defaultRawValue }
         let rawValueDegrees = Util.radians(toDegree: rawValue)
         return self.convertSceneToDegrees(rawValueDegrees, for: spriteObject)
     }

--- a/src/CattyTests/PlayerEngine/Sensors/Object/RotationSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Object/RotationSensorTest.swift
@@ -256,4 +256,20 @@ final class RotationSensorTest: XCTestCase {
         type(of: sensor).setRawValue(userInput: 180.0, for: spriteObject)
         XCTAssertEqual(90.0, spriteNode.rotationDegreeOffset)
     }
+
+    func testConvertToStandardizedWithoutSpritNode() {
+        spriteObject.spriteNode = nil
+        XCTAssertEqual(0, type(of: sensor).convertToStandardized(rawValue: 0, for: spriteObject), accuracy: Double.epsilon)
+        XCTAssertEqual(0, type(of: sensor).convertToStandardized(rawValue: Double.pi, for: spriteObject), accuracy: Double.epsilon)
+        XCTAssertEqual(0, type(of: sensor).convertToStandardized(rawValue: Double.pi / 2, for: spriteObject), accuracy: Double.epsilon)
+        XCTAssertEqual(0, type(of: sensor).convertToStandardized(rawValue: Double.pi * 2, for: spriteObject), accuracy: Double.epsilon)
+        XCTAssertEqual(0, type(of: sensor).convertToStandardized(rawValue: Double.pi / 6, for: spriteObject), accuracy: Double.epsilon)
+
+        // after the first circle (360)
+        XCTAssertEqual(0, type(of: sensor).convertToStandardized(rawValue: Double.pi * 5, for: spriteObject), accuracy: Double.epsilon)
+
+        // before the first circle circle (0)
+        XCTAssertEqual(0, type(of: sensor).convertToStandardized(rawValue: -Double.pi * 4, for: spriteObject), accuracy: Double.epsilon)
+        XCTAssertEqual(0, type(of: sensor).convertToStandardized(rawValue: -Double.pi / 4, for: spriteObject), accuracy: Double.epsilon)
+    }
 }


### PR DESCRIPTION
App crash when computing "direction" in FE. Reproduce by adding the "direction" sensor and pressing "compute" in the Formula Editor.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
