### PR TITLE
CATTY-530 Modify Swift extension for ProjectDetailStoreViewController

### DIFF
--- a/src/Catty/Extension&Delegate&Protocol/Extensions/UIViewController/ProjectDetailStoreViewControllerReportExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/UIViewController/ProjectDetailStoreViewControllerReportExtension.swift
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2010-2020 The Catrobat Team
+ *  Copyright (C) 2010-2021 The Catrobat Team
  *  (http://developer.catrobat.org/credits)
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewController.h
+++ b/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewController.h
@@ -37,7 +37,9 @@
 @property (nonatomic, strong) CatrobatProject *project;
 @property (nonatomic, weak) IBOutlet UIScrollView *scrollViewOutlet;
 @property (nonatomic, strong) StoreProjectDownloader *storeProjectDownloader;
+@property (nonatomic, strong) UIView *projectView;
 
-- (void) hideLoadingView;
+- (void)showLoadingView;
+- (void)hideLoadingView;
 
 @end

--- a/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewController.m
+++ b/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewController.m
@@ -34,7 +34,6 @@
 
 @interface ProjectDetailStoreViewController ()
 
-@property (nonatomic, strong) UIView *projectView;
 @property (nonatomic, strong) LoadingView *loadingView;
 @property (nonatomic, strong) Project *loadedProject;
 @property (strong, nonatomic) NSURLSession *session;
@@ -71,28 +70,6 @@
     return _storeProjectDownloader;
 }
 
--(void)loadProject:(CatrobatProject*)project {
-    [self.projectView removeFromSuperview];
-    self.projectView = [self createViewForProject:project];
-    if(!self.project.author){
-        [self showLoadingView];
-        UIButton * button =(UIButton*)[self.projectView viewWithTag:kDownloadButtonTag];
-        button.enabled = NO;
-    }
-    CGFloat minHeight = self.view.frame.size.height;
-    [self.scrollViewOutlet addSubview:self.projectView];
-    self.scrollViewOutlet.delegate = self;
-    CGSize contentSize = self.projectView.bounds.size;
-    
-    if (contentSize.height < minHeight) {
-        contentSize.height = minHeight;
-    }
-    contentSize.height += 30.0f;
-    [self.scrollViewOutlet setContentSize:contentSize];
-    self.automaticallyAdjustsScrollViewInsets = NO;
-    self.scrollViewOutlet.userInteractionEnabled = YES;
-}
-
 - (void)initNavigationBar
 {
     self.title = self.navigationItem.title = kLocalizedDetails;
@@ -103,12 +80,6 @@
     [super viewWillDisappear:animated];
     self.hidesBottomBarWhenPushed = NO;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
-- (UIView*)createViewForProject:(CatrobatProject*)project
-{
-    UIView *view = [self createProjectDetailView:project target:self];
-    return view;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -137,21 +108,21 @@
 
 - (void)openButtonPressed:(id)sender
 {
-    
+
     NSString *localProjectName = [Project projectNameForProjectID:self.project.projectID];
-    
+
     [self showLoadingView];
     [CATransaction flush];
-    
+
     self.loadedProject = [Project projectWithLoadingInfo:[ProjectLoadingInfo projectLoadingInfoForProjectWithName:localProjectName projectID:self.project.projectID]];
-    
+
     [self hideLoadingView];
-    
+
     if (!self.loadedProject) {
         [Util alertWithText:kLocalizedUnableToLoadProject];
         return;
     }
-    
+
     [self openProject:self.loadedProject];
 }
 
@@ -206,15 +177,6 @@
     }
 }
 
-- (void)reloadWithProject:(CatrobatProject *)loadedProject
-{
-    [self loadProject:loadedProject];
-    UIButton * button =(UIButton*)[self.projectView viewWithTag:kDownloadButtonTag];
-    button.enabled = YES;
-    [self hideLoadingView];
-    [self.view setNeedsDisplay];
-}
-
 #pragma mark - loading view
 - (void)showLoadingView
 {
@@ -234,11 +196,11 @@
 - (void)stopLoading
 {
     [self.storeProjectDownloader cancelDownloadForProjectWithId:self.project.projectID];
-    
+
     EVCircularProgressView* button = (EVCircularProgressView*)[self.view viewWithTag:kStopLoadingTag];
     button.hidden = YES;
     button.progress = 0;
-    
+
     UIButton* downloadAgainButton = (UIButton*)[self.projectView viewWithTag:kDownloadAgainButtonTag];
     if(downloadAgainButton.enabled) {
         [self.view viewWithTag:kDownloadButtonTag].hidden = NO;

--- a/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewControllerExtension.swift
+++ b/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewControllerExtension.swift
@@ -38,7 +38,7 @@ let kHTMLAHrefTagPattern = "href=\"(.*?)\""
         self.addLoadingButton(to: view, withTarget: target)
         self.addOpenButton(to: view, withTarget: target)
         self.addDownloadAgainButton(to: view, withTarget: target)
-        self.addProjectDescriptionLabel(withDescription: project.projectDescription, to: view, target: target)
+        _ = self.addProjectDescriptionLabel(withDescription: project.projectDescription, to: view, target: target)
         let projectDouble = (project.uploaded as NSString).doubleValue
         let projectDate = Date(timeIntervalSince1970: TimeInterval(projectDouble))
         let uploaded = CatrobatProject.uploadDateFormatter().string(from: projectDate)
@@ -332,6 +332,11 @@ let kHTMLAHrefTagPattern = "href=\"(.*?)\""
         label?.layer.shadowOffset = CGSize(width: 0.0, height: 0.0)
     }
 
+    private func createView(forProject project: CatrobatProject) -> UIView? {
+        let view = self.createProjectDetailView(project, target: self)
+        return view
+    }
+
     private func getInformationTitleLabel(withTitle icon: UIImage?, atXPosition xPosition: CGFloat, atYPosition yPosition: CGFloat, andHeight height: CGFloat) -> UIImageView? {
         let titleInformation = UIImageView(frame: CGRect(x: xPosition, y: yPosition, width: 15, height: 15))
         titleInformation.image = icon
@@ -352,6 +357,30 @@ let kHTMLAHrefTagPattern = "href=\"(.*?)\""
         detailInformationLabel.backgroundColor = UIColor.clear
         detailInformationLabel.sizeToFit()
         return detailInformationLabel
+    }
+
+    func loadProject(_ project: CatrobatProject) {
+        self.projectView?.removeFromSuperview()
+        self.projectView = self.createView(forProject: project)
+
+        if self.project.author == nil {
+            self.showLoadingView()
+            let button = self.projectView.viewWithTag(Int(kDownloadButtonTag)) as! UIButton
+            button.isEnabled = false
+        }
+
+        self.scrollViewOutlet.addSubview(self.projectView)
+        self.scrollViewOutlet.delegate = self
+        var contentSize = self.projectView.bounds.size
+        let minHeight = self.view.frame.size.height
+
+        if contentSize.height < minHeight {
+            contentSize.height = minHeight
+        }
+        contentSize.height += 30.0
+        self.scrollViewOutlet.contentSize = contentSize
+        self.automaticallyAdjustsScrollViewInsets = false
+        self.scrollViewOutlet.isUserInteractionEnabled = true
     }
 
     private func setMaxHeightIfGreaterFor(_ view: UIView?, withHeight height: CGFloat) {

--- a/src/CattyTests/Extensions/ProjectDetailStoreViewControllerExtensionTests.swift
+++ b/src/CattyTests/Extensions/ProjectDetailStoreViewControllerExtensionTests.swift
@@ -35,9 +35,14 @@ class ProjectDetailStoreViewControllerExtensionTests: XCTestCase {
         self.projectDetailStoreVC.project = CatrobatProject.init()
         self.projectDetailStoreVC.project.projectID = "817"
         self.projectDetailStoreVC.project.projectName = "Tic-Tac-Toe Master"
+        self.projectDetailStoreVC.project.projectDescription = "This is a fun game"
+        self.projectDetailStoreVC.project.uploaded = "1614680355"
         self.projectDetailStoreVC.project.downloadUrl = "https://web-test.catrob.at/pocketcode/download/817.catrobat"
 
         self.projectDetailStoreVC.storeProjectDownloader = storeProjectDownloaderMock
+
+        let scrollView = UIScrollView()
+        self.projectDetailStoreVC.scrollViewOutlet = scrollView
 
         self.expectedZippedProjectData = "zippedProjectData".data(using: .utf8)
         self.projectDetailStoreVC.viewDidLoad()


### PR DESCRIPTION
https://jira.catrob.at/browse/CATTY-530

The following methods have been moved from ProjectDetailStoreViewController.m to ProjectDetailStoreViewControllerExtension.swift:
loadProject
createViewForProject

And the following method has been removed: reloadWithProject

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
