### PR TITLE
Catty-532 App crash -> allow to use photo library

### DIFF
--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController.m
@@ -839,17 +839,19 @@ UITextFieldDelegate>
         PHAuthorizationStatus status = [PHPhotoLibrary authorizationStatus];
         if (status == PHAuthorizationStatusNotDetermined) {
             [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
-                switch (status) {
-                    case PHAuthorizationStatusAuthorized:
-                        [self presentImagePicker:pickerType];
-                        break;
-                    case PHAuthorizationStatusRestricted:
-                        break;
-                    case PHAuthorizationStatusDenied:
-                        break;
-                    default:
-                        break;
-                }
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    switch (status) {
+                        case PHAuthorizationStatusAuthorized:
+                            [self presentImagePicker:pickerType];
+                            break;
+                        case PHAuthorizationStatusRestricted:
+                            break;
+                        case PHAuthorizationStatusDenied:
+                            break;
+                        default:
+                            break;
+                    }
+                });
             }];
         }else{
             state = YES;


### PR DESCRIPTION
If you are using the app for the first time and want to set a background, the app crashes if you give permission for the photo library.
Important: This happens only on the actual develop branch not on the latest Release.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
