### PR TITLE
CATTY-533 UnDo a rotation of an image, it is not on the correct position

### DIFF
--- a/src/Catty/PocketPaint/UndoManager/UndoManager.m
+++ b/src/Catty/PocketPaint/UndoManager/UndoManager.m
@@ -48,9 +48,20 @@
         // post notifications to update UI
     } else {
         [[self prepareWithInvocationTarget:self] setImage:(CIImage*)self.canvas.saveView.image];
-        //    self.canvas.helper.frame = CGRectMake(self.canvas.helper.frame.origin.x,self.canvas.helper.frame.origin.y, image.size.width, image.size.height);
-        //    self.canvas.saveView.frame = CGRectMake(self.canvas.saveView.frame.origin.x, self.canvas.saveView.frame.origin.y, image.size.width, image.size.height);
-        //    self.canvas.drawView.frame = CGRectMake(self.canvas.drawView.frame.origin.x, self.canvas.drawView.frame.origin.y, image.size.width, image.size.height);
+        
+        CGSize imageSize = image.size;
+        CGSize canvasSizes = self.canvas.helper.frame.size;
+        
+        if ((imageSize.height > imageSize.width && canvasSizes.height < canvasSizes.width) ||
+            (imageSize.height < imageSize.width && canvasSizes.height > canvasSizes.width)) {
+            CGFloat zoomScale = self.canvas.scrollView.zoomScale;
+            self.canvas.scrollView.zoomScale = 1.0;
+            self.canvas.saveView.frame = CGRectMake(0, 0, floor(self.canvas.helper.frame.size.height), floor(self.canvas.helper.frame.size.width));
+            self.canvas.drawView.frame = CGRectMake(0, 0, floor(self.canvas.helper.frame.size.height), floor(self.canvas.helper.frame.size.width));
+            self.canvas.helper.frame = CGRectMake(self.canvas.helper.frame.origin.x, self.canvas.helper.frame.origin.y, floor(self.canvas.helper.frame.size.height), floor(self.canvas.helper.frame.size.width));
+            self.canvas.scrollView.zoomScale = zoomScale;
+        }
+        
         self.canvas.saveView.image = image;
         [self.canvas.saveView setNeedsDisplay];
     }

--- a/src/Catty/Supporting Files/Catty-Bridging-Header.h
+++ b/src/Catty/Supporting Files/Catty-Bridging-Header.h
@@ -168,6 +168,7 @@
 #import "RuntimeImageCache.h"
 #import "CBMutableCopyContext.h"
 #import "CameraPreviewHandler.h"
+#import "UndoManager.h"
 
 //------------------------------------------------------------------------------------------------------------
 // ViewController classes

--- a/src/CattyTests/Mocks/PaintViewControllerMock.swift
+++ b/src/CattyTests/Mocks/PaintViewControllerMock.swift
@@ -23,6 +23,7 @@
 @testable import Pocket_Code
 
 class PaintViewControllerMock: PaintViewController {
+    var manager: UndoManager!
 
     let navigationControllerMock: UINavigationController
 
@@ -37,6 +38,8 @@ class PaintViewControllerMock: PaintViewController {
         self.navigationControllerMock = navigationController
 
         super.init(coder: coder)
+
+        manager = UndoManager.init(drawViewCanvas: self)
 
         self.editingImage = editingImage
         self.helper = UIView()

--- a/src/CattyTests/ViewController/PaintViewControllerTests.swift
+++ b/src/CattyTests/ViewController/PaintViewControllerTests.swift
@@ -123,6 +123,67 @@ final class PaintViewControllerTests: XCTestCase {
         XCTAssertTrue(Double(verticalDistanceUpperEdge - verticalDistanceLowerEdge) <= Double.epsilon)
     }
 
+    func testUndoDoNotRotateImage() {
+        let size = CGSize(width: CGFloat(100), height: CGFloat(150))
+        let image = createImage(size)
+        let frame = CGRect(x: 0, y: 0, width: floor(size.width), height: floor(size.height))
+
+        guard let paintViewControllerMock = PaintViewControllerMock(editingImage: image, navigationController: navigationController) else { return }
+        guard let undoManager = paintViewControllerMock.manager else { return }
+
+        paintViewControllerMock.saveView.frame = frame
+        paintViewControllerMock.drawView.frame = frame
+        paintViewControllerMock.helper.frame = frame
+
+        undoManager.setImage(image)
+
+        XCTAssertEqual(paintViewControllerMock.saveView.frame, frame)
+        XCTAssertEqual(paintViewControllerMock.drawView.frame, frame)
+        XCTAssertEqual(paintViewControllerMock.helper.frame, frame)
+    }
+
+    func testUndoVerticalRotateImage() {
+        let size = CGSize(width: CGFloat(100), height: CGFloat(150))
+        let image = createImage(size)
+
+        let frameHorizontal = CGRect(x: 0, y: 0, width: floor(size.height), height: floor(size.width))
+        let frameVertical = CGRect(x: 0, y: 0, width: floor(size.width), height: floor(size.height))
+
+        guard let paintViewControllerMock = PaintViewControllerMock(editingImage: image, navigationController: navigationController) else { return }
+        guard let undoManager = paintViewControllerMock.manager else { return }
+
+        paintViewControllerMock.saveView.frame = frameHorizontal
+        paintViewControllerMock.drawView.frame = frameHorizontal
+        paintViewControllerMock.helper.frame = frameHorizontal
+
+        undoManager.setImage(image)
+
+        XCTAssertEqual(paintViewControllerMock.saveView.frame, frameVertical)
+        XCTAssertEqual(paintViewControllerMock.drawView.frame, frameVertical)
+        XCTAssertEqual(paintViewControllerMock.helper.frame, frameVertical)
+    }
+
+    func testUndoHorizontalRotateImage() {
+        let size = CGSize(width: CGFloat(150), height: CGFloat(100))
+        let image = createImage(size)
+
+        let frameVertical = CGRect(x: 0, y: 0, width: floor(size.height), height: floor(size.width))
+        let frameHorizontal = CGRect(x: 0, y: 0, width: floor(size.width), height: floor(size.height))
+
+        guard let paintViewControllerMock = PaintViewControllerMock(editingImage: image, navigationController: navigationController) else { return }
+        guard let undoManager = paintViewControllerMock.manager else { return }
+
+        paintViewControllerMock.saveView.frame = frameVertical
+        paintViewControllerMock.drawView.frame = frameVertical
+        paintViewControllerMock.helper.frame = frameVertical
+
+        undoManager.setImage(image)
+
+        XCTAssertEqual(paintViewControllerMock.saveView.frame, frameHorizontal)
+        XCTAssertEqual(paintViewControllerMock.drawView.frame, frameHorizontal)
+        XCTAssertEqual(paintViewControllerMock.helper.frame, frameHorizontal)
+    }
+
     private func createImage(_ size: CGSize) -> UIImage {
         let rect = CGRect(origin: .zero, size: size)
 


### PR DESCRIPTION
Image is not on the correct position anymore, after rotate and undo this action. (PocketPaint, not Brick)

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
