### PR TITLE
CATTY-376 Image resolution worsens after rotating the background image

### DIFF
--- a/src/Catty/PocketPaint/Tools/MirrorRotationZoomTool.m
+++ b/src/Catty/PocketPaint/Tools/MirrorRotationZoomTool.m
@@ -99,28 +99,20 @@
 - (void)rotateRight
 {
   self.canvas.degrees += 90;
-    UIImage *image = [self.canvas.saveView.image imageRotatedByDegrees:90];
-    CGFloat zoomScale = self.canvas.scrollView.zoomScale;
-    self.canvas.scrollView.zoomScale = 1.0;
+  UIImage *image = [self.canvas.saveView.image imageRotatedByDegrees:90];
+  CGFloat zoomScale = self.canvas.scrollView.zoomScale;
+  self.canvas.scrollView.zoomScale = 1.0;
 
-    self.canvas.saveView.frame = CGRectMake(0, 0, floor(self.canvas.helper.frame.size.height), floor(self.canvas.helper.frame.size.width));
-    self.canvas.drawView.frame = CGRectMake(0, 0, floor(self.canvas.helper.frame.size.height), floor(self.canvas.helper.frame.size.width));
-    self.canvas.helper.frame = CGRectMake(self.canvas.helper.frame.origin.x, self.canvas.helper.frame.origin.y, floor(self.canvas.helper.frame.size.height), floor(self.canvas.helper.frame.size.width));
+  self.canvas.saveView.frame = CGRectMake(0, 0, floor(self.canvas.helper.frame.size.height), floor(self.canvas.helper.frame.size.width));
+  self.canvas.drawView.frame = CGRectMake(0, 0, floor(self.canvas.helper.frame.size.height), floor(self.canvas.helper.frame.size.width));
+  self.canvas.helper.frame = CGRectMake(self.canvas.helper.frame.origin.x, self.canvas.helper.frame.origin.y, floor(self.canvas.helper.frame.size.height), floor(self.canvas.helper.frame.size.width));
 
-    self.canvas.scrollView.zoomScale = zoomScale;
-    
-    CGSize imageSize = CGSizeMake(floor(self.canvas.helper.frame.size.width), floor(self.canvas.helper.frame.size.height));
-    
-    UIGraphicsBeginImageContext(imageSize);
-    UIImage *tempImage = [image copy];
-    [tempImage drawInRect:CGRectMake(0, 0, imageSize.width, imageSize.height)];
-    tempImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
+  self.canvas.scrollView.zoomScale = zoomScale;
 
-    //UNDO-Manager
-    UndoManager* manager = [self.canvas getUndoManager];
-    [manager setImage:self.canvas.saveView.image];
-  self.canvas.saveView.image = tempImage;
+  //UNDO-Manager
+  UndoManager* manager = [self.canvas getUndoManager];
+  [manager setImage:self.canvas.saveView.image];
+  self.canvas.saveView.image = image;
 }
 
 - (void)rotateLeft
@@ -134,18 +126,10 @@
   self.canvas.helper.frame = CGRectMake(self.canvas.helper.frame.origin.x, self.canvas.helper.frame.origin.y, floor(self.canvas.helper.frame.size.height), floor(self.canvas.helper.frame.size.width));
   self.canvas.scrollView.zoomScale = zoomScale;
     
-    CGSize imageSize = CGSizeMake(floor(self.canvas.helper.frame.size.width), floor(self.canvas.helper.frame.size.height));
-    
-    UIGraphicsBeginImageContext(imageSize);
-    UIImage *tempImage = [image copy];
-    [tempImage drawInRect:CGRectMake(0, 0, imageSize.width, imageSize.height)];
-    tempImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    
-    //UNDO-Manager
-    UndoManager* manager = [self.canvas getUndoManager];
-    [manager setImage:self.canvas.saveView.image];
-  self.canvas.saveView.image = tempImage;
+  //UNDO-Manager
+  UndoManager* manager = [self.canvas getUndoManager];
+  [manager setImage:self.canvas.saveView.image];
+  self.canvas.saveView.image = image;
 }
 
 - (void)zoomIn

--- a/src/CattyTests/CattyTests-Bridging-Header.h
+++ b/src/CattyTests/CattyTests-Bridging-Header.h
@@ -42,4 +42,4 @@
 #import "ButtonTags.h"
 #import "RoundBorderedButton.h"
 #import <TTTAttributedLabel/TTTAttributedLabel.h>
-
+#import "MirrorRotationZoomTool.h"

--- a/src/CattyTests/Mocks/PaintViewControllerMock.swift
+++ b/src/CattyTests/Mocks/PaintViewControllerMock.swift
@@ -24,6 +24,7 @@
 
 class PaintViewControllerMock: PaintViewController {
     var manager: UndoManager!
+    var mirrorRotationZoomTool: MirrorRotationZoomTool!
 
     let navigationControllerMock: UINavigationController
 
@@ -40,6 +41,7 @@ class PaintViewControllerMock: PaintViewController {
         super.init(coder: coder)
 
         manager = UndoManager.init(drawViewCanvas: self)
+        mirrorRotationZoomTool = MirrorRotationZoomTool.init(drawViewCanvas: self)
 
         self.editingImage = editingImage
         self.helper = UIView()

--- a/src/CattyTests/ViewController/PaintViewControllerTests.swift
+++ b/src/CattyTests/ViewController/PaintViewControllerTests.swift
@@ -184,6 +184,52 @@ final class PaintViewControllerTests: XCTestCase {
         XCTAssertEqual(paintViewControllerMock.helper.frame, frameHorizontal)
     }
 
+    func testRotateRight() {
+        let size = CGSize(width: CGFloat(100), height: CGFloat(150))
+        let image = createImage(size)
+
+        let frame = CGRect(x: 0, y: 0, width: floor(size.height), height: floor(size.width))
+        let frameRotate = CGRect(x: 0, y: 0, width: floor(size.width), height: floor(size.height))
+
+        guard let paintViewControllerMock = PaintViewControllerMock(editingImage: image, navigationController: navigationController) else { return }
+        guard let mirrorRotationZoomTool = paintViewControllerMock.mirrorRotationZoomTool else { return }
+
+        paintViewControllerMock.saveView.frame = frame
+        paintViewControllerMock.drawView.frame = frame
+        paintViewControllerMock.helper.frame = frame
+        paintViewControllerMock.saveView.image = image
+
+        mirrorRotationZoomTool.rotateRight()
+
+        XCTAssertEqual(paintViewControllerMock.saveView.frame, frameRotate)
+        XCTAssertEqual(paintViewControllerMock.drawView.frame, frameRotate)
+        XCTAssertEqual(paintViewControllerMock.helper.frame, frameRotate)
+        XCTAssertEqual(paintViewControllerMock.degrees, 90)
+    }
+
+    func testRotateLeft() {
+        let size = CGSize(width: CGFloat(100), height: CGFloat(150))
+        let image = createImage(size)
+
+        let frame = CGRect(x: 0, y: 0, width: floor(size.height), height: floor(size.width))
+        let frameRotate = CGRect(x: 0, y: 0, width: floor(size.width), height: floor(size.height))
+
+        guard let paintViewControllerMock = PaintViewControllerMock(editingImage: image, navigationController: navigationController) else { return }
+        guard let mirrorRotationZoomTool = paintViewControllerMock.mirrorRotationZoomTool else { return }
+
+        paintViewControllerMock.saveView.frame = frame
+        paintViewControllerMock.drawView.frame = frame
+        paintViewControllerMock.helper.frame = frame
+        paintViewControllerMock.saveView.image = image
+
+        mirrorRotationZoomTool.rotateLeft()
+
+        XCTAssertEqual(paintViewControllerMock.saveView.frame, frameRotate)
+        XCTAssertEqual(paintViewControllerMock.drawView.frame, frameRotate)
+        XCTAssertEqual(paintViewControllerMock.helper.frame, frameRotate)
+        XCTAssertEqual(paintViewControllerMock.degrees, -90)
+    }
+
     private func createImage(_ size: CGSize) -> UIImage {
         let rect = CGRect(origin: .zero, size: size)
 


### PR DESCRIPTION
When rotating a background image e.g. 4 times so that it is aligned as it was before, it can be clearly seen that there is a huge difference in resolution. When using the rotated image as background afterwards, it can also be seen a difference because the background is much smaller by default.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
