### PR TITLE
CATTY-521 Merging of EmbroideryStreams crashes

### DIFF
--- a/src/Catty/Embroidery/EmbroideryDSTService.swift
+++ b/src/Catty/Embroidery/EmbroideryDSTService.swift
@@ -117,7 +117,12 @@ class EmbroideryDSTService: EmbroideryProtocol {
     }
 
     func byteFromConversionTable(position: Int) -> UInt {
-        position < 0 ?
+        guard position > -EmbroideryDefines.MAX_STITCHING_DISTANCE
+                && position < EmbroideryDefines.MAX_STITCHING_DISTANCE
+        else {
+            fatalError("Embroidery Stream cannot be represented as DST")
+        }
+        return position < 0 ?
             EmbroideryDefines.CONVERSION_TABLE[(position * (-1)) + 121] :
             EmbroideryDefines.CONVERSION_TABLE[position]
     }

--- a/src/Catty/Embroidery/EmbroideryStream.swift
+++ b/src/Catty/Embroidery/EmbroideryStream.swift
@@ -55,16 +55,17 @@ class EmbroideryStream: Collection {
         size *= screenRatio
     }
 
-    init(streams: [EmbroideryStream], withName name: String? = nil) {
-        self.name = name
-        self.nextStitchIsColorChange = false
-        size = SpriteKitDefines.defaultCatrobatStitchingSize * EmbroideryDefines.sizeConversionFactor
+    convenience init(streams: [EmbroideryStream], withName name: String? = nil) {
+        self.init(projectWidth: nil, projectHeight: nil, withName: name)
 
+        guard streams.isNotEmpty else {
+            return
+        }
+
+        self.size = streams[0].size
         for stream in streams {
-            let syncArrayEnumerated = stream.stitches.enumerated()
-
-            for (_, value1) in syncArrayEnumerated {
-                self.append(value1)
+            for stitch in stream {
+                self.add(stitch)
             }
             self.addColorChange()
         }

--- a/src/CattyTests/Embroidery/EmbroideryDSTServiceTests.swift
+++ b/src/CattyTests/Embroidery/EmbroideryDSTServiceTests.swift
@@ -59,24 +59,24 @@ final class EmbroideryDSTServiceTests: XCTestCase {
         XCTAssertEqual(out, reference)
     }
 
-//    func testGenerateInitWithStreams() {
-//        let bundlePath = Bundle(for: type(of: self)).path(forResource: "color_change", ofType: "dst")
-//        let reference = try? Data(contentsOf: URL(fileURLWithPath: bundlePath!))
-//
-//        let DSTService = EmbroideryDSTService()
-//
-//        let stream = EmbroideryStream(projectWidth: width, projectHeight: height)
-//        stream.add(Stitch(atPosition: CGPoint(x: 0, y: 0)))
-//        stream.add(Stitch(atPosition: CGPoint(x: 250, y: 0)))
-//
-//        let streamTwo = EmbroideryStream(projectWidth: width, projectHeight: height)
-//        streamTwo.add(Stitch(atPosition: CGPoint(x: 0, y: 0)))
-//        streamTwo.add(Stitch(atPosition: CGPoint(x: 0, y: 250)))
-//
-//        let streamArray = [stream, streamTwo]
-//        let mergedStream = EmbroideryStream(streams: streamArray)
-//
-//        let out = DSTService.generateOutput(embroideryStream: mergedStream)
-//        XCTAssertEqual(out, reference)
-//    }
+    func testGenerateInitWithStreams() {
+        let bundlePath = Bundle(for: type(of: self)).path(forResource: "color_change", ofType: "dst")
+        let reference = try? Data(contentsOf: URL(fileURLWithPath: bundlePath!))
+
+        let DSTService = EmbroideryDSTService()
+
+        let stream = EmbroideryStream(projectWidth: width, projectHeight: height)
+        stream.add(Stitch(atPosition: CGPoint(x: 0, y: 0)))
+        stream.add(Stitch(atPosition: CGPoint(x: 250, y: 0)))
+
+        let streamTwo = EmbroideryStream(projectWidth: width, projectHeight: height)
+        streamTwo.add(Stitch(atPosition: CGPoint(x: 0, y: 0)))
+        streamTwo.add(Stitch(atPosition: CGPoint(x: 0, y: 250)))
+
+        let streamArray = [stream, streamTwo]
+        let mergedStream = EmbroideryStream(streams: streamArray, withName: "EmbroideryStitc")
+
+        let out = DSTService.generateOutput(embroideryStream: mergedStream)
+        XCTAssertEqual(out, reference)
+    }
 }

--- a/src/CattyTests/Embroidery/EmbroideryStreamTests.swift
+++ b/src/CattyTests/Embroidery/EmbroideryStreamTests.swift
@@ -235,6 +235,7 @@ final class EmbroideryStreamTests: XCTestCase {
         let streamArray = [stream, streamTwo]
         let mergedStream = EmbroideryStream(streams: streamArray)
         XCTAssertEqual(mergedStream.stitches.count, 8)
+        XCTAssertEqual(mergedStream.size, stream.size)
         XCTAssertFalse(mergedStream.stitches[0]!.isColorChange)
         XCTAssertFalse(mergedStream.stitches[1]!.isColorChange)
         XCTAssertFalse(mergedStream.stitches[2]!.isColorChange)
@@ -243,5 +244,11 @@ final class EmbroideryStreamTests: XCTestCase {
         XCTAssertFalse(mergedStream.stitches[5]!.isColorChange)
         XCTAssertFalse(mergedStream.stitches[6]!.isColorChange)
         XCTAssertFalse(mergedStream.stitches[7]!.isColorChange)
+    }
+
+    func testGenerateInitWithEmptyStreamsArray() {
+        let empty: [EmbroideryStream] = []
+        let stream = EmbroideryStream(streams: empty, withName: "Empty")
+        XCTAssertEqual(0, stream.count)
     }
 }


### PR DESCRIPTION
Currently merging two `EmbroideryStream`s with too much distance between them causes the app to crash wenn the resulting Stream is converted to a DST-file.
This PR fixes this issue  

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
