### PR TITLE
CATTY-543-PPPP-Recently-used-Bricks

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0502CFA826754E570028CF53 /* RecentlyUsedBricksManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0502CFA726754E570028CF53 /* RecentlyUsedBricksManager.swift */; };
+		0502CFAD26763BCC0028CF53 /* RecentlyUsedBricksManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0502CFAB26763B6B0028CF53 /* RecentlyUsedBricksManagerTests.swift */; };
 		05501DE7255E106F00C64E58 /* color_change.dst in Resources */ = {isa = PBXBuildFile; fileRef = 05501DE4255E106F00C64E58 /* color_change.dst */; };
 		05A3CE6D24F5164A0051DB39 /* CatrobatTableViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A3CE6A24F516490051DB39 /* CatrobatTableViewControllerExtension.swift */; };
 		05A3D46824F517220051DB39 /* StoreProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A3D46724F517220051DB39 /* StoreProjectTests.swift */; };
@@ -1885,6 +1887,8 @@
 		008104EAAB0CBEC616F8EABD /* uz */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/Localizable.strings; sourceTree = "<group>"; };
 		04A3B489CBF02EB8C919DC3B /* sr */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = sr; path = sr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		04FC473CDF0FCFB7BD890320 /* el */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Localizable.strings; sourceTree = "<group>"; };
+		0502CFA726754E570028CF53 /* RecentlyUsedBricksManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlyUsedBricksManager.swift; sourceTree = "<group>"; };
+		0502CFAB26763B6B0028CF53 /* RecentlyUsedBricksManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlyUsedBricksManagerTests.swift; sourceTree = "<group>"; };
 		05501DE4255E106F00C64E58 /* color_change.dst */ = {isa = PBXFileReference; lastKnownFileType = file; path = color_change.dst; sourceTree = "<group>"; };
 		05A3CE6A24F516490051DB39 /* CatrobatTableViewControllerExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CatrobatTableViewControllerExtension.swift; sourceTree = "<group>"; };
 		05A3D46724F517220051DB39 /* StoreProjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreProjectTests.swift; sourceTree = "<group>"; };
@@ -5770,6 +5774,7 @@
 			isa = PBXGroup;
 			children = (
 				4C38B3732371522200F33721 /* BrickManagerTests.swift */,
+				0502CFAB26763B6B0028CF53 /* RecentlyUsedBricksManagerTests.swift */,
 			);
 			path = BrickManager;
 			sourceTree = "<group>";
@@ -6909,6 +6914,7 @@
 				4CB4FE031B95DF2900431757 /* BrickInsertManager.m */,
 				4CB4FE041B95DF2900431757 /* BrickMoveManager.h */,
 				4CB4FE051B95DF2900431757 /* BrickMoveManager.m */,
+				0502CFA726754E570028CF53 /* RecentlyUsedBricksManager.swift */,
 			);
 			path = BrickManager;
 			sourceTree = "<group>";
@@ -11873,6 +11879,7 @@
 				4C68FC951B25A00B00AB3EE8 /* InternFormulaTokenSelectionTest.m in Sources */,
 				4C68FC8C1B25A00B00AB3EE8 /* FormulaParserErrorDetectionTest.m in Sources */,
 				4C2CBB5525A5AA8400C1C143 /* XMLParserTests098.swift in Sources */,
+				0502CFAD26763BCC0028CF53 /* RecentlyUsedBricksManagerTests.swift in Sources */,
 				4C2CBB4B25A5AA8400C1C143 /* XMLParserHeaderTests095.swift in Sources */,
 				9EA6DCB02329A9E1007E837A /* MoveNStepsBrickTests.swift in Sources */,
 				4C82267D213FA7A400F3D750 /* PositionYSensorTest.swift in Sources */,
@@ -12535,6 +12542,7 @@
 				F470A2E32129DAFB005EC9A3 /* ElementFunction.swift in Sources */,
 				97770B8825E5A88C00F51EFA /* SetBrightnessBrick.swift in Sources */,
 				92FF30FF1A24DCAA00093DA7 /* Project.m in Sources */,
+				0502CFA826754E570028CF53 /* RecentlyUsedBricksManager.swift in Sources */,
 				186E99172488F4F400627E36 /* PenUpBrickCell.swift in Sources */,
 				4C82268D213FB29A00F3D750 /* MultiFingerYFunction.swift in Sources */,
 				BA987D0F2194EA1F002DAA05 /* WaitUntilBrick+Instruction.swift in Sources */,

--- a/src/Catty/Defines/LanguageTranslationDefines.h
+++ b/src/Catty/Defines/LanguageTranslationDefines.h
@@ -770,7 +770,7 @@
 //************************************       BrickCategoryTitles        **************************************
 //************************************************************************************************************
 
-#define kLocalizedCategoryFrequentlyUsed NSLocalizedString(@"Frequently used", @"Title of View where the user can see the frequently used bricks.")
+#define kLocalizedCategoryRecentlyUsed NSLocalizedString(@"Recently used", @"Title of brick category where the user can see his or her recently used bricks.")
 #define kLocalizedCategoryEvent NSLocalizedString(@"Event", nil)
 #define kLocalizedCategoryControl NSLocalizedString(@"Control", nil)
 #define kLocalizedCategoryMotion NSLocalizedString(@"Motion", nil)

--- a/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
+++ b/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
@@ -770,7 +770,7 @@ let kUIFETextMessage = NSLocalizedString("Text message:", comment: "")
 //************************************       BrickCategoryTitles        **************************************
 //************************************************************************************************************
 
-let kLocalizedCategoryFrequentlyUsed = NSLocalizedString("Frequently used", comment: "Title of View where the user can see the frequently used bricks.")
+let kLocalizedCategoryRecentlyUsed = NSLocalizedString("Recently used", comment: "Title of brick category where the user can see his or her recently used bricks.")
 let kLocalizedCategoryEvent = NSLocalizedString("Event", comment: "")
 let kLocalizedCategoryControl = NSLocalizedString("Control", comment: "")
 let kLocalizedCategoryMotion = NSLocalizedString("Motion", comment: "")

--- a/src/Catty/Defines/UIDefines.h
+++ b/src/Catty/Defines/UIDefines.h
@@ -97,9 +97,6 @@ typedef NS_ENUM(NSUInteger, kBrickCategoryType) {
     kRecentlyUsedBricks        = 0
 };
 
-#define kMinRecentlyUsedSize 1
-#define kMaxRecentlyUsedSize 10
-
 #define WRAP_UINT_IN_NSNUMBER(number) ([NSNumber numberWithUnsignedInteger:number])
 #define kNSNumberZero WRAP_UINT_IN_NSNUMBER(0)
 

--- a/src/Catty/Defines/UIDefines.h
+++ b/src/Catty/Defines/UIDefines.h
@@ -93,12 +93,12 @@ typedef NS_ENUM(NSUInteger, kBrickCategoryType) {
     kPhiroBrick                = 8,
     kPenBrick                  = 9,
     kEmbroideryBrick           = 10,
-    kInvisible                = 99,
-    kFavouriteBricks           = 0
+    kInvisible                 = 99,
+    kRecentlyUsedBricks        = 0
 };
 
-#define kMinFavouriteBrickSize 5
-#define kMaxFavouriteBrickSize 10
+#define kMinRecentlyUsedSize 1
+#define kMaxRecentlyUsedSize 10
 
 #define WRAP_UINT_IN_NSNUMBER(number) ([NSNumber numberWithUnsignedInteger:number])
 #define kNSNumberZero WRAP_UINT_IN_NSNUMBER(0)

--- a/src/Catty/Defines/UIDefines.swift
+++ b/src/Catty/Defines/UIDefines.swift
@@ -41,4 +41,7 @@ class UIDefines: NSObject {
     @objc static let lookPickerAccessibilityLabel = "LookView"
     @objc static let backgroundPickerAccessibilityLabel = "BackgroundView"
     @objc static let iOS12OrLessAccessibilityLabel = "iOS 12.0 or less"
+
+    static let recentlyUsedBricksMinSize = 1
+    static let recentlyUsedBricksMaxSize = 10
 }

--- a/src/Catty/Extension&Delegate&Protocol/Extensions/UIColorExtension.swift
+++ b/src/Catty/Extension&Delegate&Protocol/Extensions/UIColorExtension.swift
@@ -317,11 +317,11 @@ extension UIColor {
         UIColor(red: 120.0 / 255.0, green: 220.0 / 255.0, blue: 225.0 / 255.0, alpha: 1.0)
     }
 
-    static var frequentlyUsedBricks: UIColor {
+    static var recentlyUsedBricks: UIColor {
         UIColor(red: 234.0 / 255.0, green: 200.0 / 255.0, blue: 59.0 / 255.0, alpha: 1.0)
     }
 
-    static var frequentlyUsedBricksStroke: UIColor {
+    static var recentlyUsedBricksStroke: UIColor {
         UIColor(red: 240.0 / 255.0, green: 240.0 / 255.0, blue: 150.0 / 255.0, alpha: 1.0)
     }
 

--- a/src/Catty/Helpers/Util/Util.swift
+++ b/src/Catty/Helpers/Util/Util.swift
@@ -277,7 +277,6 @@ func synchronized(lock: AnyObject, closure: () -> Void) {
                 return sound
             }
         }
-
         return nil
     }
 }

--- a/src/Catty/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en.lproj/Localizable.strings
@@ -763,9 +763,6 @@
 /* No comment provided by engineer. */
 "Fr" = "Fr";
 
-/* Title of View where the user can see the frequently used bricks. */
-"Frequently used" = "Frequently used";
-
 /* No comment provided by engineer. */
 "Friday" = "Friday";
 
@@ -1437,6 +1434,9 @@
 
 /* No comment provided by engineer. */
 "RE" = "RE";
+
+/* Title of brick category where the user can see his or her recently used bricks. */
+"Recently used" = "Recently used";
 
 /* No comment provided by engineer. */
 "Recording" = "Recording";

--- a/src/Catty/Setup/CatrobatSetup+Bricks.swift
+++ b/src/Catty/Setup/CatrobatSetup+Bricks.swift
@@ -204,12 +204,12 @@
                                              strokeColor: UIColor.phiroBrickStroke,
                                              enabled: isPhiroEnabled()))
         }
-        if isFavouritesCategoryAvailable() {
-            categories.prepend(BrickCategory(type: kBrickCategoryType.favouriteBricks,
+        if isRecentlyUsedAvailable() {
+            categories.prepend(BrickCategory(type: kBrickCategoryType.recentlyUsedBricks,
                                              name: kLocalizedCategoryFrequentlyUsed,
                                              color: UIColor.frequentlyUsedBricks,
                                              strokeColor: UIColor.frequentlyUsedBricksStroke,
-                                             enabled: isFavouritesCategoryAvailable()))
+                                             enabled: isRecentlyUsedAvailable()))
         }
 
         return categories
@@ -223,8 +223,8 @@
         UserDefaults.standard.bool(forKey: kUsePhiroBricks)
     }
 
-    private static func isFavouritesCategoryAvailable() -> Bool {
-        Util.getBrickInsertionDictionaryFromUserDefaults()?.count ?? 0 >= kMinFavouriteBrickSize
+    private static func isRecentlyUsedAvailable() -> Bool {
+        RecentlyUsedBricksManager.getRecentlyUsedBricks().count >= kMinRecentlyUsedSize
     }
 
     private static func isEmbroideryEnabled() -> Bool {

--- a/src/Catty/Setup/CatrobatSetup+Bricks.swift
+++ b/src/Catty/Setup/CatrobatSetup+Bricks.swift
@@ -206,9 +206,9 @@
         }
         if isRecentlyUsedAvailable() {
             categories.prepend(BrickCategory(type: kBrickCategoryType.recentlyUsedBricks,
-                                             name: kLocalizedCategoryFrequentlyUsed,
-                                             color: UIColor.frequentlyUsedBricks,
-                                             strokeColor: UIColor.frequentlyUsedBricksStroke,
+                                             name: kLocalizedCategoryRecentlyUsed,
+                                             color: UIColor.recentlyUsedBricks,
+                                             strokeColor: UIColor.recentlyUsedBricksStroke,
                                              enabled: isRecentlyUsedAvailable()))
         }
 
@@ -224,7 +224,7 @@
     }
 
     private static func isRecentlyUsedAvailable() -> Bool {
-        RecentlyUsedBricksManager.getRecentlyUsedBricks().count >= kMinRecentlyUsedSize
+        RecentlyUsedBricksManager.getRecentlyUsedBricks().count >= UIDefines.recentlyUsedBricksMinSize
     }
 
     private static func isEmbroideryEnabled() -> Bool {

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryViewController.m
@@ -123,6 +123,7 @@ didSelectItemAtIndexPath:(NSIndexPath*)indexPath
     NSAssert(cell.scriptOrBrick, @"Error, no brick.");
     
     [Util incrementStatisticCountForBrick:cell.scriptOrBrick];
+    [RecentlyUsedBricksManager updateRecentlyUsedBricksFor: NSStringFromClass([cell.scriptOrBrick class])];
     
     [[NSNotificationCenter defaultCenter] postNotificationName:NotificationName.brickSelected object:cell.scriptOrBrick];
     

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickManager/BrickManager.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickManager/BrickManager.m
@@ -80,13 +80,13 @@
     NSArray *selectableBricks = [self selectableBricks];
     NSMutableArray *selectableBricksForCategoryMutable = [NSMutableArray arrayWithCapacity:[selectableBricks count]];
     
-    if (categoryType == kFavouriteBricks) {
-        NSArray *favouriteBricks = [Util getSubsetOfTheMostFavoriteChosenBricks:kMaxFavouriteBrickSize];
+    if (categoryType == kRecentlyUsedBricks) {
+        NSArray *recentlyUsedBricks = [RecentlyUsedBricksManager getRecentlyUsedBricks];
         
-        for(NSString* favouriteBrick in favouriteBricks) {
+        for(NSString* recentlyUsedBrick in recentlyUsedBricks) {
             for(id<BrickProtocol> scriptOrBrick in selectableBricks) {
                 NSString *wrappedBrickType = NSStringFromClass([scriptOrBrick class]);
-                if([wrappedBrickType isEqualToString:favouriteBrick] && !([scriptOrBrick isDisabledForBackground] && inBackground)) {
+                if([wrappedBrickType isEqualToString:recentlyUsedBrick] && !([scriptOrBrick isDisabledForBackground] && inBackground)) {
                     [selectableBricksForCategoryMutable addObject:scriptOrBrick];
                 }
             }

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickManager/RecentlyUsedBricksManager.swift
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickManager/RecentlyUsedBricksManager.swift
@@ -1,0 +1,58 @@
+/**
+ *  Copyright (C) 2010-2021 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import Foundation
+
+@objc
+class RecentlyUsedBricksManager: NSObject {
+
+    @objc
+    class func getRecentlyUsedBricks() -> [String] {
+        let userDefaults = UserDefaults.standard
+        if let recentlyUsed = userDefaults.array(forKey: "recentlyUsedBricks") as? [String] {
+            return recentlyUsed
+        } else {
+            let recentlyUsed = [String]()
+            setRecentlyUsedBricks(to: recentlyUsed)
+            return recentlyUsed
+            }
+        }
+
+    @objc
+    class func updateRecentlyUsedBricks(for brickOrScript: String) {
+        var recentlyUsed = getRecentlyUsedBricks()
+        recentlyUsed.removeAll(where: { $0 == brickOrScript })
+        if recentlyUsed.count >= kMaxRecentlyUsedSize {
+            recentlyUsed.removeLast()
+        }
+        recentlyUsed.prepend(brickOrScript)
+        setRecentlyUsedBricks(to: recentlyUsed)
+    }
+
+    class func setRecentlyUsedBricks(to recentlyUsed: [String]) {
+        UserDefaults.standard.set(recentlyUsed, forKey: "recentlyUsedBricks")
+    }
+
+    class func resetRecentlyUsedBricks() {
+        setRecentlyUsedBricks(to: [String]())
+    }
+}

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickManager/RecentlyUsedBricksManager.swift
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickManager/RecentlyUsedBricksManager.swift
@@ -41,7 +41,7 @@ class RecentlyUsedBricksManager: NSObject {
     class func updateRecentlyUsedBricks(for brickOrScript: String) {
         var recentlyUsed = getRecentlyUsedBricks()
         recentlyUsed.removeAll(where: { $0 == brickOrScript })
-        if recentlyUsed.count >= kMaxRecentlyUsedSize {
+        if recentlyUsed.count >= UIDefines.recentlyUsedBricksMaxSize {
             recentlyUsed.removeLast()
         }
         recentlyUsed.prepend(brickOrScript)

--- a/src/CattyTests/Bricks/BrickManager/RecentlyUsedBricksManagerTests.swift
+++ b/src/CattyTests/Bricks/BrickManager/RecentlyUsedBricksManagerTests.swift
@@ -1,0 +1,66 @@
+/**
+ *  Copyright (C) 2010-2021 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+@testable import Pocket_Code
+
+final class RecentlyUsedBricksManagerTests: XCTestCase {
+    func testSetAndGetRecentlyUsedBricks() {
+        let usedBricks = [NSStringFromClass(StitchBrick.self), NSStringFromClass(TurnLeftBrick.self), NSStringFromClass(MoveNStepsBrick.self)]
+        RecentlyUsedBricksManager.resetRecentlyUsedBricks()
+        RecentlyUsedBricksManager.setRecentlyUsedBricks(to: usedBricks)
+        let savedBricks = RecentlyUsedBricksManager.getRecentlyUsedBricks()
+        XCTAssertEqual(usedBricks, savedBricks)
+    }
+
+    func testResetRecentlyUsedBricks() {
+        let usedBricks = [NSStringFromClass(StitchBrick.self), NSStringFromClass(TurnLeftBrick.self), NSStringFromClass(MoveNStepsBrick.self)]
+        RecentlyUsedBricksManager.setRecentlyUsedBricks(to: usedBricks)
+        RecentlyUsedBricksManager.resetRecentlyUsedBricks()
+        let savedBricks = RecentlyUsedBricksManager.getRecentlyUsedBricks()
+        XCTAssertEqual(0, savedBricks.count)
+        XCTAssertEqual([String](), savedBricks)
+    }
+
+    func testUpdateRecentlyUsedBricksAddNew() {
+        let usedBricks = [NSStringFromClass(StitchBrick.self), NSStringFromClass(TurnLeftBrick.self), NSStringFromClass(MoveNStepsBrick.self)]
+        RecentlyUsedBricksManager.resetRecentlyUsedBricks()
+        RecentlyUsedBricksManager.setRecentlyUsedBricks(to: usedBricks)
+
+        RecentlyUsedBricksManager.updateRecentlyUsedBricks(for: NSStringFromClass(TurnRightBrick.self))
+        let savedBricks = RecentlyUsedBricksManager.getRecentlyUsedBricks()
+
+        XCTAssertEqual([NSStringFromClass(TurnRightBrick.self)] + usedBricks, savedBricks)
+    }
+
+    func testUpdateRecentlyUsedBricksReorder() {
+        let usedBricks = [NSStringFromClass(StitchBrick.self), NSStringFromClass(TurnLeftBrick.self), NSStringFromClass(MoveNStepsBrick.self)]
+
+        RecentlyUsedBricksManager.resetRecentlyUsedBricks()
+        RecentlyUsedBricksManager.setRecentlyUsedBricks(to: usedBricks)
+        RecentlyUsedBricksManager.updateRecentlyUsedBricks(for: NSStringFromClass(StitchBrick.self))
+        let savedBricks = RecentlyUsedBricksManager.getRecentlyUsedBricks()
+
+        XCTAssertEqual(usedBricks, savedBricks)
+    }
+}

--- a/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
+++ b/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
@@ -770,7 +770,7 @@ let kUIFETextMessage = NSLocalizedString("Text message:", bundle: Bundle(for: La
 //************************************       BrickCategoryTitles        **************************************
 //************************************************************************************************************
 
-let kLocalizedCategoryFrequentlyUsed = NSLocalizedString("Frequently used", bundle: Bundle(for: LanguageTranslation.self), comment: "Title of View where the user can see the frequently used bricks.")
+let kLocalizedCategoryRecentlyUsed = NSLocalizedString("Recently used", bundle: Bundle(for: LanguageTranslation.self), comment: "Title of brick category where the user can see his or her recently used bricks.")
 let kLocalizedCategoryEvent = NSLocalizedString("Event", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedCategoryControl = NSLocalizedString("Control", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedCategoryMotion = NSLocalizedString("Motion", bundle: Bundle(for: LanguageTranslation.self), comment: "")


### PR DESCRIPTION
Instead of the currently available "Frequently used" Bricks, this feature should be named "Recently used" Bricks and display the last used 10 Bricks. 10 should be a variable which can be defined in the UIDefines.swift.

The recently used Bricks should be persisted and be available on a cross-project manner. Thus, they need to be persisted. Come up with a new and clean implementation in Swift and add tests.

In case a user installs Catty as a new app, the "Recently used" category should not be displayed (like the "Frequently used" category)

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
