### PR TITLE
CATTY-537 Open multiple downloaded project from Store

### DIFF
--- a/src/Catty/DataModel/Project/Project.h
+++ b/src/Catty/DataModel/Project/Project.h
@@ -76,6 +76,5 @@
 + (NSString* _Nonnull)projectDirectoryNameForProjectName:(NSString* _Nonnull)projectName
                                                projectID:(NSString* _Nullable)projectID;
 + (nullable ProjectLoadingInfo *)projectLoadingInfoForProjectDirectoryName:(NSString* _Nonnull)projectDirectoryName;
-+ (nullable NSString *)projectNameForProjectID:(NSString* _Nonnull)projectID;
 
 @end

--- a/src/Catty/DataModel/Project/Project.m
+++ b/src/Catty/DataModel/Project/Project.m
@@ -246,20 +246,6 @@
     return [ProjectLoadingInfo projectLoadingInfoForProjectWithName:projectName projectID:projectID];
 }
 
-+ (nullable NSString *)projectNameForProjectID:(NSString*)projectID
-{
-    if ((! projectID) || (! [projectID length])) {
-        return nil;
-    }
-    NSArray *allProjectLoadingInfos = [[self class] allProjectLoadingInfos];
-    for (ProjectLoadingInfo *projectLoadingInfo in allProjectLoadingInfos) {
-        if ([projectLoadingInfo.projectID isEqualToString:projectID]) {
-            return projectLoadingInfo.visibleName;
-        }
-    }
-    return nil;
-}
-
 // returns true if either same projectID and/or same projectName already exists
 + (BOOL)projectExistsWithProjectName:(NSString*)projectName projectID:(NSString*)projectID
 {

--- a/src/Catty/IO/ProjectManager.swift
+++ b/src/Catty/IO/ProjectManager.swift
@@ -21,9 +21,9 @@
  */
 
 @objc(ProjectManager)
-@objcMembers class ProjectManager: NSObject {
+class ProjectManager: NSObject {
 
-    static func createProject(name: String, projectId: String?) -> Project {
+    @objc static func createProject(name: String, projectId: String?) -> Project {
         ProjectManager.createProject(name: name, projectId: projectId, fileManager: CBFileManager.shared(), imageCache: RuntimeImageCache.shared())
     }
 
@@ -76,8 +76,7 @@
         return project
     }
 
-    static func loadPreviewImageAndCache(projectLoadingInfo: ProjectLoadingInfo,
-                                         completion: @escaping (_ image: UIImage?, _ path: String?) -> Void) {
+    @objc static func loadPreviewImageAndCache(projectLoadingInfo: ProjectLoadingInfo, completion: @escaping (_ image: UIImage?, _ path: String?) -> Void) {
         ProjectManager.loadPreviewImageAndCache(projectLoadingInfo: projectLoadingInfo, fileManager: CBFileManager.shared(), imageCache: RuntimeImageCache.shared(), completion: completion)
     }
 
@@ -114,5 +113,23 @@
         }
 
         return
+    }
+
+    static func projectNames(for projectID: String, fileManager: CBFileManager = CBFileManager.shared()) -> [String]? {
+        if projectID.isEmpty {
+            return nil
+        }
+
+        var projectNames = [String]()
+        let allProjectLoadingInfos = Project.allProjectLoadingInfos()
+        for case let projectLoadingInfo as ProjectLoadingInfo in allProjectLoadingInfos where projectLoadingInfo.projectID == projectID {
+            projectNames.append(projectLoadingInfo.visibleName)
+        }
+
+        if projectNames.isEmpty {
+            return nil
+        }
+
+        return projectNames
     }
 }

--- a/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewController.m
+++ b/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewController.m
@@ -35,7 +35,6 @@
 @interface ProjectDetailStoreViewController ()
 
 @property (nonatomic, strong) LoadingView *loadingView;
-@property (nonatomic, strong) Project *loadedProject;
 @property (strong, nonatomic) NSURLSession *session;
 @property (strong, nonatomic) NSURLSessionDataTask *dataTask;
 
@@ -86,7 +85,6 @@
 {
     [super viewWillAppear:animated];
     [self.navigationController setToolbarHidden:YES];
-    self.loadedProject = nil;
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -108,22 +106,7 @@
 
 - (void)openButtonPressed:(id)sender
 {
-
-    NSString *localProjectName = [Project projectNameForProjectID:self.project.projectID];
-
-    [self showLoadingView];
-    [CATransaction flush];
-
-    self.loadedProject = [Project projectWithLoadingInfo:[ProjectLoadingInfo projectLoadingInfoForProjectWithName:localProjectName projectID:self.project.projectID]];
-
-    [self hideLoadingView];
-
-    if (!self.loadedProject) {
-        [Util alertWithText:kLocalizedUnableToLoadProject];
-        return;
-    }
-
-    [self openProject:self.loadedProject];
+    [self openButtonPressed];
 }
 
 - (void)downloadButtonPressed

--- a/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewControllerExtension.swift
+++ b/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewControllerExtension.swift
@@ -401,4 +401,42 @@ import ActiveLabel
 
         label.handleURLTap { url in UIApplication.shared.open(url, options: [:], completionHandler: nil) }
     }
+
+    func openButtonPressed() {
+        guard let localProjectNames = ProjectManager.projectNames(for: project.projectID) else {
+            Util.alert(text: kLocalizedUnableToLoadProject)
+            return
+        }
+
+        if localProjectNames.count > 1 {
+            let nameSelectionSheet = UIAlertController(title: kLocalizedOpen, message: nil, preferredStyle: .actionSheet)
+
+            nameSelectionSheet.addAction(title: kLocalizedCancel, style: .cancel, handler: nil)
+
+            for localProjectName in localProjectNames {
+                nameSelectionSheet.addAction(title: localProjectName, style: .default, handler: { action in
+                    self.openProject(withLocalName: action.title)
+                })
+            }
+
+            self.present(nameSelectionSheet, animated: true, completion: nil)
+        } else {
+            openProject(withLocalName: localProjectNames.first)
+        }
+
+    }
+
+    private func openProject(withLocalName localProjectName: String?) {
+        showLoadingView()
+        CATransaction.flush()
+
+        guard let selectedProject = Project.init(loadingInfo: ProjectLoadingInfo.init(forProjectWithName: localProjectName, projectID: project.projectID)) else {
+            hideLoadingView()
+            Util.alert(text: kLocalizedUnableToLoadProject)
+            return
+        }
+
+        hideLoadingView()
+        openProject(selectedProject)
+    }
 }

--- a/src/CattyTests/FileManager/ProjectManagerTests.swift
+++ b/src/CattyTests/FileManager/ProjectManagerTests.swift
@@ -268,4 +268,38 @@ final class ProjectManagerTests: XCTestCase {
         }
         fileManager.addDefaultProjectToProjectsRootDirectoryIfNoProjectsExist()
     }
+
+    func testProjectNamesForID() {
+        // TODO: Remove this once Project.allProjectLoadingInfos() has been moved to ProjectManager and can use CBFileManagerMock
+        let fileManager = CBFileManager.shared()!
+        for loadingInfo in Project.allProjectLoadingInfos() as! [ProjectLoadingInfo] {
+            fileManager.deleteDirectory(loadingInfo.basePath!)
+        }
+
+        var projectNames = ProjectManager.projectNames(for: "")
+        XCTAssertNil(projectNames)
+
+        projectNames = ProjectManager.projectNames(for: "invalid")
+        XCTAssertNil(projectNames)
+
+        let project = ProjectManager.createProject(name: "projectName", projectId: "1234", fileManager: fileManager, imageCache: imageCache)
+
+        projectNames = ProjectManager.projectNames(for: project.header.programID)
+        XCTAssertNotNil(projectNames)
+        XCTAssertEqual(1, projectNames?.count)
+        XCTAssertEqual(projectNames?.first!, project.header.programName)
+
+        let anotherProject = ProjectManager.createProject(name: project.header.programName + " (1)", projectId: project.header.programID, fileManager: fileManager, imageCache: imageCache)
+
+        projectNames = ProjectManager.projectNames(for: project.header.programID)
+        XCTAssertNotNil(projectNames)
+        XCTAssertEqual(2, projectNames?.count)
+
+        project.rename(toProjectName: project.header.programName, andProjectId: project.header.programID + "5", andShowSaveNotification: true)
+
+        projectNames = ProjectManager.projectNames(for: anotherProject.header.programID)
+        XCTAssertNotNil(projectNames)
+        XCTAssertEqual(1, projectNames?.count)
+        XCTAssertEqual(projectNames?.first!, anotherProject.header.programName)
+    }
 }

--- a/src/CattyTests/Project/ProjectTests.swift
+++ b/src/CattyTests/Project/ProjectTests.swift
@@ -25,7 +25,7 @@
 import Nimble
 import XCTest
 
-class ProjectTest: XCTestCase {
+class ProjectTests: XCTestCase {
 
     var project: Project!
     var fileManager: CBFileManager!


### PR DESCRIPTION
Implements https://jira.catrob.at/browse/CATTY-537

Instead of opening the most recent, it was agreed to let the user choose the project to open if multiple are present on the device (see ticket).

Code was moved to Swift Extension to avoid writing any new ObjC code.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
