### PR TITLE
CATTY-574 Xcode 12.5 support

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		05E6802C255B5E3400D1E295 /* CGVectorExtentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E6802B255B5E3400D1E295 /* CGVectorExtentions.swift */; };
 		05E6802F255B602700D1E295 /* stitch.dst in Resources */ = {isa = PBXBuildFile; fileRef = 05E6802E255B602700D1E295 /* stitch.dst */; };
 		17A8ABE92624EAA400DDD480 /* FormulaParserTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A8ABE82624EAA400DDD480 /* FormulaParserTest.swift */; };
+		17A8AC652644E6A900DDD480 /* ForceInit.m in Sources */ = {isa = PBXBuildFile; fileRef = 17A8AC642644E6A900DDD480 /* ForceInit.m */; };
+		17A8AC6F2644E79B00DDD480 /* BluetoothMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926198011BF48384006D1A61 /* BluetoothMocks.swift */; };
 		1801591E25E4D5CE00E5B673 /* FormulaEditorSectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1801591D25E4D5CE00E5B673 /* FormulaEditorSectionViewController.swift */; };
 		180DDF3F25067E1700EA526C /* FirebaseAnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 180DDF3E25067E1700EA526C /* FirebaseAnalyticsTests.swift */; };
 		180DDF432506800600EA526C /* AnalyticsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 180DDF422506800600EA526C /* AnalyticsMock.swift */; };
@@ -1138,7 +1140,6 @@
 		923503911BA707DE00021F6A /* LoginViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9235038F1BA707DE00021F6A /* LoginViewController.m */; };
 		925819881C0208E8003247A9 /* CALayer+XibConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 925819871C0208E8003247A9 /* CALayer+XibConfiguration.m */; };
 		926197F01BF3249E006D1A61 /* ArduinoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926197EF1BF3249E006D1A61 /* ArduinoTests.swift */; };
-		926198021BF48384006D1A61 /* BluetoothMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926198011BF48384006D1A61 /* BluetoothMocks.swift */; };
 		9276B7051C9E8F6C008BC594 /* SoundCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 9276B7041C9E8F6C008BC594 /* SoundCache.m */; };
 		9276B70B1C9EA68A008BC594 /* CatrobatPlayerItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 9276B70A1C9EA68A008BC594 /* CatrobatPlayerItem.m */; };
 		927F79D71BEE39A3008D1635 /* BrickCellPhiroIfSensorData.m in Sources */ = {isa = PBXBuildFile; fileRef = 927F79D61BEE39A3008D1635 /* BrickCellPhiroIfSensorData.m */; };
@@ -1900,6 +1901,8 @@
 		113CDA22CF21176FFA49E694 /* sd */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = sd; path = sd.lproj/Localizable.strings; sourceTree = "<group>"; };
 		13B5EB79EDA9CF73908FF75C /* no */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = no; path = no.lproj/Localizable.strings; sourceTree = "<group>"; };
 		17A8ABE82624EAA400DDD480 /* FormulaParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FormulaParserTest.swift; path = Formula/FormulaParserTest.swift; sourceTree = "<group>"; };
+		17A8AC642644E6A900DDD480 /* ForceInit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ForceInit.m; sourceTree = "<group>"; };
+		17A8AC6B2644E6B500DDD480 /* ForceInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForceInit.h; sourceTree = "<group>"; };
 		1801591D25E4D5CE00E5B673 /* FormulaEditorSectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormulaEditorSectionViewController.swift; sourceTree = "<group>"; };
 		180DDF3E25067E1700EA526C /* FirebaseAnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAnalyticsTests.swift; sourceTree = "<group>"; };
 		180DDF422506800600EA526C /* AnalyticsMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsMock.swift; sourceTree = "<group>"; };
@@ -10267,6 +10270,8 @@
 			children = (
 				BA38080B21A1D8920075B831 /* ConvertExceptionToError.m */,
 				BA38080D21A1D8CD0075B831 /* ConvertExceptionToError.h */,
+				17A8AC642644E6A900DDD480 /* ForceInit.m */,
+				17A8AC6B2644E6B500DDD480 /* ForceInit.h */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -11561,6 +11566,7 @@
 				4C5AEEF322F6F22700280F8B /* MoveNStepsBrickCellTests.swift in Sources */,
 				18B5B529247E542A007D24A3 /* NSDataExtensionTests.swift in Sources */,
 				4CBF5F9C21AF1D200079C834 /* TouchManagerTests.swift in Sources */,
+				17A8AC652644E6A900DDD480 /* ForceInit.m in Sources */,
 				4C2732A91CE4F30F00CA61AC /* CBSpriteNodeTests.swift in Sources */,
 				4C6FE169212D2D2E0067B7D5 /* ExpFunctionTest.swift in Sources */,
 				9ECDCB132328578F00EBDA63 /* HideBrickTests.swift in Sources */,
@@ -11839,6 +11845,7 @@
 				4C2CBB5025A5AA8400C1C143 /* XMLParserBlackBoxTests095.swift in Sources */,
 				5973F239202EF34700A4CED9 /* MediaLibraryCollectionViewDataSourceDelegateMock.swift in Sources */,
 				6F17FA1824B7579000885E07 /* UploadViewControllerTests.swift in Sources */,
+				17A8AC6F2644E79B00DDD480 /* BluetoothMocks.swift in Sources */,
 				186E991D2488FBDB00627E36 /* PenUpBrickTests.swift in Sources */,
 				5921F2AB24F51F3B0044D936 /* BrickCellLookDataTests.swift in Sources */,
 				4C2CBB5F25A5AA8400C1C143 /* XMLParserBlackBoxTests0993.swift in Sources */,
@@ -12588,7 +12595,6 @@
 				639CB8E525C418FE0051CB82 /* Sound.swift in Sources */,
 				4CE6788F210C506B00D90B5D /* FunctionManagerProtocol.swift in Sources */,
 				92DFB0151A38949E00FA9B0F /* InternFormulaParserEmptyStackException.m in Sources */,
-				926198021BF48384006D1A61 /* BluetoothMocks.swift in Sources */,
 				AA74EFF31BC05B5F00D1E954 /* ClearGraphicEffectBrick.m in Sources */,
 				AAF6D9C91BC0914100686849 /* CBPlayerConfig.swift in Sources */,
 				9EC5175824FBE5B20029CD0E /* Sampler.swift in Sources */,

--- a/src/CattyTests/BluetoothDevices/Arduino/ArduinoTests.swift
+++ b/src/CattyTests/BluetoothDevices/Arduino/ArduinoTests.swift
@@ -28,7 +28,7 @@ import XCTest
 class ArduinoTests: XCTestCase {
 
     var mock = ArduinoTestMock()
-    var arduinoTest = ArduinoDevice(peripheral: Peripheral(cbPeripheral: PeripheralMock(test: true), advertisements: [String: String](), rssi: 0))
+    var arduinoTest = ArduinoDevice(peripheral: Peripheral(cbPeripheral: PeripheralMock.create(), advertisements: [String: String](), rssi: 0))
 
     override func setUp( ) {
         super.setUp()
@@ -571,7 +571,7 @@ class ArduinoTests: XCTestCase {
         //Given
         let name = "test"
         let data = name.data(using: String.Encoding.ascii)
-        arduinoTest.txCharacteristic = CharacteristicMock(test: true)
+        arduinoTest.txCharacteristic = CharacteristicMock.create()
         //When
         arduinoTest.sendData(data!)
         //Then
@@ -587,7 +587,7 @@ class ArduinoTests: XCTestCase {
         //Given
         let name = "testtesttesttesttesttest"
         let data = name.data(using: String.Encoding.ascii)
-        arduinoTest.txCharacteristic = CharacteristicMock(test: true)
+        arduinoTest.txCharacteristic = CharacteristicMock.create()
         //When
         arduinoTest.sendData(data!)
         //Then

--- a/src/CattyTests/BluetoothDevices/BluetoothMocks/BluetoothMocks.swift
+++ b/src/CattyTests/BluetoothDevices/BluetoothMocks/BluetoothMocks.swift
@@ -23,6 +23,8 @@
 import BluetoothHelper
 import CoreBluetooth
 
+@testable import Pocket_Code
+
 class FirmataDelegateMock: FirmataDelegate {
     var callbackInvolved = false
     var data = Data()
@@ -159,23 +161,31 @@ class FirmataMock: Firmata {
 
 class PeripheralMock: CBPeripheral {
 
-    var dataToSend = Data()
+    private static var dataToSendStorage = [PeripheralMock: Data]()
 
-    init(test: Bool) {
-        //HACK
+    static func create() -> PeripheralMock {
+        let cbPeripheral = ForceInit.createInstance(ofClass: "CBPeripheral") as! CBPeripheral
+        object_setClass(cbPeripheral, PeripheralMock.self)
+        let peripheralMock = cbPeripheral as! PeripheralMock
+        PeripheralMock.dataToSendStorage[peripheralMock] = Data()
+        return peripheralMock
     }
 
     override func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType) {
-        dataToSend = data
+        PeripheralMock.dataToSendStorage[self] = data
+    }
+
+    var dataToSend: Data {
+        PeripheralMock.dataToSendStorage[self]!
     }
 }
 
 class CharacteristicMock: CBCharacteristic {
 
-    init(test: Bool) {
-        //HACK
-        //        self.properties = CBCharacteristicProperties(CBCharacteristicProperties.WriteWithoutResponse.rawValue)
-
+    static func create() -> CharacteristicMock {
+        let cbCharacteristic = ForceInit.createInstance(ofClass: "CBCharacteristic") as! CBCharacteristic
+        object_setClass(cbCharacteristic, CharacteristicMock.self)
+        return cbCharacteristic as! CharacteristicMock
     }
 
     override internal var properties: CBCharacteristicProperties {

--- a/src/CattyTests/BluetoothDevices/Phiro/PhiroDeviceTest.swift
+++ b/src/CattyTests/BluetoothDevices/Phiro/PhiroDeviceTest.swift
@@ -27,7 +27,7 @@ import XCTest
 
 class PhiroDeviceTest: XCTestCase {
 
-    var device = PhiroDevice(peripheral: Peripheral(cbPeripheral: PeripheralMock(test: true), advertisements: [String: String](), rssi: 0))
+    var device = PhiroDevice(peripheral: Peripheral(cbPeripheral: PeripheralMock.create(), advertisements: [String: String](), rssi: 0))
 
     override func setUp() {
         super.setUp()

--- a/src/CattyTests/Firebase/FirebaseCrashlyticsReporterTests.swift
+++ b/src/CattyTests/Firebase/FirebaseCrashlyticsReporterTests.swift
@@ -34,7 +34,7 @@ final class FirebaseCrashlyticsReporterTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        crashlytics = CrashlyticsMock(collectionEnabled: false)
+        crashlytics = CrashlyticsMock.create(collectionEnabled: false)
         UserDefaults.standard.set(true, forKey: kFirebaseSendCrashReports)
         reporter = FirebaseCrashlyticsReporter(crashlytics: crashlytics!)
     }
@@ -46,7 +46,7 @@ final class FirebaseCrashlyticsReporterTests: XCTestCase {
     func testSetupCrashReportsDisabled() {
         UserDefaults.standard.set(false, forKey: kFirebaseSendCrashReports)
 
-        crashlytics = CrashlyticsMock(collectionEnabled: false)
+        crashlytics = CrashlyticsMock.create(collectionEnabled: false)
         _ = FirebaseCrashlyticsReporter(crashlytics: crashlytics!)
         XCTAssertFalse(crashlytics!.isCrashlyticsCollectionEnabled())
     }

--- a/src/CattyTests/Mocks/CrashlyticsMock.swift
+++ b/src/CattyTests/Mocks/CrashlyticsMock.swift
@@ -24,27 +24,39 @@ import Firebase
 
 final class CrashlyticsMock: Crashlytics {
 
-    public var logs: [String]
-    public var records: [Error]
-    var collectionEnabled: Bool
+    private static var logStorage = [CrashlyticsMock: [String]]()
+    private static var recordStorage = [CrashlyticsMock: [Error]]()
+    private static var collectionEnabled = [CrashlyticsMock: Bool]()
 
-    init(collectionEnabled: Bool) {
-        self.collectionEnabled = collectionEnabled
-        self.logs = []
-        self.records = []
+    static func create(collectionEnabled: Bool) -> CrashlyticsMock {
+        let crashlytics = ForceInit.createInstance(ofClass: "FIRCrashlytics") as! Crashlytics
+        object_setClass(crashlytics, CrashlyticsMock.self)
+        let crashlyticsMock = crashlytics as! CrashlyticsMock
+        CrashlyticsMock.collectionEnabled[crashlyticsMock] = collectionEnabled
+        CrashlyticsMock.logStorage[crashlyticsMock] = [String]()
+        CrashlyticsMock.recordStorage[crashlyticsMock] = [Error]()
+        return crashlyticsMock
     }
 
-    override func isCrashlyticsCollectionEnabled() -> Bool { collectionEnabled }
+    override func isCrashlyticsCollectionEnabled() -> Bool { CrashlyticsMock.collectionEnabled[self]! }
 
     override func setCrashlyticsCollectionEnabled(_ enabled: Bool) {
-        collectionEnabled = enabled
+        CrashlyticsMock.collectionEnabled[self] = enabled
     }
 
     override func log(_ msg: String) {
-        logs.append(msg)
+        CrashlyticsMock.logStorage[self]!.append(msg)
     }
 
     override func record(error: Error) {
-        records.append(error)
+        CrashlyticsMock.recordStorage[self]!.append(error)
+    }
+
+    var logs: [String] {
+        CrashlyticsMock.logStorage[self]!
+    }
+
+    var records: [Error] {
+        CrashlyticsMock.recordStorage[self]!
     }
 }

--- a/src/CattyTests/PlayerEngine/AudioEngine/Helpers/AudioEngineAbstractTest.swift
+++ b/src/CattyTests/PlayerEngine/AudioEngine/Helpers/AudioEngineAbstractTest.swift
@@ -34,7 +34,8 @@ class AudioEngineAbstractTest: XMLAbstractTest {
     override func setUp() {
         super.setUp()
         do {
-            tape = try AKAudioFile()
+            // FIXME: Use proper default initializer when migrating to AudioKit 5
+            tape = try AKAudioFile(writeIn: AKAudioFile.BaseDirectory.temp, name: nil, settings: [:])
             audioEngine = AudioEngineFingerprintingStub(audioPlayerFactory: FingerprintingAudioPlayerFactory())
             recorder = audioEngine.addNodeRecorderAtEngineOut(tape: tape)
 

--- a/src/CattyTests/TestHelpers/ForceInit.h
+++ b/src/CattyTests/TestHelpers/ForceInit.h
@@ -20,26 +20,10 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
+#import <Foundation/Foundation.h>
 
-#import "Catty-Bridging-Header.h"
+@interface ForceInit : NSObject
 
-#import "ConvertExceptionToError.h"
-#import "ForceInit.h"
-#import "chromaprint.h"
-#import "LoginViewController.h"
-#import "BaseCollectionViewController.h"
-#import "ScriptCollectionViewController.h"
-#import "FormulaEditorViewController.h"
-#import "LookImageViewController.h"
-#import "LooksTableViewController.h"
-#import "PaintViewController.h"
-#import "BrickCellMessageData.h"
-#import "BroadcastBrickCell.h"
-#import "BrickInsertManager.h"
-#import "EVCircularProgressView.h"
-#import "ButtonTags.h"
-#import "RoundBorderedButton.h"
-#import "MirrorRotationZoomTool.h"
++ (id)createInstanceOfClass:(NSString *)className;
+
+@end

--- a/src/CattyTests/TestHelpers/ForceInit.m
+++ b/src/CattyTests/TestHelpers/ForceInit.m
@@ -20,26 +20,13 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
-#import "Catty-Bridging-Header.h"
-
-#import "ConvertExceptionToError.h"
 #import "ForceInit.h"
-#import "chromaprint.h"
-#import "LoginViewController.h"
-#import "BaseCollectionViewController.h"
-#import "ScriptCollectionViewController.h"
-#import "FormulaEditorViewController.h"
-#import "LookImageViewController.h"
-#import "LooksTableViewController.h"
-#import "PaintViewController.h"
-#import "BrickCellMessageData.h"
-#import "BroadcastBrickCell.h"
-#import "BrickInsertManager.h"
-#import "EVCircularProgressView.h"
-#import "ButtonTags.h"
-#import "RoundBorderedButton.h"
-#import "MirrorRotationZoomTool.h"
+
+@implementation ForceInit
+
++ (id)createInstanceOfClass:(NSString *)className
+{
+    return [NSClassFromString(className) new];
+}
+
+@end


### PR DESCRIPTION
Implements https://jira.catrob.at/browse/CATTY-574

Xcode 12.5 is more strict when checking initializers marked as NS_UNAVAILABLE, thus some old hacks for creating Mock objects started to produce errors. This PR contains some new hacks that make it work again.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
