### PR TITLE
CATTY-576 Remove notifications in Formula Editor

### DIFF
--- a/src/Catty/FormulaEditor/ViewController/FormulaEditorViewController.m
+++ b/src/Catty/FormulaEditor/ViewController/FormulaEditorViewController.m
@@ -135,12 +135,11 @@ NS_ENUM(NSInteger, ButtonIndex) {
 
 # pragma mark BrickCellDelegate
 - (void)openFormulaEditor:(BrickCellFormulaData*)formulaData withEvent:(UIEvent*)event {
-    BOOL forceChange = event != nil && ((UITouch*)[[event allTouches] anyObject]).tapCount == 2;
-    [self changeBrickCellFormulaData:formulaData andForce:forceChange];
+    [self changeBrickCellFormulaData:formulaData];
     [self.brickCell setNeedsDisplay];
 }
 
-- (BOOL)changeBrickCellFormulaData:(BrickCellFormulaData *)brickCellData andForce:(BOOL)forceChange
+- (BOOL)changeBrickCellFormulaData:(BrickCellFormulaData *)brickCellData
 {
     InternFormulaParser *internFormulaParser = [[InternFormulaParser alloc] initWithTokens:[self.internFormula getInternTokenList] andFormulaManager:self.formulaManager];
     
@@ -164,20 +163,11 @@ NS_ENUM(NSInteger, ButtonIndex) {
             saved = YES;
         }
         [self initFormulaData:brickCellData];
-        if(saved) {
-            [self showChangesSavedView];
-        }
         return saved;
     } else if(formulaParserStatus == FORMULA_PARSER_STACK_OVERFLOW) {
         [self showFormulaTooLongView];
     } else {
-        if(forceChange) {
-            [self initFormulaData:brickCellData];
-            [self showChangesDiscardedView];
-            return YES;
-        } else {
             [self showSyntaxErrorView];
-        }
     }
     
     return NO;
@@ -682,42 +672,6 @@ NS_ENUM(NSInteger, ButtonIndex) {
     NSDebug(@"Text: %@", text);
     [self handleInputWithTitle:text AndButtonType:TOKEN_TYPE_STRING];
     [self.formulaEditorTextView becomeFirstResponder];
-}
-
-- (void)showNotification:(NSString*)text andDuration:(CGFloat)duration
-{
-    if(self.notficicationHud)
-        [self.notficicationHud removeFromSuperview];
-    
-    CGFloat brickAndInputHeight = self.navigationController.navigationBar.frame.size.height + self.brickCellData.brickCell.frame.size.height + self.formulaEditorTextView.frame.size.height + [[UIApplication sharedApplication] statusBarFrame].size.height + 10;
-    CGFloat keyboardHeight = self.formulaEditorTextView.inputView.frame.size.height;
-    CGFloat spacerHeight = self.view.frame.size.height - brickAndInputHeight - keyboardHeight;
-    CGFloat offset;
-    
-    self.notficicationHud = [BDKNotifyHUD notifyHUDWithImage:nil text:text];
-    self.notficicationHud.destinationOpacity = kBDKNotifyHUDDestinationOpacity;
-    
-    if(spacerHeight < self.notficicationHud.frame.size.height)
-        offset = brickAndInputHeight / 2 + self.notficicationHud.frame.size.height / 2;
-    else
-        offset = brickAndInputHeight + self.notficicationHud.frame.size.height / 2 + kBDKNotifyHUDPaddingTop;
-    
-    self.notficicationHud.center = CGPointMake(self.view.center.x, offset);
-    
-    [self.view addSubview:self.notficicationHud];
-    [self.notficicationHud presentWithDuration:duration
-                                         speed:kBDKNotifyHUDPresentationSpeed
-                                        inView:self.view completion:^{ [self.notficicationHud removeFromSuperview]; }];
-}
-
-- (void)showChangesSavedView
-{
-    [self showNotification:kUIFEChangesSaved andDuration:kBDKNotifyHUDPresentationDuration];
-}
-
-- (void)showChangesDiscardedView
-{
-    [self showNotification:kUIFEChangesDiscarded andDuration:kBDKNotifyHUDPresentationDuration];
 }
 
 #pragma mark NotificationCenter


### PR DESCRIPTION
When opening the Formula Editor for a Brick with (at least) two formulas, and switching the formula by tapping on another formula, a "changes saved" notification appears. This notification should be removed.

Also remove the "changes discarded" notification and the force change gesture with double-tap which is not working properly and which is not needed anymore (showChangesDiscardedView and forceChange parameter of changeBrickCellFormulaData).

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
