### PR TITLE
CATTY-578 Incorrect color change when merging EmbroideryStreams

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -366,8 +366,8 @@
 		4614B1D22560856B004174AD /* StitchBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4614B1CF2560856B004174AD /* StitchBrick.swift */; };
 		4614B1DD25608E8B004174AD /* StitchBrickCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4614B1DC25608E8B004174AD /* StitchBrickCell.swift */; };
 		46162CBD2544AE5600DF6042 /* SetRotationStyleBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46162CB92544AE2D00DF6042 /* SetRotationStyleBrickTests.swift */; };
-		4635B28125E98B2800970CCA /* NextLookBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4635B28025E98B2800970CCA /* NextLookBrick.swift */; };
 		4635B25B25E82C8100970CCA /* 817.catrobat in Resources */ = {isa = PBXBuildFile; fileRef = 4635B25625E82C7200970CCA /* 817.catrobat */; };
+		4635B28125E98B2800970CCA /* NextLookBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4635B28025E98B2800970CCA /* NextLookBrick.swift */; };
 		4647D55A23D8AF9F001A67F6 /* PrivacyPolicyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647D55923D8AF9F001A67F6 /* PrivacyPolicyViewController.swift */; };
 		46A75DF425752B1200F3963D /* CircleShapeNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A75DF325752B1200F3963D /* CircleShapeNodeTests.swift */; };
 		46B472BD2560946F007972DB /* StitchBrick+Instruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46B472BA2560946E007972DB /* StitchBrick+Instruction.swift */; };
@@ -903,6 +903,7 @@
 		4CEB22761B95E4BC00B3BE2F /* BrickInsertManagerRepeatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CEB22711B95E4BC00B3BE2F /* BrickInsertManagerRepeatTests.m */; };
 		4CEB22771B95E4BC00B3BE2F /* BrickInsertManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CEB22721B95E4BC00B3BE2F /* BrickInsertManagerTests.m */; };
 		4CECF3BE254969ED0031B024 /* LanguageTranslationDefinesUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CECF3BD254969ED0031B024 /* LanguageTranslationDefinesUI.swift */; };
+		4CEE86542653963A002BC7ED /* EmbroideryServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEE86512653963A002BC7ED /* EmbroideryServiceMock.swift */; };
 		4CEFFAD32105DE4800DC5CFE /* ObjectSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEFFAD02105DE4800DC5CFE /* ObjectSensor.swift */; };
 		4CEFFADA2105E46500DC5CFE /* ObjectStringSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEFFAD82105E46400DC5CFE /* ObjectStringSensor.swift */; };
 		4CEFFADB2105E46500DC5CFE /* ObjectDoubleSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEFFAD92105E46400DC5CFE /* ObjectDoubleSensor.swift */; };
@@ -2255,8 +2256,8 @@
 		4614B1CF2560856B004174AD /* StitchBrick.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StitchBrick.swift; sourceTree = "<group>"; };
 		4614B1DC25608E8B004174AD /* StitchBrickCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StitchBrickCell.swift; sourceTree = "<group>"; };
 		46162CB92544AE2D00DF6042 /* SetRotationStyleBrickTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetRotationStyleBrickTests.swift; sourceTree = "<group>"; };
-		4635B28025E98B2800970CCA /* NextLookBrick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextLookBrick.swift; sourceTree = "<group>"; };
 		4635B25625E82C7200970CCA /* 817.catrobat */ = {isa = PBXFileReference; lastKnownFileType = file; name = 817.catrobat; path = CattyTests/Resources/ParserTests/ZipProjects/817.catrobat; sourceTree = SOURCE_ROOT; };
+		4635B28025E98B2800970CCA /* NextLookBrick.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextLookBrick.swift; sourceTree = "<group>"; };
 		4647D55923D8AF9F001A67F6 /* PrivacyPolicyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyViewController.swift; sourceTree = "<group>"; };
 		46A75DF325752B1200F3963D /* CircleShapeNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleShapeNodeTests.swift; sourceTree = "<group>"; };
 		46B472BA2560946E007972DB /* StitchBrick+Instruction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StitchBrick+Instruction.swift"; sourceTree = "<group>"; };
@@ -2877,6 +2878,7 @@
 		4CEB22711B95E4BC00B3BE2F /* BrickInsertManagerRepeatTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BrickInsertManagerRepeatTests.m; sourceTree = "<group>"; };
 		4CEB22721B95E4BC00B3BE2F /* BrickInsertManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BrickInsertManagerTests.m; sourceTree = "<group>"; };
 		4CECF3BD254969ED0031B024 /* LanguageTranslationDefinesUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LanguageTranslationDefinesUI.swift; path = CattyUITests/Defines/LanguageTranslationDefinesUI.swift; sourceTree = SOURCE_ROOT; };
+		4CEE86512653963A002BC7ED /* EmbroideryServiceMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmbroideryServiceMock.swift; sourceTree = "<group>"; };
 		4CEFFAD02105DE4800DC5CFE /* ObjectSensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectSensor.swift; sourceTree = "<group>"; };
 		4CEFFAD82105E46400DC5CFE /* ObjectStringSensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectStringSensor.swift; sourceTree = "<group>"; };
 		4CEFFAD92105E46400DC5CFE /* ObjectDoubleSensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectDoubleSensor.swift; sourceTree = "<group>"; };
@@ -7320,6 +7322,7 @@
 			children = (
 				4CB73A8F23FC1F0300D5E9A7 /* CatrobatTableViewControllerMock.swift */,
 				4C1A596723FE9997001A78D2 /* CrashlyticsMock.swift */,
+				4CEE86512653963A002BC7ED /* EmbroideryServiceMock.swift */,
 				4C3B151A23F07C7800527D4A /* ErrorMock.swift */,
 				4CD27AA921B5765B00DDADB5 /* FeatureMock.swift */,
 				4C28D78A2132A83D00870CE2 /* FormulaMock.swift */,
@@ -11820,6 +11823,7 @@
 				4C665F6C253F209D00A84BB6 /* LooksTableViewControllerTests.swift in Sources */,
 				9EBCBD832329B44E0074C2D9 /* NextLookBrickTests.swift in Sources */,
 				46C5D9F4254FF637003D58D9 /* SpriteObjectTest.swift in Sources */,
+				4CEE86542653963A002BC7ED /* EmbroideryServiceMock.swift in Sources */,
 				4C2CBB5425A5AA8400C1C143 /* XMLParserBlackBoxTests097.swift in Sources */,
 				4CF4CB7521E64BEE009D6DD9 /* InsertItemIntoUserListBrickTests.swift in Sources */,
 				9E05FAAC247FF356008951DE /* AppDelegateTests.swift in Sources */,

--- a/src/Catty/ViewController/Stage/StagePresenterViewControllerShareExtension.swift
+++ b/src/Catty/ViewController/Stage/StagePresenterViewControllerShareExtension.swift
@@ -25,7 +25,7 @@
     func shareDST() {
 
         var embroideryStream = [EmbroideryStream]()
-        for object in project.scene.objects() {
+        for object in project.scene.objects() where !object.spriteNode.embroideryStream.isEmpty {
             embroideryStream.append(object.spriteNode.embroideryStream)
         }
         let embroideryStreamMerged = EmbroideryStream(streams: embroideryStream)

--- a/src/Catty/ViewController/Stage/StagePresenterViewControllerShareExtension.swift
+++ b/src/Catty/ViewController/Stage/StagePresenterViewControllerShareExtension.swift
@@ -20,16 +20,20 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-@objc extension StagePresenterViewController {
+extension StagePresenterViewController {
 
-    func shareDST() {
+    @objc func shareDST() {
+        shareDST(embroideryService: EmbroideryDSTService())
+    }
+
+    func shareDST(embroideryService: EmbroideryProtocol) {
 
         var embroideryStream = [EmbroideryStream]()
         for object in project.scene.objects() where !object.spriteNode.embroideryStream.isEmpty {
             embroideryStream.append(object.spriteNode.embroideryStream)
         }
         let embroideryStreamMerged = EmbroideryStream(streams: embroideryStream)
-        let data = EmbroideryDSTService().generateOutput(embroideryStream: embroideryStreamMerged)
+        let data = embroideryService.generateOutput(embroideryStream: embroideryStreamMerged)
 
         let temporaryFolder = FileManager.default.temporaryDirectory
         let fileName = String(self.project.header.programName!) + ".dst"

--- a/src/CattyTests/Mocks/EmbroideryServiceMock.swift
+++ b/src/CattyTests/Mocks/EmbroideryServiceMock.swift
@@ -22,22 +22,17 @@
 
 @testable import Pocket_Code
 
-class StagePresenterViewControllerMock: StagePresenterViewController {
+class EmbroideryServiceMock: EmbroideryProtocol {
 
-    var showLoadingViewCalls = 0
-    var hideLoadingViewCalls = 0
-    var latestPresentedViewController: UIViewController?
-    var embroideryService: EmbroideryProtocol?
+    var inputStream: EmbroideryStream?
+    var outputData: Data
 
-    override func showLoadingView() {
-        showLoadingViewCalls += 1
+    init(outputData: Data) {
+        self.outputData = outputData
     }
 
-    override func hideLoadingView() {
-        hideLoadingViewCalls += 1
-    }
-
-    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
-        self.latestPresentedViewController = viewControllerToPresent
+    func generateOutput(embroideryStream: EmbroideryStream) -> Data {
+        self.inputStream = embroideryStream
+        return self.outputData
     }
 }

--- a/src/CattyTests/PlayerEngine/Mocks/SpriteObjectMock.swift
+++ b/src/CattyTests/PlayerEngine/Mocks/SpriteObjectMock.swift
@@ -30,6 +30,12 @@ final class SpriteObjectMock: SpriteObject {
         background = false
     }
 
+    init(scene: Scene) {
+        background = false
+        super.init()
+        self.scene = scene
+    }
+
     override func isBackground() -> Bool {
         self.background
     }

--- a/src/CattyTests/ViewController/Stage/StagePresenterViewControllerTests.swift
+++ b/src/CattyTests/ViewController/Stage/StagePresenterViewControllerTests.swift
@@ -108,4 +108,40 @@ final class StagePresenterViewControllerTest: XCTestCase {
         expect(self.vc.showLoadingViewCalls).toEventually(equal(1))
         expect(self.vc.hideLoadingViewCalls).toEventually(equal(1))
     }
+
+    func testShareDST() {
+        let expectedStitch = Stitch(x: 0, y: 1)
+        let data = Data()
+
+        let stream = EmbroideryStream(projectWidth: project.header.screenWidth as? CGFloat, projectHeight: project.header.screenHeight as? CGFloat)
+        stream.stitches.append(expectedStitch)
+
+        let embroideryServiceMock = EmbroideryServiceMock(outputData: data)
+
+        vc.project = project
+
+        XCTAssertEqual(1, project.allObjects().count)
+
+        let background = project.allObjects().first!
+        let backgroundNode = CBSpriteNodeMock(spriteObject: background)
+        background.spriteNode = backgroundNode
+
+        let object = SpriteObjectMock(scene: project.scene)
+        let objectNode = CBSpriteNodeMock(spriteObject: object)
+        objectNode.embroideryStream = stream
+        object.spriteNode = objectNode
+        project.scene.add(object: object)
+
+        XCTAssertEqual(2, project.allObjects().count)
+        XCTAssertNil(vc.latestPresentedViewController)
+        XCTAssertNil(embroideryServiceMock.inputStream)
+
+        vc.shareDST(embroideryService: embroideryServiceMock)
+
+        XCTAssertNotNil(embroideryServiceMock.inputStream)
+        XCTAssertEqual(1, embroideryServiceMock.inputStream?.stitches.count)
+        XCTAssertEqual(expectedStitch.getPosition(), embroideryServiceMock.inputStream?.stitches.first?.getPosition())
+
+        XCTAssertNotNil(vc.latestPresentedViewController as? UIActivityViewController)
+    }
 }


### PR DESCRIPTION
Merging EmbroideryStreams can lead to lost stitches due to conversion into color change stitches.
Furthermore the exact behavior of color changes between merged streams is not well defined.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
