### PR TITLE
CATTY-557 Hide Maximize icon in sidebar for landscape mode

### DIFF
--- a/src/Catty/ViewController/Stage/StagePresenterSideMenuView.swift
+++ b/src/Catty/ViewController/Stage/StagePresenterSideMenuView.swift
@@ -220,7 +220,13 @@ enum SideMenuButtonType {
             setupImage("stage_dialog_button_aspect_ratio", for: aspectRatioButton)
         }
 
-        if CGFloat(project.header.screenWidth.floatValue) == Util.screenWidth(true) && CGFloat(project.header.screenHeight.floatValue) == Util.screenHeight(true) {
+        let screenHeight = Util.screenHeight(true)
+        let screenWidth = Util.screenWidth(true)
+        let projectWidth = CGFloat(project.header.screenWidth.floatValue)
+        let projectHeight = CGFloat(project.header.screenHeight.floatValue)
+        let hideAspectRatio = landscape ? (projectWidth == screenHeight && projectHeight == screenWidth) : (projectWidth == screenWidth && projectHeight == screenHeight)
+
+        if hideAspectRatio {
             aspectRatioLabel.isHidden = true
             aspectRatioButton.isHidden = true
         } else {

--- a/src/CattyTests/ViewController/Stage/StagePresenterSideMenuViewTests.swift
+++ b/src/CattyTests/ViewController/Stage/StagePresenterSideMenuViewTests.swift
@@ -91,6 +91,28 @@ final class StagePresenterSideMenuViewTests: XCTestCase {
         XCTAssertTrue(view.aspectRatioLabel!.isHidden)
     }
 
+    func testAspectRatioLandscape() {
+        project.header.screenWidth = NSNumber(value: Util.screenWidth(true).doubleValue)
+        project.header.screenHeight = NSNumber(value: Util.screenHeight(true).doubleValue)
+        project.header.landscapeMode = true
+
+        let view = StagePresenterSideMenuView(frame: .zero, delegate: delegateMock)
+
+        XCTAssertFalse(view.aspectRatioButton!.isHidden)
+        XCTAssertFalse(view.aspectRatioLabel!.isHidden)
+    }
+
+    func testAspectRatioLandscapeHidden() {
+        project.header.screenWidth = NSNumber(value: Util.screenHeight(true).doubleValue)
+        project.header.screenHeight = NSNumber(value: Util.screenWidth(true).doubleValue)
+        project.header.landscapeMode = true
+
+        let view = StagePresenterSideMenuView(frame: .zero, delegate: delegateMock)
+
+        XCTAssertTrue(view.aspectRatioButton!.isHidden)
+        XCTAssertTrue(view.aspectRatioLabel!.isHidden)
+    }
+
     func testRestart() {
         let view = StagePresenterSideMenuView(frame: .zero, delegate: delegateMock)
         XCTAssertFalse(view.landscape)


### PR DESCRIPTION
Currently the "Maximize" icon is permanently shown in landscape mode. Hide the "Maximize" icon if the project's resolution is the same as the current device's resolution.
Do not forget to add tests.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
