### PR TITLE
CATTY-579 Crash while using line tool

### DIFF
--- a/src/Catty/PocketPaint/Tools/LineTool.m
+++ b/src/Catty/PocketPaint/Tools/LineTool.m
@@ -42,7 +42,9 @@
     
     //    if (enabled) {
     fingerSwiped = NO;
-    lastPoint = [recognizer locationOfTouch:0 inView:self.canvas.drawView];
+    if ([recognizer numberOfTouches] > 0) {
+        lastPoint = [recognizer locationOfTouch:0 inView:self.canvas.drawView];
+    }
     //    }
     
   }else if (recognizer.state == UIGestureRecognizerStateChanged){


### PR DESCRIPTION
The last point should just get saved if the recognizer recognized more than zero touches. I was unable to reproduce the BUG afterwards, but hence it occurred occasionally before it would be great to additionally manual test the PR's version.

https://jira.catrob.at/browse/CATTY-579

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline]
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
