### PR TITLE
 CATTY-588-Play-media-library-sound-while-muted

### DIFF
--- a/src/Catty/Supporting Files/Catty-Bridging-Header.h
+++ b/src/Catty/Supporting Files/Catty-Bridging-Header.h
@@ -158,6 +158,8 @@
 #import "CBMutableCopyContext.h"
 #import "CameraPreviewHandler.h"
 #import "UndoManager.h"
+#import "SharkfoodMuteSwitchDetector.h"
+#import <AudioToolbox/AudioToolbox.h>
 
 //------------------------------------------------------------------------------------------------------------
 // ViewController classes

--- a/src/Catty/ViewController/MediaLibrary/MediaLibraryViewController.swift
+++ b/src/Catty/ViewController/MediaLibrary/MediaLibraryViewController.swift
@@ -174,13 +174,14 @@ extension MediaLibraryViewController: SoundsLibraryCollectionViewDataSourceDeleg
         self.audioPlayerFinishPlayingCompletionBlock?.completion?()
         self.audioPlayerFinishPlayingCompletionBlock = nil
 
-        silentDetector?.silentNotify = { silent in
-            if silent {
-                Util.alert(
-                text: (Util.isPhone()
-                    ? kLocalizedDeviceIsInMutedStateIPhoneDescription
-                    : kLocalizedDeviceIsInMutedStateIPadDescription))
-            return            }
+        if silentDetector?.isMute == true {
+            Util.alert(
+            text: (Util.isPhone()
+                ? kLocalizedDeviceIsInMutedStateIPhoneDescription
+                : kLocalizedDeviceIsInMutedStateIPadDescription))
+
+            completion?()
+            return
         }
 
         do {

--- a/src/Catty/ViewController/MediaLibrary/MediaLibraryViewController.swift
+++ b/src/Catty/ViewController/MediaLibrary/MediaLibraryViewController.swift
@@ -43,6 +43,7 @@ final class MediaLibraryViewController: UICollectionViewController {
 
     private var audioPlayer: AVAudioPlayer?
     private var audioPlayerFinishPlayingCompletionBlock: AudioPlayerFinishPlayingCompletionBlock?
+    private var silentDetector: SharkfoodMuteSwitchDetector?
 
     // MARK: - Initializers
 
@@ -50,6 +51,12 @@ final class MediaLibraryViewController: UICollectionViewController {
         self.dataSource = MediaLibraryCollectionViewDataSource.dataSource(for: mediaType)
         super.init(collectionViewLayout: UICollectionViewFlowLayout())
         self.dataSource.delegate = self
+        self.silentDetector = SharkfoodMuteSwitchDetector.shared()
+        silentDetector?.silentNotify = { silent in
+            if silent {
+                self.audioPlayer?.stop()
+            }
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -74,12 +81,10 @@ final class MediaLibraryViewController: UICollectionViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        enableSoundInSilentMode()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        undoEnableSoundInSilentMode()
     }
 
     override func didReceiveMemoryWarning() {
@@ -169,6 +174,15 @@ extension MediaLibraryViewController: SoundsLibraryCollectionViewDataSourceDeleg
         self.audioPlayerFinishPlayingCompletionBlock?.completion?()
         self.audioPlayerFinishPlayingCompletionBlock = nil
 
+        silentDetector?.silentNotify = { silent in
+            if silent {
+                Util.alert(
+                text: (Util.isPhone()
+                    ? kLocalizedDeviceIsInMutedStateIPhoneDescription
+                    : kLocalizedDeviceIsInMutedStateIPadDescription))
+            return            }
+        }
+
         do {
             audioPlayerFinishPlayingCompletionBlock = AudioPlayerFinishPlayingCompletionBlock(completion)
             let audioPlayer = try AVAudioPlayer(data: data)
@@ -220,21 +234,5 @@ extension MediaLibraryViewController: SoundsLibraryCollectionViewDataSourceDeleg
             self?.navigationController?.popViewController(animated: true)
         }
         self.present(alertController, animated: true, completion: nil)
-    }
-}
-
-extension MediaLibraryViewController {
-    private func enableSoundInSilentMode() {
-        let sharedAudioSession = AVAudioSession.sharedInstance()
-        self.originalAudioSessionCategory = sharedAudioSession.category
-        self.originalAudioSessionCategoryOptions = sharedAudioSession.categoryOptions
-        try? sharedAudioSession.setCategory(.playback, mode: .default, options: .mixWithOthers)
-    }
-
-    private func undoEnableSoundInSilentMode() {
-        if let category = self.originalAudioSessionCategory, let options = self.originalAudioSessionCategoryOptions {
-            let sharedAudioSession = AVAudioSession.sharedInstance()
-            try? sharedAudioSession.setCategory(category, mode: .default, options: options)
-        }
     }
 }


### PR DESCRIPTION
When adding a sound from the media library, sounds can be played while being in the media library. That should not be possible when having the mute switch on. Instead, the same alert should be displayed, like when trying to play sounds from within the "SoundsTableViewController".

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
