### PR TITLE
CATTY-569 Refactor UIDefines.h

### DIFF
--- a/src/Catty/DataModel/Bricks/Motion/GoToBrick.h
+++ b/src/Catty/DataModel/Bricks/Motion/GoToBrick.h
@@ -23,6 +23,10 @@
 #import "Brick.h"
 #import "BrickStaticChoiceProtocol.h"
 
+#define kGoToTouchPosition 80
+#define kGoToRandomPosition 81
+#define kGoToOtherSpritePosition 82
+
 @class SpriteObject;
 
 @interface GoToBrick : Brick<BrickStaticChoiceProtocol>

--- a/src/Catty/DataModel/Scripts/WhenScript.m
+++ b/src/Catty/DataModel/Scripts/WhenScript.m
@@ -22,13 +22,14 @@
 
 #import "WhenScript.h"
 #import "Util.h"
+#import "Pocket_Code-Swift.h"
 
 @implementation WhenScript
 
 - (instancetype)init {
     self = [super init];
     if(self) {
-        self.action = kWhenScriptDefaultAction;
+        self.action = UIDefines.whenScriptDefaultAction;
     }
     return self;
 }

--- a/src/Catty/Defines/UIDefines.h
+++ b/src/Catty/Defines/UIDefines.h
@@ -22,64 +22,6 @@
 
 #import "LanguageTranslationDefines.h"
 
-// Screen Sizes in Points
-#define kIphone4ScreenHeight 480.0f
-#define kIphone5ScreenHeight 568.0f
-#define kIphone6PScreenHeight 736.0f
-#define kIpadScreenHeight 1028.0f
-
-// ScenePresenterViewController
-#define kSlidingStartArea 40
-#define kFirstSwipeDuration 0.65f
-#define kHideMenuViewDelay 0.45f
-
-// Blocked characters for project names, object names, images names, sounds names and variable/list names
-#define kTextFieldBlockedCharacters @""
-
-#define kMenuImageNameContinue @"continue"
-#define kMenuImageNameNew @"new"
-#define kMenuImageNameProjects @"projects"
-#define kMenuImageNameHelp @"help"
-#define kMenuImageNameExplore @"explore"
-#define kMenuImageNameUpload @"upload"
-
-// view tag
-#define kSavedViewTag          99996
-
-// delete button bricks
-#define kBrickCellDeleteButtonWidthHeight 55.0f
-#define kSelectButtonOffset 30.0f
-#define kSelectButtonTranslationOffsetX 60.0f
-
-// Notifications
-static NSString *const kBrickCellAddedNotification = @"BrickCellAddedNotification";
-static NSString *const kSoundAddedNotification = @"SoundAddedNotification";
-static NSString *const kRecordAddedNotification = @"RecordAddedNotification";
-static NSString *const kBrickDetailViewDismissed = @"BrickDetailViewDismissed";
-static NSString *const kHideLoadingViewNotification = @"HideLoadingViewNotification";
-static NSString *const kShowSavedViewNotification = @"ShowSavedViewNotification";
-static NSString *const kReadyToUpload = @"ReadyToUploadProject";
-static NSString *const kLoggedInNotification = @"LoggedInNotification";
-
-// Notification keys
-static NSString *const kUserInfoKeyBrickCell = @"UserInfoKeyBrickCell";
-static NSString *const kUserInfoSpriteObject = @"UserInfoSpriteObject";
-static NSString *const kUserInfoSound = @"UserInfoSound";
-
-// UI Elements
-#define kToolbarHeight 44.0f
-
-//BDKNotifyHUD
-#define kBDKNotifyHUDDestinationOpacity 0.3f
-#define kBDKNotifyHUDCenterOffsetY (-20.0f)
-#define kBDKNotifyHUDPresentationDuration 0.5f
-#define kBDKNotifyHUDPresentationSpeed 0.1f
-#define kBDKNotifyHUDPaddingTop 30.0f
-static NSString *const kBDKNotifyHUDCheckmarkImageName = @"checkmark.png";
-
-#define kFormulaEditorShowResultDuration 4.0f
-#define kFormulaEditorTopOffset 64.0f
-
 // ---------------------- BRICK CONFIG ---------------------------------------
 // brick categories
 typedef NS_ENUM(NSUInteger, kBrickCategoryType) {
@@ -97,50 +39,8 @@ typedef NS_ENUM(NSUInteger, kBrickCategoryType) {
     kRecentlyUsedBricks        = 0
 };
 
-#define WRAP_UINT_IN_NSNUMBER(number) ([NSNumber numberWithUnsignedInteger:number])
-#define kNSNumberZero WRAP_UINT_IN_NSNUMBER(0)
-
-#define kWhenScriptDefaultAction @"Tapped" // at the moment Catrobat only supports this type of action for WhenScripts
-
 typedef NS_ENUM(NSInteger, kBrickShapeType) {
     kBrickShapeSquareSmall = 0,
     kBrickShapeRoundedSmall,
     kBrickShapeRoundedBig
 };
-
-// brick heights
-#define kBrickHeight1h 55.9f
-#define kBrickHeight2h 75.9f
-#define kBrickHeight3h 98.9f
-#define kBrickHeightControl1h 72.4f
-#define kBrickHeightControl2h 99.4f
-
-#define kBrickOverlapHeight -4.4f
-
-// brick subview const values
-#define kBrickInlineViewOffsetX 54.0f
-#define kBrickShapeNormalInlineViewOffsetY 4.0f
-#define kBrickShapeRoundedSmallInlineViewOffsetY 20.7f
-#define kBrickShapeRoundedBigInlineViewOffsetY 37.0f
-#define kBrickShapeNormalMarginHeightDeduction 14.0f
-#define kBrickShapeRoundedSmallMarginHeightDeduction 27.0f
-#define kBrickShapeRoundedBigMarginHeightDeduction 47.0f
-#define kBrickInlineViewCanvasOffsetX 0.0f
-#define kBrickInlineViewCanvasOffsetY 0.0f
-
-#define kBrickLabelFontSize 15.0f
-#define kBrickTextFieldFontSize 15.0f
-#define kBrickInputFieldHeight 28.0f
-#define kBrickInputFieldMinWidth 40.0f
-#define kBrickInputFieldMaxWidth [Util screenWidth]/2.0f
-#define kBrickComboBoxWidth [Util screenWidth] - 65
-#define kBrickInputFieldTopMargin 4.0f
-#define kBrickInputFieldBottomMargin 5.0f
-#define kBrickInputFieldLeftMargin 4.0f
-#define kBrickInputFieldRightMargin 4.0f
-#define kBrickInputFieldMinRowHeight kBrickInputFieldHeight
-#define kDefaultImageCellBorderWidth 0.5f
-
-#define kGoToTouchPosition 80
-#define kGoToRandomPosition 81
-#define kGoToOtherSpritePosition 82

--- a/src/Catty/Defines/UIDefines.swift
+++ b/src/Catty/Defines/UIDefines.swift
@@ -44,4 +44,85 @@ class UIDefines: NSObject {
 
     static let recentlyUsedBricksMinSize = 1
     static let recentlyUsedBricksMaxSize = 10
+
+    // Screen Sizes in Points
+    @objc static let iPhone4ScreenHeight = CGFloat(480.0)
+    @objc static let iPhone5ScreenHeight = CGFloat(568.0)
+    @objc static let iPhone6PScreenHeight = CGFloat(736.0)
+    @objc static let iPadScreenHeight = CGFloat(1028.0)
+
+    // ScenePresenterViewController
+    @objc static let slidingStartArea = 40
+    @objc static let firstSwipeDuration = CGFloat(0.65)
+    @objc static let hideMenuViewDelay = CGFloat(0.45)
+
+    // Blocked characters for project names, object names, images names, sounds names and variable/list names
+    @objc static let textFieldBlockedCharacters = ""
+
+    @objc static let menuImageNameContinue = "continue"
+    @objc static let menuImageNameNew = "new"
+    @objc static let menuImageNameProjects = "projects"
+    @objc static let menuImageNameHelp = "help"
+    @objc static let menuImageNameExplore = "explore"
+    @objc static let menuImageNameUpload = "upload"
+
+    // view tag
+    @objc static let savedViewTag = Int(99996)
+
+    // delete button bricks
+    @objc static let brickCellDeleteButtonWidthHeight = CGFloat(55.0)
+    @objc static let selectButtonOffset = CGFloat(30.0)
+    @objc static let selectButtonTranslationOffsetX = CGFloat(60.0)
+
+    // UI Elements
+    @objc static let toolbarHeight = CGFloat(44.0)
+
+    //BDKNotifyHUD
+    @objc static let bdkNotifyHUDDestinationOpacity = CGFloat(0.3)
+    @objc static let bdkNotifyHUDCenterOffsetY = CGFloat(-20.0)
+    @objc static let bdkNotifyHUDPresentationDuration = CGFloat(0.5)
+    @objc static let bdkNotifyHUDPresentationSpeed = CGFloat(0.1)
+    @objc static let bdkNotifyHUDCheckmarkImageName = "checkmark.png"
+
+    // ---------------------- BRICK CONFIG ---------------------------------------
+    // brick categories
+    @objc static let minFavouriteBrickSize = 5
+    @objc static let maxFavouriteBrickSize = 10
+
+    @objc static let nsNumberZero = NSNumber(value: UInt(0))
+
+    @objc static let whenScriptDefaultAction = "Tapped" // at the moment Catrobat only supports this type of action for WhenScripts
+
+    // brick heights
+    @objc static let brickHeight1h = CGFloat(55.9)
+    @objc static let brickHeight2h = CGFloat(75.9)
+    @objc static let brickHeight3h = CGFloat(98.9)
+    @objc static let brickHeightControl1h = CGFloat(72.4)
+    @objc static let brickHeightControl2h = CGFloat(99.4)
+
+    @objc static let brickOverlapHeight = CGFloat(-4.4)
+
+    // brick subview const values
+    @objc static let brickInlineViewOffsetX = CGFloat(54.0)
+    @objc static let brickShapeNormalInlineViewOffsetY = CGFloat(4.0)
+    @objc static let brickShapeRoundedSmallInlineViewOffsetY = CGFloat(20.7)
+    @objc static let brickShapeRoundedBigInlineViewOffsetY = CGFloat(37.0)
+    @objc static let brickShapeNormalMarginHeightDeduction = CGFloat(14.0)
+    @objc static let brickShapeRoundedSmallMarginHeightDeduction = CGFloat(27.0)
+    @objc static let brickShapeRoundedBigMarginHeightDeduction = CGFloat(47.0)
+    @objc static let brickInlineViewCanvasOffsetX = CGFloat(0.0)
+    @objc static let brickInlineViewCanvasOffsetY = CGFloat(0.0)
+
+    @objc static let brickLabelFontSize = CGFloat(15.0)
+    @objc static let brickTextFieldFontSize = CGFloat(15.0)
+    @objc static let brickInputFieldHeight = CGFloat(28.0)
+    @objc static let brickInputFieldMinWidth = CGFloat(40.0)
+    @objc static let brickInputFieldMaxWidth = CGFloat(Util.screenWidth() / 2.0)
+    @objc static let brickComboBoxWidth = CGFloat(Util.screenWidth() - 65)
+    @objc static let brickInputFieldTopMargin = CGFloat(4.0)
+    @objc static let brickInputFieldBottomMargin = CGFloat(5.0)
+    @objc static let brickInputFieldLeftMargin = CGFloat(4.0)
+    @objc static let brickInputFieldRightMargin = CGFloat(4.0)
+    @objc static let brickInputFieldMinRowHeight = brickInputFieldHeight
+    @objc static let defaultImageCellBorderWidth = CGFloat(0.5)
 }

--- a/src/Catty/Defines/UIDefines.swift
+++ b/src/Catty/Defines/UIDefines.swift
@@ -85,12 +85,6 @@ class UIDefines: NSObject {
     @objc static let bdkNotifyHUDCheckmarkImageName = "checkmark.png"
 
     // ---------------------- BRICK CONFIG ---------------------------------------
-    // brick categories
-    @objc static let minFavouriteBrickSize = 5
-    @objc static let maxFavouriteBrickSize = 10
-
-    @objc static let nsNumberZero = NSNumber(value: UInt(0))
-
     @objc static let whenScriptDefaultAction = "Tapped" // at the moment Catrobat only supports this type of action for WhenScripts
 
     // brick heights

--- a/src/Catty/Helpers/Util/UIUtil.m
+++ b/src/Catty/Helpers/Util/UIUtil.m
@@ -50,7 +50,7 @@
 }
 
 + (UILabel*)newDefaultBrickLabelWithFrame:(CGRect)frame {
-    return [self newDefaultBrickLabelWithFrame:frame AndText:nil andRemainingSpace:kBrickInputFieldMaxWidth];
+    return [self newDefaultBrickLabelWithFrame:frame AndText:nil andRemainingSpace:UIDefines.brickInputFieldMaxWidth];
 }
 
 + (UILabel*)newDefaultBrickLabelWithFrame:(CGRect)frame AndText:(NSString*)text
@@ -58,7 +58,7 @@
 {
     UILabel *label = [[UILabel alloc] initWithFrame:frame];
     label.textColor = UIColor.whiteColor;
-    label.font = [UIFont fontWithName:@"Helvetica-Bold" size:kBrickLabelFontSize];
+    label.font = [UIFont fontWithName:@"Helvetica-Bold" size:UIDefines.brickLabelFontSize];
     if (text) {
         label.text = text;
         // adapt size to fit text

--- a/src/Catty/Helpers/Util/Util.h
+++ b/src/Catty/Helpers/Util/Util.h
@@ -137,10 +137,6 @@ if (__functor) __functor(__VA_ARGS__);  \
 
 + (NSArray* _Nullable)getSubsetOfTheMostFavoriteChosenBricks:(NSUInteger) amount;
 
-+ (void)resetBrickStatistics;
-
-+ (NSDictionary* _Nullable)defaultBrickStatisticDictionary;
-
 + (NSString* _Nullable)replaceBlockedCharactersForString:(NSString* _Nullable)string;
 
 + (NSString* _Nullable)enableBlockedCharactersForString:(NSString* _Nullable)string;

--- a/src/Catty/Helpers/Util/Util.m
+++ b/src/Catty/Helpers/Util/Util.m
@@ -565,7 +565,7 @@
     NSArray* defautArray = [NSArray new];
     OrderedDictionary * dict = [[OrderedDictionary alloc] initWithCapacity:defautArray.count];
     for (NSString * brick in defautArray.reverseObjectEnumerator) {
-        [dict insertObject:kNSNumberZero forKey:brick atIndex:0];
+        [dict insertObject:UIDefines.nsNumberZero forKey:brick atIndex:0];
     }
     return dict;
 }

--- a/src/Catty/Helpers/Util/Util.m
+++ b/src/Catty/Helpers/Util/Util.m
@@ -553,23 +553,6 @@
              usedBricksInDictionary:[self getBrickInsertionDictionaryFromUserDefaults]];
 }
 
-+ (void)resetBrickStatistics
-{
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    [userDefaults setObject:[self defaultBrickStatisticDictionary] forKey:kUserDefaultsBrickSelectionStatisticsMap];
-    [userDefaults synchronize];
-}
-
-+ (NSDictionary*)defaultBrickStatisticDictionary
-{
-    NSArray* defautArray = [NSArray new];
-    OrderedDictionary * dict = [[OrderedDictionary alloc] initWithCapacity:defautArray.count];
-    for (NSString * brick in defautArray.reverseObjectEnumerator) {
-        [dict insertObject:UIDefines.nsNumberZero forKey:brick atIndex:0];
-    }
-    return dict;
-}
-
 + (NSString*)replaceBlockedCharactersForString:(NSString*)string
 {
     string = [string stringByReplacingOccurrencesOfString:@"/" withString:@"%2F"];

--- a/src/Catty/Helpers/Util/Util.swift
+++ b/src/Catty/Helpers/Util/Util.swift
@@ -186,7 +186,7 @@ func synchronized(lock: AnyObject, closure: () -> Void) {
     class func screenSize(_ inPixel: Bool) -> CGSize {
         var screenSize = inPixel ? UIScreen.main.nativeBounds.size : UIScreen.main.bounds.size
 
-        if inPixel && UIScreen.main.bounds.height == CGFloat(kIphone6PScreenHeight) {
+        if inPixel && UIScreen.main.bounds.height == UIDefines.iPhone6PScreenHeight {
             let iPhonePlusDownsamplingFactor = CGFloat(1.15)
             screenSize.height /= iPhonePlusDownsamplingFactor
             screenSize.width /= iPhonePlusDownsamplingFactor
@@ -230,12 +230,12 @@ func synchronized(lock: AnyObject, closure: () -> Void) {
             return
         }
 
-        hud.destinationOpacity = CGFloat(kBDKNotifyHUDDestinationOpacity)
+        hud.destinationOpacity = UIDefines.bdkNotifyHUDDestinationOpacity
         hud.center = CGPoint(x: vc.view.center.x, y: vc.view.center.y)
 
         vc.view.addSubview(hud)
-        hud.present(withDuration: CGFloat(kBDKNotifyHUDPresentationDuration),
-                    speed: CGFloat(kBDKNotifyHUDPresentationSpeed),
+        hud.present(withDuration: UIDefines.bdkNotifyHUDPresentationDuration,
+                    speed: UIDefines.bdkNotifyHUDPresentationSpeed,
                     in: vc.view,
                     completion: {
                         hud.removeFromSuperview()
@@ -243,7 +243,7 @@ func synchronized(lock: AnyObject, closure: () -> Void) {
     }
 
     class func showNotificationForSaveAction() {
-        guard let hud = BDKNotifyHUD(image: UIImage(named: kBDKNotifyHUDCheckmarkImageName), text: kLocalizedSaved) else {
+        guard let hud = BDKNotifyHUD(image: UIImage(named: UIDefines.bdkNotifyHUDCheckmarkImageName), text: kLocalizedSaved) else {
             return
         }
 
@@ -252,14 +252,14 @@ func synchronized(lock: AnyObject, closure: () -> Void) {
             return
         }
 
-        hud.destinationOpacity = CGFloat(kBDKNotifyHUDDestinationOpacity)
+        hud.destinationOpacity = UIDefines.bdkNotifyHUDDestinationOpacity
         hud.center = CGPoint(x: vc.view.center.x,
-                             y: vc.view.center.y + CGFloat(kBDKNotifyHUDCenterOffsetY))
-        hud.tag = Int(kSavedViewTag)
+                             y: vc.view.center.y + UIDefines.bdkNotifyHUDCenterOffsetY)
+        hud.tag = UIDefines.savedViewTag
 
         vc.view.addSubview(hud)
-        hud.present(withDuration: CGFloat(kBDKNotifyHUDPresentationDuration),
-                    speed: CGFloat(kBDKNotifyHUDPresentationSpeed),
+        hud.present(withDuration: UIDefines.bdkNotifyHUDPresentationDuration,
+                    speed: UIDefines.bdkNotifyHUDPresentationSpeed,
                     in: vc.view,
                     completion: {
                         hud.removeFromSuperview()

--- a/src/Catty/PocketPaint/Tools/ResizeViewManager.m
+++ b/src/Catty/PocketPaint/Tools/ResizeViewManager.m
@@ -284,24 +284,24 @@
     [NSTimer scheduledTimerWithTimeInterval:0.15f target:self selector:@selector(hideShowUserAction) userInfo:nil repeats:NO];
     BDKNotifyHUD *hud = [BDKNotifyHUD notifyHUDWithImage:nil
                                                     text:kLocalizedPaintInserted];
-    hud.destinationOpacity = kBDKNotifyHUDDestinationOpacity;
-    hud.center = CGPointMake(self.canvas.view.center.x, self.canvas.view.center.y + kBDKNotifyHUDCenterOffsetY);
+    hud.destinationOpacity = UIDefines.bdkNotifyHUDDestinationOpacity;
+    hud.center = CGPointMake(self.canvas.view.center.x, self.canvas.view.center.y + UIDefines.bdkNotifyHUDCenterOffsetY);
     [self.canvas.view addSubview:hud];
-    [hud presentWithDuration:kBDKNotifyHUDPresentationDuration
-                       speed:kBDKNotifyHUDPresentationSpeed
+    [hud presentWithDuration:UIDefines.bdkNotifyHUDPresentationDuration
+                       speed:UIDefines.bdkNotifyHUDPresentationSpeed
                       inView:self.canvas.view
                   completion:^{ [hud removeFromSuperview]; }];
 }
 
 - (void)showStampAction
 {
-    BDKNotifyHUD *hud = [BDKNotifyHUD notifyHUDWithImage:[UIImage imageNamed:kBDKNotifyHUDCheckmarkImageName]
+    BDKNotifyHUD *hud = [BDKNotifyHUD notifyHUDWithImage:[UIImage imageNamed:UIDefines.bdkNotifyHUDCheckmarkImageName]
                                                     text:kLocalizedPaintStamped];
-    hud.destinationOpacity = kBDKNotifyHUDDestinationOpacity;
-    hud.center = CGPointMake(self.canvas.view.center.x, self.canvas.view.center.y + kBDKNotifyHUDCenterOffsetY);
+    hud.destinationOpacity = UIDefines.bdkNotifyHUDDestinationOpacity;
+    hud.center = CGPointMake(self.canvas.view.center.x, self.canvas.view.center.y + UIDefines.bdkNotifyHUDCenterOffsetY);
     [self.canvas.view addSubview:hud];
-    [hud presentWithDuration:kBDKNotifyHUDPresentationDuration
-                       speed:kBDKNotifyHUDPresentationSpeed
+    [hud presentWithDuration:UIDefines.bdkNotifyHUDPresentationDuration
+                       speed:UIDefines.bdkNotifyHUDPresentationSpeed
                       inView:self.canvas.view
                   completion:^{ [hud removeFromSuperview]; }];
 }

--- a/src/Catty/ViewController/BaseViewController/BaseTableViewController.m
+++ b/src/Catty/ViewController/BaseViewController/BaseTableViewController.m
@@ -126,7 +126,7 @@
 {
     [super viewWillAppear:animated];
     for (UIView *view in self.view.subviews) {
-        if (view.tag == kSavedViewTag)
+        if (view.tag == UIDefines.savedViewTag)
             [view removeFromSuperview];
     }
     [self hideLoadingView];

--- a/src/Catty/ViewController/CatrobatTableViewController/CatrobatTableViewController.m
+++ b/src/Catty/ViewController/CatrobatTableViewController/CatrobatTableViewController.m
@@ -145,7 +145,7 @@ NS_ENUM(NSInteger, ViewControllerIndex) {
                   kLocalizedCatrobatCommunity,
                   kLocalizedUploadProject, nil];
 
-    self.imageNames = [[NSArray alloc] initWithObjects:kMenuImageNameContinue, kMenuImageNameNew, kMenuImageNameProjects, kMenuImageNameHelp, kMenuImageNameExplore, kMenuImageNameUpload, nil];
+    self.imageNames = [[NSArray alloc] initWithObjects:UIDefines.menuImageNameContinue, UIDefines.menuImageNameNew, UIDefines.menuImageNameProjects, UIDefines.menuImageNameHelp, UIDefines.menuImageNameExplore, UIDefines.menuImageNameUpload, nil];
 }
 
 - (void)initNavigationBar

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/ScriptCollectionViewController.m
@@ -189,7 +189,7 @@
                    layout:(UICollectionViewLayout*)collectionViewLayout
 minimumLineSpacingForSectionAtIndex:(NSInteger)section
 {
-    return kBrickOverlapHeight;
+    return UIDefines.brickOverlapHeight;
 }
 
 - (BOOL)collectionView:(UICollectionView *)collectionView shouldHighlightItemAtIndexPath:(NSIndexPath *)indexPath
@@ -536,7 +536,7 @@ willBeginDraggingItemAtIndexPath:(NSIndexPath*)indexPath
         [brickCell insertAnimate:brickCell.scriptOrBrick.isAnimatedInsertBrick];
     }
     if (self.isEditing) {
-        brickCell.center = CGPointMake(brickCell.center.x + kSelectButtonTranslationOffsetX, brickCell.center.y);
+        brickCell.center = CGPointMake(brickCell.center.x + UIDefines.selectButtonTranslationOffsetX, brickCell.center.y);
         brickCell.selectButton.alpha = 1.0f;
         if(!brickCell.isScriptBrick)
         {
@@ -1369,7 +1369,7 @@ willBeginDraggingItemAtIndexPath:(NSIndexPath*)indexPath
     
     [UIView animateWithDuration:0.5f  delay:0.0f usingSpringWithDamping:0.6f initialSpringVelocity:1.5f options:UIViewAnimationOptionCurveEaseInOut animations:^{
         for (BrickCell *brickCell in self.collectionView.visibleCells) {
-            brickCell.center = CGPointMake(brickCell.center.x + kSelectButtonTranslationOffsetX, brickCell.center.y);
+            brickCell.center = CGPointMake(brickCell.center.x + UIDefines.selectButtonTranslationOffsetX, brickCell.center.y);
             brickCell.selectButton.alpha = 1.0f;
         }
     } completion:^(BOOL finished) {

--- a/src/Catty/ViewController/Download/ChartProjects/ChartProjectsStoreViewController.swift
+++ b/src/Catty/ViewController/Download/ChartProjects/ChartProjectsStoreViewController.swift
@@ -96,8 +96,8 @@ class ChartProjectsStoreViewController: UIViewController, SelectedChartProjectsD
 
     // check iPhone4 or iphone5
     private func checkIphoneScreenSize() -> Bool {
-        let screenHeight = Float(Util.screenHeight())
-        return (((screenHeight - kIphone4ScreenHeight) == 0) || ((screenHeight - kIphone5ScreenHeight) == 0)) ? true : false
+        let screenHeight = Util.screenHeight()
+        return (((screenHeight - UIDefines.iPhone4ScreenHeight) == 0) || ((screenHeight - UIDefines.iPhone5ScreenHeight) == 0)) ? true : false
     }
 
     private func setupTableView() {

--- a/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewControllerExtension.swift
+++ b/src/Catty/ViewController/Download/Details/ProjectDetailStoreViewControllerExtension.swift
@@ -96,7 +96,7 @@ import ActiveLabel
 
         let maximumLabelSize = CGSize(width: view.frame.size.width / 100 * (100 - type(of: self).marginLeftPercentage * 2), height: CGFloat(Int.max))
         var attributes: [AnyHashable: Any]?
-        if height == CGFloat(kIpadScreenHeight) {
+        if height == UIDefines.iPadScreenHeight {
             attributes = [descriptionTitleLabel.font: UIFont.systemFont(ofSize: 20)]
         } else {
             attributes = [descriptionTitleLabel.font: UIFont.systemFont(ofSize: 14)]
@@ -297,7 +297,7 @@ import ActiveLabel
 
     private func configureTitleLabel(_ label: UILabel?, andHeight height: CGFloat) {
         label?.backgroundColor = UIColor.clear
-        if height == CGFloat(kIpadScreenHeight) {
+        if height == UIDefines.iPadScreenHeight {
             label?.font = UIFont.boldSystemFont(ofSize: 24)
         } else {
             label?.font = UIFont.boldSystemFont(ofSize: 17)
@@ -309,7 +309,7 @@ import ActiveLabel
 
     private func configureTextLabel(_ label: UILabel?, andHeight height: CGFloat) {
         label?.backgroundColor = UIColor.clear
-        if height == CGFloat(kIpadScreenHeight) {
+        if height == UIDefines.iPadScreenHeight {
             label?.font = UIFont.boldSystemFont(ofSize: 18)
         } else {
             label?.font = UIFont.boldSystemFont(ofSize: 12)
@@ -321,7 +321,7 @@ import ActiveLabel
 
     private func configureAuthorLabel(_ label: UILabel?, andHeight height: CGFloat) {
         label?.backgroundColor = UIColor.clear
-        if height == CGFloat(kIpadScreenHeight) {
+        if height == UIDefines.iPadScreenHeight {
             label?.font = UIFont.boldSystemFont(ofSize: 18)
         } else {
             label?.font = UIFont.boldSystemFont(ofSize: 12)
@@ -347,7 +347,7 @@ import ActiveLabel
         let detailInformationLabel = UILabel(frame: CGRect(x: xPosition, y: yPosition, width: 155, height: 25))
         detailInformationLabel.text = title?.stringByEscapingHTMLEntities()
         detailInformationLabel.textColor = UIColor.textTint
-        if height == CGFloat(kIpadScreenHeight) {
+        if height == UIDefines.iPadScreenHeight {
             detailInformationLabel.font = UIFont.systemFont(ofSize: 18.0)
         } else {
             detailInformationLabel.font = UIFont.systemFont(ofSize: 14.0)

--- a/src/Catty/ViewController/Help/HelpWebViewController.swift
+++ b/src/Catty/ViewController/Help/HelpWebViewController.swift
@@ -127,9 +127,9 @@ class HelpWebViewController: UIViewController, WKUIDelegate, WKNavigationDelegat
         super.viewWillLayoutSubviews()
 
         touchHelperView?.frame = CGRect(x: CGFloat(0.0),
-                                        y: view.bounds.height - CGFloat(kToolbarHeight),
+                                        y: view.bounds.height - UIDefines.toolbarHeight,
                                         width: view.bounds.width,
-                                        height: CGFloat(kToolbarHeight))
+                                        height: UIDefines.toolbarHeight)
     }
 
     // MARK: - WebViewDelegate

--- a/src/Catty/ViewController/MediaLibrary/ContentViews/LibraryCategoryCollectionReusableView.swift
+++ b/src/Catty/ViewController/MediaLibrary/ContentViews/LibraryCategoryCollectionReusableView.swift
@@ -29,7 +29,7 @@ class LibraryCategoryCollectionReusableView: UICollectionReusableView {
     override func awakeFromNib() {
         super.awakeFromNib()
         self.borderView.backgroundColor = UIColor.utilityTint
-        self.borderThicknessConstraint.constant = CGFloat(kDefaultImageCellBorderWidth)
+        self.borderThicknessConstraint.constant = UIDefines.defaultImageCellBorderWidth
     }
 
     var title: String {

--- a/src/Catty/ViewController/Stage/StagePresenterViewController.m
+++ b/src/Catty/ViewController/Stage/StagePresenterViewController.m
@@ -253,7 +253,7 @@
     }
     
     [self hideLoadingView];
-    [self continueActionWithDuration:kFirstSwipeDuration];
+    [self continueActionWithDuration:UIDefines.firstSwipeDuration];
 }
 
 -(void)resaveLooks
@@ -304,7 +304,7 @@
 
 - (void)continueActionWithDuration:(CGFloat)duration
 {
-    if (duration != kFirstSwipeDuration) {
+    if (duration != UIDefines.firstSwipeDuration) {
         [self resumeAction];
     }
     
@@ -312,7 +312,7 @@
     animateDuration = (duration > 0.0001f && duration < 1.0f)? duration : 0.35f;
 
     [UIView animateWithDuration:animateDuration
-                          delay:kHideMenuViewDelay
+                          delay:UIDefines.hideMenuViewDelay
                         options: UIViewAnimationOptionTransitionFlipFromRight
                      animations:^{[self hideMenuView];}
                      completion:^(BOOL finished){
@@ -426,7 +426,7 @@
     }
     
     if (gesture.state == UIGestureRecognizerStateChanged) {
-        if (translate.x > 0.0 && translate.x < self.menuView.frame.size.width && self.firstGestureTouchPoint.x < kSlidingStartArea && self.menuOpen == NO ) {
+        if (translate.x > 0.0 && translate.x < self.menuView.frame.size.width && self.firstGestureTouchPoint.x < UIDefines.slidingStartArea && self.menuOpen == NO ) {
             [UIView animateWithDuration:0.25
                                   delay:0.0
                                 options:UIViewAnimationOptionCurveEaseOut
@@ -451,7 +451,7 @@
     if (gesture.state == UIGestureRecognizerStateCancelled ||
         gesture.state == UIGestureRecognizerStateEnded ||
         gesture.state == UIGestureRecognizerStateFailed) {
-        if (translate.x > (self.menuView.frame.size.width/4) && self.menuOpen == NO && self.firstGestureTouchPoint.x < kSlidingStartArea) {
+        if (translate.x > (self.menuView.frame.size.width/4) && self.menuOpen == NO && self.firstGestureTouchPoint.x < UIDefines.slidingStartArea) {
             [UIView animateWithDuration:0.25
                                   delay:0.0
                                 options:UIViewAnimationOptionCurveEaseOut
@@ -463,7 +463,7 @@
                                  view.paused=YES;
                                  [self pauseAction];
                              }];
-        } else if(translate.x > 0.0 && translate.x <(self.menuView.frame.size.width/4) && self.menuOpen == NO && self.firstGestureTouchPoint.x < kSlidingStartArea) {
+        } else if(translate.x > 0.0 && translate.x <(self.menuView.frame.size.width/4) && self.menuOpen == NO && self.firstGestureTouchPoint.x < UIDefines.slidingStartArea) {
             [UIView animateWithDuration:0.25
                                   delay:0.0
                                 options:UIViewAnimationOptionCurveEaseOut

--- a/src/Catty/Views/Custom/AlertController/TextFieldAlertController.swift
+++ b/src/Catty/Views/Custom/AlertController/TextFieldAlertController.swift
@@ -131,7 +131,7 @@ final class TextFieldAlertController: BaseAlertController, TextFieldAlertDefinin
 
     func defaultCharacterValidator() -> TextFieldInputValidating {
         characterValidator = { (input: String) -> Bool in
-            guard let _ = input.rangeOfCharacter(from: CharacterSet.init(charactersIn: kTextFieldBlockedCharacters)) else {
+            guard let _ = input.rangeOfCharacter(from: CharacterSet.init(charactersIn: UIDefines.textFieldBlockedCharacters)) else {
                 return true
             }
             return false

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellFormulaData.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellFormulaData.m
@@ -48,7 +48,7 @@
         _parameterNumber = parameter;
         
         self.titleLabel.textColor = UIColor.whiteColor;
-        self.titleLabel.font = [UIFont systemFontOfSize:kBrickTextFieldFontSize];
+        self.titleLabel.font = [UIFont systemFontOfSize:UIDefines.brickTextFieldFontSize];
         self.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
         [self setTitle:[formula getDisplayString] forState:UIControlStateNormal];
         

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellTextData.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCellData/BrickCellTextData.m
@@ -48,7 +48,7 @@
         self.text = [textBrick textForLineNumber:line andParameterNumber:parameter];
         
         self.borderStyle = UITextBorderStyleNone;
-        self.font = [UIFont systemFontOfSize:kBrickTextFieldFontSize];
+        self.font = [UIFont systemFontOfSize:UIDefines.brickTextFieldFontSize];
         self.autocorrectionType = UITextAutocorrectionTypeNo;
         self.keyboardType = UIKeyboardTypeDefault;
         self.returnKeyType = UIReturnKeyDone;

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Arduino/ArduinoSendDigitalValueBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Arduino/ArduinoSendDigitalValueBrickCell.m
@@ -32,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Arduino/ArduinoSendPWMValueBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Arduino/ArduinoSendPWMValueBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ArduinoSendPWMValueBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ArduinoSendPWMValueBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/BrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/BrickCell.m
@@ -73,7 +73,7 @@
 {
     [super layoutSubviews];
     self.contentView.frame = CGRectIntegral(self.bounds);
-    self.selectButton.center = CGPointMake(self.bounds.origin.x - kSelectButtonOffset,
+    self.selectButton.center = CGPointMake(self.bounds.origin.x - UIDefines.selectButtonOffset,
                                            CGRectGetMidY(self.bounds));
 }
 
@@ -99,7 +99,7 @@
     [self renderSubViews];
     if (self.editing) {
         if (self.frame.origin.x == 0.0f) {
-            self.center = CGPointMake(self.center.x + kSelectButtonTranslationOffsetX, self.center.y);
+            self.center = CGPointMake(self.center.x + UIDefines.selectButtonTranslationOffsetX, self.center.y);
             self.selectButton.alpha = 1.0f;
         }
     } else {
@@ -148,7 +148,7 @@
 {
     if (!_selectButton) {
         _selectButton = [[SelectButton alloc] initWithFrame:CGRectMake(0.0f, 0.0f,
-                        kBrickCellDeleteButtonWidthHeight, kBrickCellDeleteButtonWidthHeight)];
+                        UIDefines.brickCellDeleteButtonWidthHeight, UIDefines.brickCellDeleteButtonWidthHeight)];
         _selectButton.alpha = 0.0f;
         [self addSubview:_selectButton];
         [_selectButton addTarget:self action:@selector(selectButtonSelected:) forControlEvents:UIControlEventTouchUpInside];
@@ -179,18 +179,18 @@
     kBrickShapeType brickShapeType = [self brickShapeType];
     CGFloat inlineViewOffsetY = 0.0f;
     if (brickShapeType != kBrickShapeRoundedSmall && brickShapeType != kBrickShapeRoundedBig) {
-        inlineViewHeight -= kBrickShapeNormalMarginHeightDeduction;
-        inlineViewOffsetY = kBrickShapeNormalInlineViewOffsetY;
+        inlineViewHeight -= UIDefines.brickShapeNormalMarginHeightDeduction;
+        inlineViewOffsetY = UIDefines.brickShapeNormalInlineViewOffsetY;
     } else if (brickShapeType == kBrickShapeRoundedSmall) {
-        inlineViewHeight -= kBrickShapeRoundedSmallMarginHeightDeduction;
-        inlineViewOffsetY = kBrickShapeRoundedSmallInlineViewOffsetY;
+        inlineViewHeight -= UIDefines.brickShapeRoundedSmallMarginHeightDeduction;
+        inlineViewOffsetY = UIDefines.brickShapeRoundedSmallInlineViewOffsetY;
     } else if (brickShapeType == kBrickShapeRoundedBig) {
-        inlineViewHeight -= kBrickShapeRoundedBigMarginHeightDeduction;
-        inlineViewOffsetY = kBrickShapeRoundedBigInlineViewOffsetY;
+        inlineViewHeight -= UIDefines.brickShapeRoundedBigMarginHeightDeduction;
+        inlineViewOffsetY = UIDefines.brickShapeRoundedBigInlineViewOffsetY;
     } else {
         NSError(@"unknown brick shape type given");
     }
-    CGRect frame = CGRectMake(kBrickInlineViewOffsetX, inlineViewOffsetY, (self.frame.size.width - kBrickInlineViewOffsetX), inlineViewHeight);
+    CGRect frame = CGRectMake(UIDefines.brickInlineViewOffsetX, inlineViewOffsetY, (self.frame.size.width - UIDefines.brickInlineViewOffsetX), inlineViewHeight);
     self.inlineView.frame = frame;
     self.inlineView.backgroundColor = UIColor.clearColor;
 
@@ -232,7 +232,7 @@
 #pragma mark - helpers
 - (NSArray*)inlineViewSubviews
 {
-    CGRect canvasFrame = CGRectMake(kBrickInlineViewCanvasOffsetX, kBrickInlineViewCanvasOffsetY, self.inlineView.frame.size.width, self.inlineView.frame.size.height);
+    CGRect canvasFrame = CGRectMake(UIDefines.brickInlineViewCanvasOffsetX, UIDefines.brickInlineViewCanvasOffsetY, self.inlineView.frame.size.width, self.inlineView.frame.size.height);
 
     NSString *brickTitle = self.brickTitle;
     NSArray *brickParams = self.parameters;
@@ -273,7 +273,7 @@
         // determine height per line and generate subviews of all lines
         CGFloat totalHeight = canvasFrame.size.height;
         CGFloat averageHeight = totalHeight / (CGFloat)numberOfLines;
-        CGFloat heightForLineWithParams = ((averageHeight > kBrickInputFieldMinRowHeight) ? averageHeight : kBrickInputFieldMinRowHeight);
+        CGFloat heightForLineWithParams = ((averageHeight > UIDefines.brickInputFieldMinRowHeight) ? averageHeight : UIDefines.brickInputFieldMinRowHeight);
         CGFloat remainingTotalHeight = (totalHeight - (heightForLineWithParams * numberOfLinesWithParams));
         CGFloat heightForLineWithNoParams = (remainingTotalHeight / (numberOfLines - numberOfLinesWithParams));
         NSMutableArray *allLinesSubviews = [NSMutableArray array];
@@ -320,7 +320,7 @@
     
     UILabel* textLabel = [UIUtil newDefaultBrickLabelWithFrame:frame AndText:labelTitle andRemainingSpace:frame.size.width];
     
-    self.maxInputFormulaFrameLength = (frame.size.width - ((NSInteger)textLabel.frame.size.width + kBrickInputFieldLeftMargin * [partLabels count]) - kBrickTextFieldFontSize) / formulaCounter;
+    self.maxInputFormulaFrameLength = (frame.size.width - ((NSInteger)textLabel.frame.size.width + UIDefines.brickInputFieldLeftMargin * [partLabels count]) - UIDefines.brickTextFieldFontSize) / formulaCounter;
 }
 
 - (NSMutableArray*)inlineViewSubviewsOfLabel:(NSString*)labelTitle WithParams:(NSArray*)params WithFrame:(CGRect)frame ForLineNumber:(NSInteger)lineNumber
@@ -345,8 +345,8 @@
     for (NSString *partLabelTitle in partLabels) {
         if (partLabelTitle.length) {
             UILabel *textLabel = [UIUtil newDefaultBrickLabelWithFrame:remainingFrame AndText:partLabelTitle andRemainingSpace:remainingFrame.size.width];
-            remainingFrame.origin.x += (textLabel.frame.size.width + kBrickInputFieldLeftMargin);
-            remainingFrame.size.width -= (textLabel.frame.size.width + kBrickInputFieldLeftMargin);
+            remainingFrame.origin.x += (textLabel.frame.size.width + UIDefines.brickInputFieldLeftMargin);
+            remainingFrame.size.width -= (textLabel.frame.size.width + UIDefines.brickInputFieldLeftMargin);
             [subviews addObject:textLabel];
         }
 
@@ -357,61 +357,61 @@
             // NOTE: * This is only code used for testing purposes. TO BE REFACTORED...
             //       * Pickers, Pluralization, Hook Ups only for inputFields ...
             CGRect inputViewFrame = remainingFrame;
-//            inputViewFrame.origin.y += kBrickInputFieldTopMargin;
-//            inputViewFrame.size.height -= (kBrickInputFieldTopMargin + kBrickInputFieldBottomMargin);
-            inputViewFrame.origin.y += (inputViewFrame.size.height - kBrickInputFieldHeight)/2 - 0.5;
-            inputViewFrame.size.height = kBrickInputFieldHeight;
-            inputViewFrame.size.width = kBrickInputFieldMinWidth;
+//            inputViewFrame.origin.y += UIDefines.brickInputFieldTopMargin;
+//            inputViewFrame.size.height -= (UIDefines.brickInputFieldTopMargin + UIDefines.brickInputFieldBottomMargin);
+            inputViewFrame.origin.y += (inputViewFrame.size.height - UIDefines.brickInputFieldHeight)/2 - 0.5;
+            inputViewFrame.size.height = UIDefines.brickInputFieldHeight;
+            inputViewFrame.size.width = UIDefines.brickInputFieldMinWidth;
             NSString *afterLabelParam = [params objectAtIndex:counter];
             UIView *inputField = nil;
             if ([afterLabelParam rangeOfString:@"FLOAT"].location != NSNotFound || [afterLabelParam rangeOfString:@"INT"].location != NSNotFound) {
                 inputField = [[BrickCellFormulaData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"TEXT"].location != NSNotFound) {
-                inputViewFrame.size.height = kBrickInputFieldHeight;
+                inputViewFrame.size.height = UIDefines.brickInputFieldHeight;
                 inputField = [[BrickCellTextData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"MESSAGE"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellMessageData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"OBJECT"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellObjectData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"SOUND"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellSoundData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"LOOK"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellLookData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"BACKGROUND"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellBackgroundData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"VARIABLE"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellVariableData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"LIST"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellListData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"STATICCHOICE"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellStaticChoiceData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"MOTOR"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellPhiroMotorData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"LIGHT"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellPhiroLightData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"TONE"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellPhiroToneData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             } else if ([afterLabelParam rangeOfString:@"PHIROIF"].location != NSNotFound) {
-                inputViewFrame.size.width = kBrickComboBoxWidth;
+                inputViewFrame.size.width = UIDefines.brickComboBoxWidth;
                 inputField = [[BrickCellPhiroIfSensorData alloc] initWithFrame:inputViewFrame andBrickCell:self andLineNumber:lineNumber andParameterNumber:counter];
             }else {
                 NSError(@"unknown data type %@ given", afterLabelParam);
                 abort();
             }
 
-            remainingFrame.origin.x += (inputField.frame.size.width + kBrickInputFieldRightMargin);
-            remainingFrame.size.width -= (inputField.frame.size.width + kBrickInputFieldRightMargin);
+            remainingFrame.origin.x += (inputField.frame.size.width + UIDefines.brickInputFieldRightMargin);
+            remainingFrame.size.width -= (inputField.frame.size.width + UIDefines.brickInputFieldRightMargin);
             [subviews addObject:inputField];
         }
         counter++;

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/BroadcastBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/BroadcastBrickCell.m
@@ -31,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/BroadcastWaitBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/BroadcastWaitBrickCell.m
@@ -31,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/ForeverBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/ForeverBrickCell.m
@@ -31,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/IfLogicBeginBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/IfLogicBeginBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "IfLogicBeginBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface IfLogicBeginBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/IfLogicElseBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/IfLogicElseBrickCell.m
@@ -31,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/IfLogicEndBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/IfLogicEndBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "IfLogicEndBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface IfLogicEndBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/IfThenLogicBeginBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/IfThenLogicBeginBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "IfThenLogicBeginBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface IfThenLogicBeginBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/IfThenLogicEndBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/IfThenLogicEndBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "IfThenLogicEndBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface IfThenLogicEndBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/LoopEndBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/LoopEndBrickCell.m
@@ -33,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)drawRect:(CGRect)rect

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/NoteBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/NoteBrickCell.m
@@ -31,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/RepeatBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/RepeatBrickCell.m
@@ -22,6 +22,7 @@
 
 #import "RepeatBrickCell.h"
 #import "RepeatBrick.h"
+#import "Pocket_Code-Swift.h"
 
 @interface RepeatBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/RepeatUntilBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/RepeatUntilBrickCell.m
@@ -32,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/WaitBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/WaitBrickCell.swift
@@ -37,7 +37,7 @@ import Foundation
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/WaitUntilBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Control/WaitUntilBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "WaitUntilBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface WaitUntilBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/AddItemToUserListBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/AddItemToUserListBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "AddItemToUserListBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface AddItemToUserListBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/ChangeVariableBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/ChangeVariableBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ChangeVariableBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ChangeVariableBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/DeleteItemOfUserListBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/DeleteItemOfUserListBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "DeleteItemOfUserListBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface DeleteItemOfUserListBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/HideTextBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/HideTextBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "HideTextBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface HideTextBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/InsertItemIntoUserListBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/InsertItemIntoUserListBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "InsertItemIntoUserListBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface InsertItemIntoUserListBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel1;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/ReplaceItemInUserListBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/ReplaceItemInUserListBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ReplaceItemInUserListBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ReplaceItemInUserListBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/SetVariableBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/SetVariableBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "SetVariableBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SetVariableBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/ShowTextBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/ShowTextBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ShowTextBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ShowTextBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/WebRequestBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Data/WebRequestBrickCell.swift
@@ -28,7 +28,7 @@ class WebRequestBrickCell: BrickCell, BrickCellProtocol {
     var variableComboBox: iOSCombobox?
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight3h)
+        UIDefines.brickHeight3h
     }
 
     func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Embroidery/StitchBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Embroidery/StitchBrickCell.swift
@@ -33,7 +33,7 @@ class StitchBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/IO/FlashBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/IO/FlashBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "FlashBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface FlashBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/IO/VibrationBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/IO/VibrationBrickCell.m
@@ -22,6 +22,7 @@
 
 #import "VibrationBrickCell.h"
 #import "VibrationBrick.h"
+#import "Pocket_Code-Swift.h"
 
 @interface VibrationBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/AskBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/AskBrickCell.swift
@@ -36,7 +36,7 @@ class AskBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight3h)
+        UIDefines.brickHeight3h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/CameraBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/CameraBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "CameraBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface CameraBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ChangeBrightnessByNBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ChangeBrightnessByNBrickCell.swift
@@ -34,7 +34,7 @@ class ChangeBrightnessByNBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight2h)
+        UIDefines.brickHeight2h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ChangeColorByNBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ChangeColorByNBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ChangeColorByNBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ChangeColorByNBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ChangeTransparencyByNBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ChangeTransparencyByNBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ChangeTransparencyByNBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ChangeTransparencyByNBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ChooseCameraBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ChooseCameraBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ChooseCameraBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ChooseCameraBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ClearGraphicEffectBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ClearGraphicEffectBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ClearGraphicEffectBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ClearGraphicEffectBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/HideBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/HideBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "HideBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface HideBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/NextLookBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/NextLookBrickCell.swift
@@ -33,7 +33,7 @@ class NextLookBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/PreviousLookBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/PreviousLookBrickCell.swift
@@ -33,7 +33,7 @@ class PreviousLookBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SayBubbleBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SayBubbleBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "SayBubbleBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SayBubbleBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SayForBubbleBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SayForBubbleBrickCell.m
@@ -22,6 +22,7 @@
 
 #import "SayForBubbleBrickCell.h"
 #import "SayForBubbleBrick.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SayForBubbleBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -33,7 +34,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetBackgroundAndWaitBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetBackgroundAndWaitBrickCell.swift
@@ -35,7 +35,7 @@ class SetBackgroundAndWaitBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight2h)
+        UIDefines.brickHeight2h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetBackgroundBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetBackgroundBrickCell.swift
@@ -35,7 +35,7 @@ class SetBackgroundBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight2h)
+        UIDefines.brickHeight2h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetBackgroundByIndexBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetBackgroundByIndexBrickCell.swift
@@ -34,7 +34,7 @@ class SetBackgroundByIndexBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetBrightnessBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetBrightnessBrickCell.swift
@@ -34,7 +34,7 @@ class SetBrightnessBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight2h)
+        UIDefines.brickHeight2h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetColorBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetColorBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "SetColorBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SetColorBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetLookBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetLookBrickCell.swift
@@ -35,7 +35,7 @@ class SetLookBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight2h)
+        UIDefines.brickHeight2h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetLookByIndexBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetLookByIndexBrickCell.swift
@@ -34,7 +34,7 @@ class SetLookByIndexBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetSizeToBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetSizeToBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "SetSizeToBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SetSizeToBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetTransparencyBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/SetTransparencyBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "SetTransparencyBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SetTransparencyBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ShowBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ShowBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ShowBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ShowBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ThinkBubbleBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ThinkBubbleBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ThinkBubbleBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ThinkBubbleBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ThinkForBubbleBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Look/ThinkForBubbleBrickCell.m
@@ -22,6 +22,7 @@
 
 #import "ThinkForBubbleBrickCell.h"
 #import "ThinkForBubbleBrick.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ThinkForBubbleBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -33,7 +34,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/ChangeSizeByNBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/ChangeSizeByNBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ChangeSizeByNBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ChangeSizeByNBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/ChangeXByNBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/ChangeXByNBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ChangeXByNBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ChangeXByNBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/ChangeYByNBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/ChangeYByNBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ChangeYByNBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ChangeYByNBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/ComeToFrontBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/ComeToFrontBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ComeToFrontBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ComeToFrontBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/GlideToBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/GlideToBrickCell.m
@@ -22,6 +22,7 @@
 
 #import "GlideToBrick.h"
 #import "GlideToBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface GlideToBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowLeftLabel;
@@ -34,7 +35,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/GoNStepsBackBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/GoNStepsBackBrickCell.m
@@ -22,6 +22,7 @@
 
 #import "GoNStepsBackBrickCell.h"
 #import "GoNStepsBackBrick.h"
+#import "Pocket_Code-Swift.h"
 
 @interface GoNStepsBackBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/GoToBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/GoToBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "GoToBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface GoToBrickCell()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/IfOnEdgeBounceBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/IfOnEdgeBounceBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "IfOnEdgeBounceBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface IfOnEdgeBounceBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/MoveNStepsBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/MoveNStepsBrickCell.m
@@ -22,6 +22,7 @@
 
 #import "MoveNStepsBrickCell.h"
 #import "MoveNStepsBrick.h"
+#import "Pocket_Code-Swift.h"
 
 @interface MoveNStepsBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/PlaceAtBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/PlaceAtBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "PlaceAtBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface PlaceAtBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/PointInDirectionBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/PointInDirectionBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "PointInDirectionBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface PointInDirectionBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/PointToBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/PointToBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "PointToBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface PointToBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/SetRotationStyleBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/SetRotationStyleBrickCell.swift
@@ -26,7 +26,7 @@
     var comboBox: iOSCombobox?
 
      static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight2h)
+        UIDefines.brickHeight2h
     }
 
      func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/SetXBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/SetXBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "SetXBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SetXBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/SetYBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/SetYBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "SetYBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SetYBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/TurnLeftBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/TurnLeftBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "TurnLeftBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface TurnLeftBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/TurnRightBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Motion/TurnRightBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "TurnRightBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface TurnRightBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/PenClearBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/PenClearBrickCell.swift
@@ -25,7 +25,7 @@ class PenClearBrickCell: BrickCell, BrickCellProtocol {
     var textLabel: UILabel?
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/PenDownBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/PenDownBrickCell.swift
@@ -25,7 +25,7 @@ class PenDownBrickCell: BrickCell, BrickCellProtocol {
     var textLabel: UILabel?
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/PenUpBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/PenUpBrickCell.swift
@@ -25,7 +25,7 @@ class PenUpBrickCell: BrickCell, BrickCellProtocol {
     var textLabel: UILabel?
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/SetPenColorBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/SetPenColorBrickCell.swift
@@ -31,7 +31,7 @@ class SetPenColorBrickCell: BrickCell, BrickCellProtocol {
     var blueTextField: UITextField?
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight2h)
+        UIDefines.brickHeight2h
     }
 
     func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/SetPenSizeBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/SetPenSizeBrickCell.swift
@@ -26,7 +26,7 @@ class SetPenSizeBrickCell: BrickCell, BrickCellProtocol {
     var textField: UITextField?
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/StampBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Pen/StampBrickCell.swift
@@ -25,7 +25,7 @@ class StampBrickCell: BrickCell, BrickCellProtocol {
     var textLabel: UILabel?
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroIfLogicBeginBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroIfLogicBeginBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "PhiroIfLogicBeginBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface PhiroIfLogicBeginBrickCell ()
 @property (nonatomic, strong) UILabel *leftTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroMotorMoveBackwardBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroMotorMoveBackwardBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "PhiroMotorMoveBackwardBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface PhiroMotorMoveBackwardBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroMotorMoveForwardBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroMotorMoveForwardBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "PhiroMotorMoveForwardBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface PhiroMotorMoveForwardBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroMotorStopBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroMotorStopBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "PhiroMotorStopBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface PhiroMotorStopBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroPlayToneBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroPlayToneBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "PhiroPlayToneBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface PhiroPlayToneBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -32,7 +33,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroRGBLightBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Phiro/PhiroRGBLightBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "PhiroRGBLightBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface PhiroRGBLightBrickCell ()
 @property (nonatomic, strong) UILabel *firstRowTextLabel;
@@ -33,7 +34,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight3h;
+    return UIDefines.brickHeight3h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/ChangeVolumeByNBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/ChangeVolumeByNBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "ChangeVolumeByNBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface ChangeVolumeByNBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/PlaySoundAndWaitBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/PlaySoundAndWaitBrickCell.swift
@@ -36,7 +36,7 @@ import Foundation
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight2h)
+        UIDefines.brickHeight2h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/PlaySoundBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/PlaySoundBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "PlaySoundBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface PlaySoundBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/SetInstrumentBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/SetInstrumentBrickCell.swift
@@ -40,7 +40,7 @@ import Foundation
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight2h)
+        UIDefines.brickHeight2h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/SetTempoToBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/SetTempoToBrickCell.swift
@@ -34,7 +34,7 @@ class SetTempoToBrickCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeight1h)
+        UIDefines.brickHeight1h
     }
 
     override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/SetVolumeToBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/SetVolumeToBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "SetVolumeToBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SetVolumeToBrickCell ()
 @property (nonatomic, strong) UILabel *rightTextLabel;
@@ -31,7 +32,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/SpeakAndWaitBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/SpeakAndWaitBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "SpeakAndWaitBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SpeakAndWaitBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/SpeakBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/SpeakBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "SpeakBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface SpeakBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight2h;
+    return UIDefines.brickHeight2h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/StopAllSoundsBrickCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Sound/StopAllSoundsBrickCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "StopAllSoundsBrickCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface StopAllSoundsBrickCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -30,7 +31,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeight1h;
+    return UIDefines.brickHeight1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickShape/BrickShapeFactory.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickShape/BrickShapeFactory.m
@@ -20,6 +20,7 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 #import "BrickShapeFactory.h"
+#import "Pocket_Code-Swift.h"
 
 #define kMarginBetweenLines 4.8
 #define kLineWidth 1
@@ -301,11 +302,11 @@
     CGFloat height = CGRectGetHeight(*frame);
     
     if (shapeType == kBrickShapeSquareSmall) {
-        offsetTop = kBrickShapeNormalInlineViewOffsetY;
+        offsetTop = UIDefines.brickShapeNormalInlineViewOffsetY;
     } else if (shapeType == kBrickShapeRoundedSmall) {
-        offsetTop = kBrickShapeRoundedSmallInlineViewOffsetY;
+        offsetTop = UIDefines.brickShapeRoundedSmallInlineViewOffsetY;
     } else if (shapeType == kBrickShapeRoundedBig) {
-        offsetTop = kBrickShapeRoundedBigInlineViewOffsetY;
+        offsetTop = UIDefines.brickShapeRoundedBigInlineViewOffsetY;
     }
     
     CGFloat yPositionFirstLine = CGRectGetMinY(*frame) + offsetTop + (height - offsetTop) / 2.0f - kMarginBetweenLines - kLineWidth;

--- a/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/BroadcastScriptCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/BroadcastScriptCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "BroadcastScriptCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface BroadcastScriptCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -35,7 +36,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeightControl2h;
+    return UIDefines.brickHeightControl2h;
 }
 
 - (void)hookUpSubViews:(NSArray*)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/StartScriptCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/StartScriptCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "StartScriptCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface StartScriptCell ()
 @property (strong, nonatomic) UILabel *textLabel;
@@ -35,7 +36,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeightControl1h;
+    return UIDefines.brickHeightControl1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/WhenBackgroundChangesScriptCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/WhenBackgroundChangesScriptCell.swift
@@ -37,7 +37,7 @@ class WhenBackgroundChangesScriptCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeightControl2h)
+        UIDefines.brickHeightControl2h
     }
 
     override func brickShapeType() -> kBrickShapeType {

--- a/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/WhenConditionScriptCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/WhenConditionScriptCell.swift
@@ -38,7 +38,7 @@ class WhenConditionScriptCell: BrickCell, BrickCellProtocol {
     }
 
     static func cellHeight() -> CGFloat {
-        CGFloat(kBrickHeightControl1h)
+        UIDefines.brickHeightControl1h
     }
 
     override func brickShapeType() -> kBrickShapeType {

--- a/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/WhenScriptCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/WhenScriptCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "WhenScriptCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface WhenScriptCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -35,7 +36,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeightControl1h;
+    return UIDefines.brickHeightControl1h;
 }
 
 - (NSString*)brickTitleForBackground:(BOOL)isBackground andInsertionScreen:(BOOL)isInsertion

--- a/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/WhenTouchDownScriptCell.m
+++ b/src/Catty/Views/Custom/CollectionViewCells/ScriptCells/WhenTouchDownScriptCell.m
@@ -21,6 +21,7 @@
  */
 
 #import "WhenTouchDownScriptCell.h"
+#import "Pocket_Code-Swift.h"
 
 @interface WhenTouchDownScriptCell ()
 @property (nonatomic, strong) UILabel *textLabel;
@@ -35,7 +36,7 @@
 
 + (CGFloat)cellHeight
 {
-    return kBrickHeightControl1h;
+    return UIDefines.brickHeightControl1h;
 }
 
 - (void)hookUpSubViews:(NSArray *)inlineViewSubViews

--- a/src/Catty/XML/XMLHandler/Scripts/Script+CBXMLHandler.m
+++ b/src/Catty/XML/XMLHandler/Scripts/Script+CBXMLHandler.m
@@ -59,7 +59,7 @@
         NSArray *actionElements = [xmlElement elementsForName:@"action"];
         [XMLError exceptionIf:[actionElements count] notEquals:1 message:@"Wrong number of action elements given!"];
         GDataXMLElement *actionElement = [actionElements firstObject];
-        [XMLError exceptionIf:[kWhenScriptDefaultAction isEqualToString:[actionElement stringValue]] equals:NO
+        [XMLError exceptionIf:[UIDefines.whenScriptDefaultAction isEqualToString:[actionElement stringValue]] equals:NO
                       message:@"Invalid action %@ for WhenScript given", [actionElement stringValue]];
         whenScript.action = [actionElement stringValue];
         script = whenScript;
@@ -277,7 +277,7 @@
     } else if ([self isKindOfClass:[WhenScript class]]) {
         WhenScript *whenScript = (WhenScript*)self;
         [XMLError exceptionIfNil:whenScript.action message:@"WhenScript contains invalid action string"];
-        [XMLError exceptionIf:[kWhenScriptDefaultAction isEqualToString:whenScript.action] equals:NO
+        [XMLError exceptionIf:[UIDefines.whenScriptDefaultAction isEqualToString:whenScript.action] equals:NO
                       message:@"WhenScript contains invalid action string %@", whenScript.action];
         GDataXMLElement *actionXmlElement = [GDataXMLElement elementWithName:@"action" stringValue:whenScript.action context:context];
         [xmlElement addChild:actionXmlElement context:context];

--- a/src/CattyTests/PlayerEngine/CBBackendTests.swift
+++ b/src/CattyTests/PlayerEngine/CBBackendTests.swift
@@ -343,7 +343,7 @@ final class CBBackendTests: XCTestCase {
         let project = ProjectManager.createProject(name: "ProjectName", projectId: "123")
 
         let whenScript = WhenScript()
-        whenScript.action = kWhenScriptDefaultAction
+        whenScript.action = UIDefines.whenScriptDefaultAction
         spriteObject.scene.project = project
         whenScript.object = spriteObject
 

--- a/src/CattyTests/PlayerEngine/Frontend/CBFrontendTests.swift
+++ b/src/CattyTests/PlayerEngine/Frontend/CBFrontendTests.swift
@@ -31,7 +31,7 @@ final class CBFrontendTests: XCTestCase {
     func testComputeOperationSequence() {
         let frontend = CBFrontend(logger: self.logger, project: nil)
         let whenScript = WhenScript()
-        whenScript.action = kWhenScriptDefaultAction
+        whenScript.action = UIDefines.whenScriptDefaultAction
         let waitBrick = WaitBrick()
         waitBrick.timeToWaitInSeconds = Formula(integer: 2)
         let noteBrick = NoteBrick()
@@ -81,7 +81,7 @@ final class CBFrontendTests: XCTestCase {
    func testComputeIfElseConditionalSequence() {
         let frontend = CBFrontend(logger: self.logger, project: nil)
         let whenScript = WhenScript()
-        whenScript.action = kWhenScriptDefaultAction
+    whenScript.action = UIDefines.whenScriptDefaultAction
         let waitBrick = WaitBrick()
         waitBrick.timeToWaitInSeconds = Formula(integer: 2)
         let noteBrick = NoteBrick()
@@ -197,7 +197,7 @@ final class CBFrontendTests: XCTestCase {
     func testComputeIfThenConditionalSequence() {
         let frontend = CBFrontend(logger: self.logger, project: nil)
         let whenScript = WhenScript()
-        whenScript.action = kWhenScriptDefaultAction
+        whenScript.action = UIDefines.whenScriptDefaultAction
         let waitBrick = WaitBrick()
         waitBrick.timeToWaitInSeconds = Formula(integer: 2)
         let noteBrick = NoteBrick()

--- a/src/CattyTests/Utils/UtilTests.swift
+++ b/src/CattyTests/Utils/UtilTests.swift
@@ -73,7 +73,7 @@ final class UtilTests: XCTestCase {
     private func mainScreenSizeInPixel() -> CGSize {
         var screenSizeInPixel = UIScreen.main.nativeBounds.size
 
-        if UIScreen.main.bounds.height == CGFloat(kIphone6PScreenHeight) {
+        if UIScreen.main.bounds.height == UIDefines.iPhone6PScreenHeight {
             let iPhonePlusDownsamplingFactor = CGFloat(1.15)
             screenSizeInPixel.height /= iPhonePlusDownsamplingFactor
             screenSizeInPixel.width /= iPhonePlusDownsamplingFactor


### PR DESCRIPTION
Remove all unused properties from UIDefines.h and convert/transfer as many as possible to UIDefines.swift.
 
kGoToTouchPosition, kGoToRandomPosition, kGoToOtherSpritePosition are not directly UI related and can be moved directly to the GoToBrick (or its instruction).

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
