### PR TITLE
CATTY-611 CollisionFunction in FormulaEditor leads to crash

### DIFF
--- a/src/Catty/PlayerEngine/Formula/FormulaManager+Editor.swift
+++ b/src/Catty/PlayerEngine/Formula/FormulaManager+Editor.swift
@@ -70,12 +70,14 @@ extension FormulaManager {
                                 objects.removeObject(spriteObject)
                             }
 
-                            for i in 0...(objects.count - 1) {
-                                let newItem = FormulaEditorItem.init(function: CollisionFunction.init() as Function)
-                                newItem.title = (kUIFEObjectActorObjectTouch + "(\'" + objects[i].name + "\')")
-                                (newItem.function as! CollisionFunction).addParameter(param: objects[i].name)
+                            if !objects.isEmpty {
+                                for i in 0...(objects.count - 1) {
+                                    let newItem = FormulaEditorItem.init(function: CollisionFunction.init() as Function)
+                                    newItem.title = (kUIFEObjectActorObjectTouch + "(\'" + objects[i].name + "\')")
+                                    (newItem.function as! CollisionFunction).addParameter(param: objects[i].name)
 
-                                items += (position + (i * 10), newItem)
+                                    items += (position + (i * 10), newItem)
+                                }
                             }
                         } else {
                             items += (position, item)

--- a/src/CattyTests/PlayerEngine/Formula/FormulaManagerTests.swift
+++ b/src/CattyTests/PlayerEngine/Formula/FormulaManagerTests.swift
@@ -248,6 +248,22 @@ final class FormulaManagerTests: XCTestCase {
         XCTAssertEqual((kUIFEObjectActorObjectTouch + "(\'" + objectNameA + "\')"), items[1].title)
     }
 
+    func testFormulaEditorNoItemsForProjectWithOnlyBackground() {
+        let collisionFunction = CollisionFunction()
+        let backgroundName = "Background"
+
+        let scene = Scene()
+
+        let backgroundObject = SpriteObjectMock(name: backgroundName, scene: scene)
+        scene.add(object: backgroundObject)
+
+        let manager = FormulaManager(sensorManager: SensorManager(sensors: [], landscapeMode: false),
+                                     functionManager: FunctionManager(functions: [collisionFunction]),
+                                     operatorManager: OperatorManager(operators: []))
+
+        XCTAssertEqual(0, manager.formulaEditorItemsForObjectSection(spriteObject: backgroundObject).count)
+    }
+
     func testFunctionExists() {
         let functionA = ZeroParameterDoubleFunctionMock(tag: "functionTagA",
                                                         value: 1.0,


### PR DESCRIPTION
When the project has only a Background object and when clicking on the properties section the Formula Manager the collision formula removes the background object and has a empty objectlist that leads to crash. Added a check to not iterate over an empty list

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [X] Include the name of the Jira ticket in the PR’s title
- [X] Verify that the Jira ticket is in the status *Ready for Development*
- [X] Include a summary of the changes plus the relevant context
- [X] Choose the proper base branch (*develop*)
- [X] Confirm that the changes follow the project’s coding guidelines
- [X] Verify that the changes generate no compiler or linter warnings
- [X] Perform a self-review of the changes
- [X] Verify to commit no other files than the intentionally changed ones
- [X] Include reasonable and readable tests verifying the added or changed behavior
- [X] Confirm that new and existing unit tests pass locally
- [X] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [X] Stick to the project’s git workflow (rebase and squash your commits)
- [X] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
