### PR TITLE
CATTY-548 Refactor SetLookByIndex- and SetBackgroundByIndexBrick

### DIFF
--- a/src/Catty/DataModel/Bricks/Look/SetBackgroundByIndexBrick.swift
+++ b/src/Catty/DataModel/Bricks/Look/SetBackgroundByIndexBrick.swift
@@ -24,9 +24,10 @@
 
 @objcMembers class SetBackgroundByIndexBrick: Brick, BrickProtocol, BrickFormulaProtocol {
 
-    var backgroundIndex: Formula?
+    var backgroundIndex: Formula
 
     override required init() {
+        self.backgroundIndex = Formula(integer: 1)
         super.init()
     }
 
@@ -39,7 +40,7 @@
     }
 
     override func getRequiredResources() -> Int {
-        backgroundIndex?.getRequiredResources() ?? ResourceType.noResources.rawValue
+        backgroundIndex.getRequiredResources()
     }
 
     override func brickCell() -> BrickCellProtocol.Type! {
@@ -55,7 +56,7 @@
     }
 
     func getFormulas() -> [Formula]! {
-        [backgroundIndex!]
+        [backgroundIndex]
     }
 
     override func setDefaultValuesFor(_ spriteObject: SpriteObject!) {

--- a/src/Catty/DataModel/Bricks/Look/SetLookByIndexBrick.swift
+++ b/src/Catty/DataModel/Bricks/Look/SetLookByIndexBrick.swift
@@ -24,9 +24,10 @@
 
 @objcMembers class SetLookByIndexBrick: Brick, BrickProtocol, BrickFormulaProtocol {
 
-    var lookIndex: Formula?
+    var lookIndex: Formula
 
     override required init() {
+        self.lookIndex = Formula(integer: kBackgroundObjects)
         super.init()
     }
 
@@ -55,7 +56,7 @@
     }
 
     func getFormulas() -> [Formula]! {
-        [lookIndex!]
+        [lookIndex]
     }
 
     override func setDefaultValuesFor(_ spriteObject: SpriteObject!) {

--- a/src/Catty/PlayerEngine/Instructions/Look/SetBackgroundByIndexBrick+Instruction.swift
+++ b/src/Catty/PlayerEngine/Instructions/Look/SetBackgroundByIndexBrick+Instruction.swift
@@ -33,8 +33,7 @@
             let spriteNode = object.spriteNode
             else { fatalError("This should never happen!") }
         return {
-            guard let backgroundIndex = self.backgroundIndex else { return }
-            let index = formulaInterpreter.interpretInteger(backgroundIndex, for: object)
+            let index = formulaInterpreter.interpretInteger(self.backgroundIndex, for: object)
             guard let look = spriteNode.look(for: index) else { return }
             var image = imageCache.cachedImage(forPath: self.path(for: look))
 

--- a/src/Catty/PlayerEngine/Instructions/Look/SetLookByIndexBrick+Instruction.swift
+++ b/src/Catty/PlayerEngine/Instructions/Look/SetLookByIndexBrick+Instruction.swift
@@ -28,12 +28,11 @@ extension SetLookByIndexBrick: CBInstructionProtocol {
 
     func actionBlock(_ formulaInterpreter: FormulaInterpreterProtocol) -> () -> Void {
         guard let object = self.script?.object,
-            let spriteNode = object.spriteNode,
-            let formula = self.lookIndex
+            let spriteNode = object.spriteNode
             else { fatalError("This should never happen!") }
 
         return {
-            let lookIndex = formulaInterpreter.interpretInteger(formula, for: object)
+            let lookIndex = formulaInterpreter.interpretInteger(self.lookIndex, for: object)
             guard let lookAtIndex = spriteNode.look(for: lookIndex) else { return }
 
             let cache = RuntimeImageCache.shared()

--- a/src/Catty/XML/XMLHandler/Bricks/LookBricks/SetBackgroundByIndexBrick+CBXMLHandler.swift
+++ b/src/Catty/XML/XMLHandler/Bricks/LookBricks/SetBackgroundByIndexBrick+CBXMLHandler.swift
@@ -42,7 +42,7 @@ extension SetBackgroundByIndexBrick: CBXMLNodeProtocol {
     func xmlElement(with context: CBXMLSerializerContext) -> GDataXMLElement? {
         let brick = super.xmlElement(for: "SetBackgroundByIndexBrick", with: context)
         let formulaList = GDataXMLElement(name: "formulaList", context: context)
-        let formula = self.backgroundIndex?.xmlElement(with: context)
+        let formula = self.backgroundIndex.xmlElement(with: context)
         formula?.addAttribute(GDataXMLElement(name: "category", stringValue: "BACKGROUND_INDEX", context: nil))
         formulaList?.addChild(formula, context: context)
         brick?.addChild(formulaList, context: context)

--- a/src/Catty/XML/XMLHandler/Bricks/LookBricks/SetLookByIndexBrick+CBXMLHandler.swift
+++ b/src/Catty/XML/XMLHandler/Bricks/LookBricks/SetLookByIndexBrick+CBXMLHandler.swift
@@ -26,14 +26,14 @@ extension SetLookByIndexBrick: CBXMLNodeProtocol {
         CBXMLParserHelper.validate(xmlElement, forNumberOfChildNodes: 1, andFormulaListWithTotalNumberOfFormulas: 1)
         let formula = CBXMLParserHelper.formula(in: xmlElement, forCategoryName: "LOOK_INDEX", with: context)
         let brick = self.init()
-        brick.lookIndex = formula
+        brick.setFormula(formula, forLineNumber: 0, andParameterNumber: 0)
         return brick
     }
 
     func xmlElement(with context: CBXMLSerializerContext) -> GDataXMLElement? {
         let brick = super.xmlElement(for: "SetLookByIndexBrick", with: context)
         let formulaList = GDataXMLElement(name: "formulaList", context: context)
-        let formula = self.lookIndex?.xmlElement(with: context)
+        let formula = self.lookIndex.xmlElement(with: context)
         formula?.addAttribute(GDataXMLElement(name: "category", stringValue: "LOOK_INDEX", context: nil))
         formulaList?.addChild(formula, context: context)
         brick?.addChild(formulaList, context: context)


### PR DESCRIPTION
The formula in those two Bricks is optional, however the Brick can not exist without such a formula. Therefore, refactor the two Bricks so that their formula is non-optional and remove any force-unwrappings.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
