### PR TITLE
CATTY-624 WhenConditionScript not working for first execution

### DIFF
--- a/src/Catty/DataModel/Scripts/WhenConditionScript.swift
+++ b/src/Catty/DataModel/Scripts/WhenConditionScript.swift
@@ -29,7 +29,7 @@ class WhenConditionScript: Script, BrickFormulaProtocol {
 
     init(condition: Formula) {
         self.condition = condition
-        self.preCondition = false
+        self.preCondition = true
         super.init()
     }
 
@@ -39,7 +39,7 @@ class WhenConditionScript: Script, BrickFormulaProtocol {
 
     override public required init() {
         self.condition = Formula(integer: 1)
-        self.preCondition = false
+        self.preCondition = true
         super.init()
     }
 

--- a/src/CattyTests/Scripts/WhenConditionScriptTests.swift
+++ b/src/CattyTests/Scripts/WhenConditionScriptTests.swift
@@ -68,6 +68,17 @@
         XCTAssertTrue(script.checkCondition(formulaInterpreter: formulaInterpreter))
     }
 
+    func testConditionOfWhenConditionScriptFirstExecution() {
+        script.condition = Formula(float: 1)
+        XCTAssertTrue(script.checkCondition(formulaInterpreter: formulaInterpreter))
+
+        script.condition = Formula(float: 0)
+        XCTAssertFalse(script.checkCondition(formulaInterpreter: formulaInterpreter))
+
+        script.condition = Formula(float: 1)
+        XCTAssertTrue(script.checkCondition(formulaInterpreter: formulaInterpreter))
+   }
+
     func testConditionOfWhenConditionScript() {
         let userVariable = UserVariable(name: "userVariable")
         let formulaTree = FormulaElement(elementType: .OPERATOR, value: AndOperator.tag)!


### PR DESCRIPTION
Enables the immediate execution of the WhenConditionScript and provides unit test. For subsequent executions the condition needs to be false in order to run a script again.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
