### PR TITLE
CATTY-606 Disable device rotation

### DIFF
--- a/src/Catty/FormulaEditor/ViewController/FormulaEditorViewController.m
+++ b/src/Catty/FormulaEditor/ViewController/FormulaEditorViewController.m
@@ -194,9 +194,6 @@ NS_ENUM(NSInteger, ButtonIndex) {
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
-    ((AppDelegate*)[UIApplication sharedApplication].delegate).disabledOrientation = true;
-    
     self.edgesForExtendedLayout = UIRectEdgeNone;
     self.view.backgroundColor = UIColor.background;
     
@@ -313,8 +310,6 @@ NS_ENUM(NSInteger, ButtonIndex) {
         [self.formulaEditorTextView removeFromSuperview];
         [self.presentingViewController dismissViewControllerAnimated:YES completion:NULL];
     }
-    
-    ((AppDelegate*)[UIApplication sharedApplication].delegate).disabledOrientation = false;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer

--- a/src/Catty/Supporting Files/AppDelegate.swift
+++ b/src/Catty/Supporting Files/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var audioEngineHelper = AudioEngineHelper()
     var projectManager = ProjectManager.shared
 
-    @objc var disabledOrientation = false
+    @objc var enabledOrientation = false
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         self.setupFirebase()
@@ -156,7 +156,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        self.disabledOrientation ? UIInterfaceOrientationMask.portrait : UIInterfaceOrientationMask.all
+        self.enabledOrientation ? UIInterfaceOrientationMask.all : UIInterfaceOrientationMask.portrait
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [: ]) -> Bool {

--- a/src/Catty/ViewController/BaseViewController/BaseCollectionViewController.m
+++ b/src/Catty/ViewController/BaseViewController/BaseCollectionViewController.m
@@ -125,6 +125,7 @@
 
 - (void)playSceneAction:(id)sender
 {
+    ((AppDelegate*)[UIApplication sharedApplication].delegate).enabledOrientation = true;
     if (!Project.lastUsedProject.header.landscapeMode) {
         [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
         [UINavigationController attemptRotationToDeviceOrientation];

--- a/src/Catty/ViewController/BaseViewController/BaseTableViewController.m
+++ b/src/Catty/ViewController/BaseViewController/BaseTableViewController.m
@@ -400,6 +400,7 @@
 
 - (void)playSceneAction:(id)sender
 {
+    ((AppDelegate*)[UIApplication sharedApplication].delegate).enabledOrientation = true;
     if (!Project.lastUsedProject.header.landscapeMode) {
         [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
         [UINavigationController attemptRotationToDeviceOrientation];

--- a/src/Catty/ViewController/Stage/StagePresenterViewController.m
+++ b/src/Catty/ViewController/Stage/StagePresenterViewController.m
@@ -114,7 +114,6 @@
     } else {
         self.menuViewRightConstraint = [self.menuView.rightAnchor constraintEqualToAnchor:self.view.leftAnchor constant:self.view.frame.size.width / StagePresenterSideMenuView.widthProportionalPortrait];
     }
-    
     self.menuViewRightConstraint.active = YES;
     self.menuViewLeadingConstraint = [self.menuView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor];
     self.menuViewLeadingConstraint.active = YES;
@@ -130,6 +129,14 @@
 {
     [super viewDidAppear:animated];
     [[NSNotificationCenter defaultCenter] postNotificationName:NotificationName.stagePresenterViewControllerDidAppear object:self];
+    ((AppDelegate*)[UIApplication sharedApplication].delegate).enabledOrientation = true;
+     if (!Project.lastUsedProject.header.landscapeMode) {
+         [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
+         [UINavigationController attemptRotationToDeviceOrientation];
+     } else {
+         [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationLandscapeRight) forKey:@"orientation"];
+         [UINavigationController attemptRotationToDeviceOrientation];
+     }
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -237,7 +244,6 @@
 {
     // Initialize scene
     Stage *stage = [[[[StageBuilder alloc] initWithProject:self.project] andFormulaManager:self.formulaManager] build];
-    
     if ([self.project.header.screenMode isEqualToString: kCatrobatHeaderScreenModeMaximize]) {
         stage.scaleMode = SKSceneScaleModeFill;
     } else if ([self.project.header.screenMode isEqualToString: kCatrobatHeaderScreenModeStretch]){
@@ -341,6 +347,9 @@
     });
     
     [self.navigationController popViewControllerAnimated:YES];
+    ((AppDelegate*)[UIApplication sharedApplication].delegate).enabledOrientation = false;
+    [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
+    [UINavigationController attemptRotationToDeviceOrientation];
 }
 
 - (void)restartAction

--- a/src/CattyTests/AppDelegateTests.swift
+++ b/src/CattyTests/AppDelegateTests.swift
@@ -97,14 +97,14 @@ final class AppDelegateTests: XCTestCase {
         expect(self.scenePresenterViewController.methodCalls).toNot(contain("resumeAction"))
     }
 
-    func testDisabledOrientation() {
-        XCTAssertEqual(appDelegate.application(UIApplication.shared, supportedInterfaceOrientationsFor: appDelegate.window), UIInterfaceOrientationMask.all)
-
-        appDelegate.disabledOrientation = true
+    func testEnabledOrientation() {
         XCTAssertEqual(appDelegate.application(UIApplication.shared, supportedInterfaceOrientationsFor: appDelegate.window), UIInterfaceOrientationMask.portrait)
 
-        appDelegate.disabledOrientation = false
+        appDelegate.enabledOrientation = true
         XCTAssertEqual(appDelegate.application(UIApplication.shared, supportedInterfaceOrientationsFor: appDelegate.window), UIInterfaceOrientationMask.all)
+
+        appDelegate.enabledOrientation = false
+        XCTAssertEqual(appDelegate.application(UIApplication.shared, supportedInterfaceOrientationsFor: appDelegate.window), UIInterfaceOrientationMask.portrait)
 
     }
 


### PR DESCRIPTION
Catty and the IDE is not usable in the landscape orientation. When using Catrobat landscape projects, the user has the manually change orientation again which leads to disturbing ui animations.
Therefore the app should only be available in the portrait mode. Only exception: when Catrobat projects are started in landscape mode, like for example in this project: https://share.catrob.at/app/project/6b664f0a-f7da-11ea-9251-005056a36f47

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
