### PR TITLE
CATTY-546 Select Arduino device screen can not be closed

### DIFF
--- a/src/Catty/ViewController/BluetoothDeviceSelection/BluetoothDevicesTableViewController.swift
+++ b/src/Catty/ViewController/BluetoothDeviceSelection/BluetoothDevicesTableViewController.swift
@@ -165,8 +165,12 @@ class BluetoothDevicesTableViewController: UITableViewController {
         delegate!.rightButton.isEnabled = false
         DispatchQueue.main.async {
             self.loadingView?.hide()
-            self.stagePresenterVC.checkResourcesAndPushViewController(to: self.navigationController!)
+
+            if let presentingNavigationController = self.navigationController?.presentingViewController as? UINavigationController {
+                self.dismiss(animated: true) {
+                    self.stagePresenterVC.checkResourcesAndPushViewController(to: presentingNavigationController)
+                }
+            }
         }
     }
-
 }


### PR DESCRIPTION
StagePresenterViewController was pushed onto NavigationController of BluetoothPopupVC, hence stopping the project lead to being trapped in the selection screen. Now, the presenting view controller (Navigation Controller of BluetoothPopupVC) gets dismissed before pushing the StagePresenterViewController.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
