### PR TITLE
CATTY-616 WebRequestBrick - max number of parallel requests

### DIFF
--- a/src/Catty/Defines/NetworkDefines.swift
+++ b/src/Catty/Defines/NetworkDefines.swift
@@ -104,6 +104,7 @@ class NetworkDefines: NSObject {
     // MARK: WebRequestDownloader
 
     static let kWebRequestMaxDownloadSizeInBytes = 1000000 // = 1MB
+    static let kNumberOfConcurrentDownloads = 10
 
     // MARK: Wiki
     static let kWebRequestWikiURL = "https://wiki.catrobat.org/bin/view/Documentation/Web%20requests/"


### PR DESCRIPTION
The maximum number of concurrent web requests should be limited to 10

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
