### PR TITLE
CATTY-452 Add missing tests for PhiroSensorTest

### DIFF
--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomLeftSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomLeftSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorPhiroBottomLeft
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
-    static let pinNumber = 2
+    static let pinNumber = PhiroDevice.pinSensorBottomLeft
     static let position = 310
 
     let getBluetoothService: () -> BluetoothService?

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomRightSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroBottomRightSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorPhiroBottomRight
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
-    static let pinNumber = 3
+    static let pinNumber = PhiroDevice.pinSensorBottomRight
     static let position = 300
 
     let getBluetoothService: () -> BluetoothService?

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontLeftSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontLeftSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorPhiroFrontLeft
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
-    static let pinNumber = 0
+    static let pinNumber = PhiroDevice.pinSensorFrontLeft
     static let position = 330
 
     let getBluetoothService: () -> BluetoothService?

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontRightSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroFrontRightSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorPhiroFrontRight
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
-    static let pinNumber = 1
+    static let pinNumber = PhiroDevice.pinSensorFrontRight
     static let position = 350
 
     let getBluetoothService: () -> BluetoothService?

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideLeftSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideLeftSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorPhiroSideLeft
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
-    static let pinNumber = 4
+    static let pinNumber = PhiroDevice.pinSensorSideLeft
     static let position = 340
 
     let getBluetoothService: () -> BluetoothService?

--- a/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideRightSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Phiro/PhiroSideRightSensor.swift
@@ -26,7 +26,7 @@
     static let name = kUIFESensorPhiroSideRight
     static let defaultRawValue = 0.0
     static let requiredResource = ResourceType.bluetoothPhiro
-    static let pinNumber = 5
+    static let pinNumber = PhiroDevice.pinSensorSideRight
     static let position = 320
 
     let getBluetoothService: () -> BluetoothService?

--- a/src/CattyTests/PlayerEngine/Sensors/Phiro/PhiroSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Phiro/PhiroSensorTest.swift
@@ -20,6 +20,7 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
+import BluetoothHelper
 import XCTest
 
 @testable import Pocket_Code
@@ -33,8 +34,6 @@ final class PhiroSensorTest: XCTestCase {
     var phiroFrontRight: PhiroFrontRightSensor!
     var phiroBottomLeft: PhiroBottomLeftSensor!
     var phiroBottomRight: PhiroBottomRightSensor!
-
-    // TODO: other tests - raw value and conversions
 
     override func setUp() {
         super.setUp()
@@ -131,5 +130,33 @@ final class PhiroSensorTest: XCTestCase {
         XCTAssertEqual(100, phiroFrontRight.convertToStandardized(rawValue: 100))
         XCTAssertEqual(100, phiroBottomLeft.convertToStandardized(rawValue: 100))
         XCTAssertEqual(100, phiroBottomRight.convertToStandardized(rawValue: 100))
+    }
+
+    func testRawValue() {
+        let device = PhiroDevice(peripheral: Peripheral(cbPeripheral: PeripheralMock.create(), advertisements: [String: String](), rssi: 0))
+        bluetoothService.phiro = device
+
+        XCTAssertEqual(0, phiroSideLeft.rawValue(landscapeMode: false))
+        XCTAssertEqual(0, phiroSideLeft.rawValue(landscapeMode: true))
+
+        bluetoothService.phiro?.didReceiveAnalogMessage(14, value: 1)
+        XCTAssertEqual(1, phiroSideRight.rawValue(landscapeMode: false))
+        XCTAssertEqual(1, phiroSideRight.rawValue(landscapeMode: true))
+
+        bluetoothService.phiro?.didReceiveAnalogMessage(18, value: 2)
+        XCTAssertEqual(2, phiroFrontLeft.rawValue(landscapeMode: false))
+        XCTAssertEqual(2, phiroFrontLeft.rawValue(landscapeMode: true))
+
+        bluetoothService.phiro?.didReceiveAnalogMessage(15, value: 3)
+        XCTAssertEqual(3, phiroFrontRight.rawValue(landscapeMode: false))
+        XCTAssertEqual(3, phiroFrontRight.rawValue(landscapeMode: true))
+
+        bluetoothService.phiro?.didReceiveAnalogMessage(17, value: 4)
+        XCTAssertEqual(4, phiroBottomLeft.rawValue(landscapeMode: false))
+        XCTAssertEqual(4, phiroBottomLeft.rawValue(landscapeMode: true))
+
+        bluetoothService.phiro?.didReceiveAnalogMessage(16, value: 5)
+        XCTAssertEqual(5, phiroBottomRight.rawValue(landscapeMode: false))
+        XCTAssertEqual(5, phiroBottomRight.rawValue(landscapeMode: true))
     }
 }


### PR DESCRIPTION
Add a test to PhiroSensorTest for each of the following sensors which should test the rawValue method:

- PhiroSideLeftSensor
- PhiroSideRightSensor
- PhiroFrontLeftSensor
- PhiroFrontRightSensor
- PhiroBottomLeftSensor
- PhiroBottomRightSensor

These methods should verify that the BluetoothService/Phirodevice is called properly with the right pin values. Create test doubles for the PhiroDevice and inject that to the BluetoothService (phiro).
 
Do not forget to remove the TODO comment in the PhiroSensorTest.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
