### PR TITLE
CATTY-580 Crash when stopping project

### DIFF
--- a/src/Catty/PlayerEngine/Stage/Stage.swift
+++ b/src/Catty/PlayerEngine/Stage/Stage.swift
@@ -296,7 +296,9 @@ final class Stage: SKScene, StageProtocol {
     @objc func stopProject() {
         view?.isPaused = true
         scheduler.shutdown() // stops all script contexts of all objects and removes all ressources
-        removeAllChildren() // remove all CBSpriteNodes from Scene
+        DispatchQueue.main.async {
+            self.removeAllChildren() // remove all CBSpriteNodes from Scene
+        }
         frontend.project?.removeReferences() // remove all references in project hierarchy
         formulaManager.stop()
         logger.info("All SpriteObjects and Scripts have been removed from Scene!")


### PR DESCRIPTION
Catty occasionally crashes when stopping a project – Firebase reports the following exception:
Call must be made on main thread

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
