### PR TITLE
CATTY-632 Uploading project with multiple categories

### DIFF
--- a/src/Catty/ViewController/Upload/UploadCategoryViewController.swift
+++ b/src/Catty/ViewController/Upload/UploadCategoryViewController.swift
@@ -44,7 +44,7 @@ class UploadCategoryViewController: UIViewController {
 
         self.view.backgroundColor = UIColor.background
         if let tags = tags {
-            for tag in tags.components(separatedBy: ", ") {
+            for tag in tags.components(separatedBy: ",") {
                 if let tagIndex = categories.firstIndex(of: tag) {
                     selectedCategoryTag.append(tagIndex)
                 }

--- a/src/Catty/ViewController/Upload/UploadViewController.swift
+++ b/src/Catty/ViewController/Upload/UploadViewController.swift
@@ -360,13 +360,13 @@ class UploadViewController: UIViewController, UploadCategoryViewControllerDelega
     }
 
     func categoriesSelected(tags: [String]) {
-        let stringRepresentationOfSelectedTags = tags.joined(separator: ", ")
+        let stringRepresentationOfSelectedTags = tags.joined(separator: ",")
         if !stringRepresentationOfSelectedTags.isEmpty {
             selectCategoriesValueLabel.text = stringRepresentationOfSelectedTags
         } else {
             selectCategoriesValueLabel.text = kLocalizedNoCategoriesSelected
         }
-        project?.header.tags = tags.joined(separator: ", ")
+        project?.header.tags = tags.joined(separator: ",")
     }
     // MARK: - Actions
 

--- a/src/CattyTests/ViewController/UploadViewControllerTests.swift
+++ b/src/CattyTests/ViewController/UploadViewControllerTests.swift
@@ -71,9 +71,9 @@ class UploadViewControllerTests: XCTestCase {
 
         uploadViewController.categoriesSelected(tags: ["testTag1", "testTag2"])
         XCTAssertNotNil(selectedCategoriesValueLabel.text)
-        XCTAssertEqual(selectedCategoriesValueLabel.text, "testTag1, testTag2")
+        XCTAssertEqual(selectedCategoriesValueLabel.text, "testTag1,testTag2")
         XCTAssertFalse(project.header.tags.isEmpty)
-        XCTAssertEqual(project.header.tags, "testTag1, testTag2")
+        XCTAssertEqual(project.header.tags, "testTag1,testTag2")
     }
 
     func testProjectTag() {
@@ -89,11 +89,11 @@ class UploadViewControllerTests: XCTestCase {
         uploadViewController.categoriesSelected(tags: ["testTag1", "testTag2"])
         uploadViewController.uploadAction()
         XCTAssertFalse(uploaderMock.projectToUpload!.header.tags.isEmpty)
-        XCTAssertEqual(uploaderMock.projectToUpload!.header.tags, "testTag1, testTag2")
+        XCTAssertEqual(uploaderMock.projectToUpload!.header.tags, "testTag1,testTag2")
 
         uploadViewController.categoriesSelected(tags: ["testTag1", "testTag2 with space"])
         uploadViewController.uploadAction()
         XCTAssertFalse(uploaderMock.projectToUpload!.header.tags.isEmpty)
-        XCTAssertEqual(uploaderMock.projectToUpload!.header.tags, "testTag1, testTag2 with space")
+        XCTAssertEqual(uploaderMock.projectToUpload!.header.tags, "testTag1,testTag2 with space")
     }
 }


### PR DESCRIPTION
https://jira.catrob.at/browse/CATTY-632

The issue was that we were using ", " as tag separators, while Catroid & the Share expect "," without a space

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
