### PR TITLE
CATTY-640 Remove bottom bar at media library

### DIFF
--- a/src/Catty/ViewController/MediaLibrary/MediaLibraryViewController.swift
+++ b/src/Catty/ViewController/MediaLibrary/MediaLibraryViewController.swift
@@ -77,6 +77,7 @@ final class MediaLibraryViewController: UICollectionViewController {
         super.viewWillAppear(animated)
         setupCollectionViewLayout()
         fetchData()
+        self.navigationController?.isToolbarHidden = true
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -85,6 +86,7 @@ final class MediaLibraryViewController: UICollectionViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        self.navigationController?.isToolbarHidden = false
     }
 
     override func didReceiveMemoryWarning() {


### PR DESCRIPTION
Removes bottom bar when pushing MediaLibraryViewController and adds it when popping.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
