### PR TITLE
CATTY-519 Computing values for face detection freezes UI

### DIFF
--- a/src/Catty/PlayerEngine/Sensors/Camera/FaceDetectionManager.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FaceDetectionManager.swift
@@ -76,9 +76,11 @@ class FaceDetectionManager: NSObject, FaceDetectionManagerProtocol, AVCaptureVid
         self.previewLayer = previewLayer
 
         let detectorOptions = [ CIDetectorAccuracy: CIDetectorAccuracyLow ]
-        self.faceDetector = CIDetector(ofType: CIDetectorTypeFace, context: nil, options: detectorOptions)
 
-        session.startRunning()
+        DispatchQueue.main.async {
+            self.faceDetector = CIDetector(ofType: CIDetectorTypeFace, context: nil, options: detectorOptions)
+            session.startRunning()
+        }
     }
 
     func stop() {


### PR DESCRIPTION
The function `FormulaEditorViewController.showComputeDialog(_:)` has a long computing time that is caused by calling `setup` on the _formulaManager_. Calling the constructor of _CIDetector_ and starting the _session_ are causing this brief freeze. Running them asynchronously fixes this behavior.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [ ] Include the name of the Jira ticket in the PR’s title
- [ ] Verify that the Jira ticket is in the status *Ready for Development*
- [ ] Include a summary of the changes plus the relevant context
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no compiler or linter warnings
- [ ] Perform a self-review of the changes
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Confirm that new and existing unit tests pass locally
- [ ] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
