### PR TITLE
CATTY-625 Stop current stitch brick

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -16,6 +16,11 @@
 		057B182C26DC903500C47E60 /* StartRunningStitchBrickCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 057B182B26DC903500C47E60 /* StartRunningStitchBrickCell.swift */; };
 		057B183026DD0A3400C47E60 /* StartRunningStitchBrick+CBXMLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 057B182F26DD0A3400C47E60 /* StartRunningStitchBrick+CBXMLHandler.swift */; };
 		0580514926EF734F00F719E0 /* StartRunningStitchBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0580514826EF734F00F719E0 /* StartRunningStitchBrickTests.swift */; };
+		0581B72C27BAA5210098BDF8 /* StopCurrentStitchBrick+Instruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0581B72927BAA5210098BDF8 /* StopCurrentStitchBrick+Instruction.swift */; };
+		0581B72E27BAA5460098BDF8 /* StopCurrentStitchBrickCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0581B72D27BAA5460098BDF8 /* StopCurrentStitchBrickCell.swift */; };
+		0581B73027BAA5520098BDF8 /* StopCurrentStitchBrick+CBXMLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0581B72F27BAA5520098BDF8 /* StopCurrentStitchBrick+CBXMLHandler.swift */; };
+		0581B73427BAA5F70098BDF8 /* StopCurrentStitchBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0581B73327BAA5F70098BDF8 /* StopCurrentStitchBrick.swift */; };
+		0581B73527BAA98E0098BDF8 /* StopCurrentStitchBrickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0581B73127BAA58D0098BDF8 /* StopCurrentStitchBrickTests.swift */; };
 		0594CE5C275E54AE007DC3F9 /* SewUpBrick+Instruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0594CE59275E54AE007DC3F9 /* SewUpBrick+Instruction.swift */; };
 		0594CE5E275E54C6007DC3F9 /* SewUpBrick.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0594CE5D275E54C6007DC3F9 /* SewUpBrick.swift */; };
 		0594CE60275E5568007DC3F9 /* SewUpBrick+CBXMLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0594CE5F275E5568007DC3F9 /* SewUpBrick+CBXMLHandler.swift */; };
@@ -1970,6 +1975,11 @@
 		057B182B26DC903500C47E60 /* StartRunningStitchBrickCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRunningStitchBrickCell.swift; sourceTree = "<group>"; };
 		057B182F26DD0A3400C47E60 /* StartRunningStitchBrick+CBXMLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StartRunningStitchBrick+CBXMLHandler.swift"; sourceTree = "<group>"; };
 		0580514826EF734F00F719E0 /* StartRunningStitchBrickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRunningStitchBrickTests.swift; sourceTree = "<group>"; };
+		0581B72927BAA5210098BDF8 /* StopCurrentStitchBrick+Instruction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StopCurrentStitchBrick+Instruction.swift"; sourceTree = "<group>"; };
+		0581B72D27BAA5460098BDF8 /* StopCurrentStitchBrickCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StopCurrentStitchBrickCell.swift; sourceTree = "<group>"; };
+		0581B72F27BAA5520098BDF8 /* StopCurrentStitchBrick+CBXMLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StopCurrentStitchBrick+CBXMLHandler.swift"; sourceTree = "<group>"; };
+		0581B73127BAA58D0098BDF8 /* StopCurrentStitchBrickTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StopCurrentStitchBrickTests.swift; sourceTree = "<group>"; };
+		0581B73327BAA5F70098BDF8 /* StopCurrentStitchBrick.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StopCurrentStitchBrick.swift; sourceTree = "<group>"; };
 		0594CE59275E54AE007DC3F9 /* SewUpBrick+Instruction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SewUpBrick+Instruction.swift"; sourceTree = "<group>"; };
 		0594CE5D275E54C6007DC3F9 /* SewUpBrick.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SewUpBrick.swift; sourceTree = "<group>"; };
 		0594CE5F275E5568007DC3F9 /* SewUpBrick+CBXMLHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SewUpBrick+CBXMLHandler.swift"; sourceTree = "<group>"; };
@@ -5355,6 +5365,7 @@
 		4614B1CE2560856B004174AD /* Embroidery */ = {
 			isa = PBXGroup;
 			children = (
+				0581B73327BAA5F70098BDF8 /* StopCurrentStitchBrick.swift */,
 				0594CE5D275E54C6007DC3F9 /* SewUpBrick.swift */,
 				4614B1CF2560856B004174AD /* StitchBrick.swift */,
 				057B182926DC8B6A00C47E60 /* StartRunningStitchBrick.swift */,
@@ -5365,6 +5376,7 @@
 		4614B1D725608DB3004174AD /* Embroidery */ = {
 			isa = PBXGroup;
 			children = (
+				0581B72D27BAA5460098BDF8 /* StopCurrentStitchBrickCell.swift */,
 				0594CE61275E55B0007DC3F9 /* SewUpBrickCell.swift */,
 				4614B1DC25608E8B004174AD /* StitchBrickCell.swift */,
 				057B182B26DC903500C47E60 /* StartRunningStitchBrickCell.swift */,
@@ -5384,6 +5396,7 @@
 		46B472B92560946E007972DB /* Embroidery */ = {
 			isa = PBXGroup;
 			children = (
+				0581B72927BAA5210098BDF8 /* StopCurrentStitchBrick+Instruction.swift */,
 				0594CE59275E54AE007DC3F9 /* SewUpBrick+Instruction.swift */,
 				46B472BA2560946E007972DB /* StitchBrick+Instruction.swift */,
 				0570883D2739CC6F00622D84 /* StartRunningStitchBrick+Instruction.swift */,
@@ -5395,6 +5408,7 @@
 		46B472BE2560950D007972DB /* Embroidery */ = {
 			isa = PBXGroup;
 			children = (
+				0581B72F27BAA5520098BDF8 /* StopCurrentStitchBrick+CBXMLHandler.swift */,
 				0594CE5F275E5568007DC3F9 /* SewUpBrick+CBXMLHandler.swift */,
 				46B472C125609573007972DB /* StitchBrick+CBXMLHandler.swift */,
 				057B182F26DD0A3400C47E60 /* StartRunningStitchBrick+CBXMLHandler.swift */,
@@ -7054,6 +7068,7 @@
 		4CEB222C1B95E47500B3BE2F /* Bricks */ = {
 			isa = PBXGroup;
 			children = (
+				0581B73127BAA58D0098BDF8 /* StopCurrentStitchBrickTests.swift */,
 				0594CE65275E567D007DC3F9 /* SewUpBrickTests.swift */,
 				4C16042D1F0025F6004525A5 /* Abstract */,
 				4C3746E622FC7AC3007B2BE1 /* BrickManager */,
@@ -11868,6 +11883,7 @@
 				4C0076DA25F6AF79002D754D /* StagePresenterSideMenuViewTests.swift in Sources */,
 				4C6FE175212D2D2E0067B7D5 /* ContainsFunctionTest.swift in Sources */,
 				4CF8276E24F0F5B0006E562A /* BrickCellBackgroundDataTests.swift in Sources */,
+				0581B73527BAA98E0098BDF8 /* StopCurrentStitchBrickTests.swift in Sources */,
 				4C822663213FA7A400F3D750 /* FacePositionXSensorTest.swift in Sources */,
 				4C2CBB5E25A5AA8400C1C143 /* XMLParserTests0993.swift in Sources */,
 				6F5B4C7124D458AC00D2D319 /* SceneTest.swift in Sources */,
@@ -12294,6 +12310,7 @@
 				AA74F0A41BC05FCE00D1E954 /* LoopEndBrickCell.m in Sources */,
 				921E84E81CC9F3E400F7EE9F /* TextInputViewController.m in Sources */,
 				921D467D1BDF61350086AD20 /* ComeToFrontBrick+Instruction.swift in Sources */,
+				0581B72E27BAA5460098BDF8 /* StopCurrentStitchBrickCell.swift in Sources */,
 				181DB738247DA62600B82B20 /* NSDataExtension.swift in Sources */,
 				9218B20F1CC4AB75007B4C60 /* MirrorRotationZoomTool.m in Sources */,
 				AA74EEF91BC057C900D1E954 /* ChangeTransparencyByNBrick+CBXMLHandler.m in Sources */,
@@ -12399,6 +12416,7 @@
 				972622CD25F5145D00ABCC7A /* SetBrightnessBrickCell.swift in Sources */,
 				2DA8790C212B443500FE0585 /* SearchStoreViewController.swift in Sources */,
 				92C631A01BC5193B00486958 /* BluetoothDevicesTableViewController.swift in Sources */,
+				0581B73427BAA5F70098BDF8 /* StopCurrentStitchBrick.swift in Sources */,
 				17D5F5BE265E927A00C678FF /* Keychain.swift in Sources */,
 				F4E6E5C0210E1FE900D86FE6 /* RandFunction.swift in Sources */,
 				92D56C391BF2098700A54750 /* PhiroProtocol.swift in Sources */,
@@ -12450,6 +12468,7 @@
 				99B2C3731D884E8A00736769 /* FlashBrickCell.m in Sources */,
 				18237D6B24EC3A9300759854 /* UIDefines.swift in Sources */,
 				AA74F0BA1BC05FCE00D1E954 /* GoNStepsBackBrickCell.m in Sources */,
+				0581B72C27BAA5210098BDF8 /* StopCurrentStitchBrick+Instruction.swift in Sources */,
 				4CF0729120D6697300F93AB5 /* LatitudeSensor.swift in Sources */,
 				AA74EE231BC053FD00D1E954 /* WaitBrick+Instruction.swift in Sources */,
 				927F79E01BEE39CB008D1635 /* PhiroIfLogicBeginBrick.m in Sources */,
@@ -12672,6 +12691,7 @@
 				92FF30FF1A24DCAA00093DA7 /* Project.m in Sources */,
 				0502CFA826754E570028CF53 /* RecentlyUsedBricksManager.swift in Sources */,
 				186E99172488F4F400627E36 /* PenUpBrickCell.swift in Sources */,
+				0581B73027BAA5520098BDF8 /* StopCurrentStitchBrick+CBXMLHandler.swift in Sources */,
 				4C82268D213FB29A00F3D750 /* MultiFingerYFunction.swift in Sources */,
 				BA987D0F2194EA1F002DAA05 /* WaitUntilBrick+Instruction.swift in Sources */,
 				BA9CAB541EC380CA00796056 /* AddItemToUserListBrick.m in Sources */,

--- a/src/Catty/DataModel/Bricks/Embroidery/StopCurrentStitchBrick.swift
+++ b/src/Catty/DataModel/Bricks/Embroidery/StopCurrentStitchBrick.swift
@@ -1,0 +1,51 @@
+/**
+ *  Copyright (C) 2010-2022 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import Foundation
+
+@objc(StopCurrentStitchBrick)
+@objcMembers class StopCurrentStitchBrick: Brick, BrickProtocol {
+
+    override required init() {
+        super.init()
+    }
+
+    func category() -> kBrickCategoryType {
+        kBrickCategoryType.embroideryBrick
+    }
+
+    override class func description() -> String {
+        "StopCurrentStitchBrick"
+    }
+
+    override func getRequiredResources() -> Int {
+        ResourceType.embroidery.rawValue
+    }
+
+    override func brickCell() -> BrickCellProtocol.Type! {
+        StopCurrentStitchBrickCell.self as BrickCellProtocol.Type
+    }
+
+    override func isSelectableForObject() -> Bool {
+        UserDefaults.standard.bool(forKey: kUseEmbroideryBricks)
+    }
+}

--- a/src/Catty/Defines/LanguageTranslationDefines.h
+++ b/src/Catty/Defines/LanguageTranslationDefines.h
@@ -352,6 +352,8 @@
 #define kLocalizedStitch NSLocalizedString(@"Stitch", nil)
 #define kLocalizedStartRunningStitch NSLocalizedString(@"Start running stitch with length", nil)
 #define kLocalizedSewUp NSLocalizedString(@"Sew up", @"literally; Sewing up a thread at the end of an embroidered pattern, so that said thread is fixed in the fabric.")
+#define kLocalizedStopCurrentStitch NSLocalizedString(@"Stop current stitch", nil)
+
 // control bricks
 #define kLocalizedScript NSLocalizedString(@"Script", nil)
 #define kLocalizedWhenProjectStarted NSLocalizedString(@"When project starts", nil)

--- a/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
+++ b/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
@@ -352,6 +352,8 @@ let kLocalizedAlwaysAllowWebRequestDescription = NSLocalizedString("Be very care
 let kLocalizedStitch = NSLocalizedString("Stitch", comment: "")
 let kLocalizedStartRunningStitch = NSLocalizedString("Start running stitch with length", comment: "")
 let kLocalizedSewUp = NSLocalizedString("Sew up", comment: "literally; Sewing up a thread at the end of an embroidered pattern, so that said thread is fixed in the fabric.")
+let kLocalizedStopCurrentStitch = NSLocalizedString("Stop current stitch", comment: "")
+
 // control bricks
 let kLocalizedScript = NSLocalizedString("Script", comment: "")
 let kLocalizedWhenProjectStarted = NSLocalizedString("When project starts", comment: "")

--- a/src/Catty/PlayerEngine/Instructions/Embroidery/StopCurrentStitchBrick+Instruction.swift
+++ b/src/Catty/PlayerEngine/Instructions/Embroidery/StopCurrentStitchBrick+Instruction.swift
@@ -1,0 +1,37 @@
+/**
+ *  Copyright (C) 2010-2022 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+extension StopCurrentStitchBrick: CBInstructionProtocol {
+
+    func instruction() -> CBInstruction {
+        .action { context in SKAction.run(self.actionBlock(context.formulaInterpreter)) }
+    }
+
+    func actionBlock(_ formulaInterpreter: FormulaInterpreterProtocol) -> () -> Void {
+        guard let object = self.script?.object, let spriteNode = object.spriteNode else {
+            fatalError("This should never happen!") }
+
+        return {
+            spriteNode.embroideryStream.activePattern = nil
+        }
+    }
+}

--- a/src/Catty/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en.lproj/Localizable.strings
@@ -1784,6 +1784,9 @@
 "Stop all sounds" = "Stop all sounds";
 
 /* No comment provided by engineer. */
+"Stop current stitch" = "Stop current stitch";
+
+/* No comment provided by engineer. */
 "Stop Phiro motor" = "Stop Phiro motor";
 
 /* No comment provided by engineer. */

--- a/src/Catty/Setup/CatrobatSetup+Bricks.swift
+++ b/src/Catty/Setup/CatrobatSetup+Bricks.swift
@@ -123,7 +123,8 @@
             // embroidery brick
             StitchBrick(),
             StartRunningStitchBrick(),
-            SewUpBrick()
+            SewUpBrick(),
+            StopCurrentStitchBrick()
         ]
 
         if isPhiroEnabled() {

--- a/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Embroidery/StopCurrentStitchBrickCell.swift
+++ b/src/Catty/Views/Custom/CollectionViewCells/BrickCells/Embroidery/StopCurrentStitchBrickCell.swift
@@ -1,0 +1,46 @@
+/**
+ *  Copyright (C) 2010-2021 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+class StopCurrentStitchBrickCell: BrickCell, BrickCellProtocol {
+
+    var textLabel: UILabel?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    static func cellHeight() -> CGFloat {
+        UIDefines.brickHeight1h
+    }
+
+    func brickTitle(forBackground isBackground: Bool, andInsertionScreen isInsertion: Bool) -> String! {
+        kLocalizedStopCurrentStitch
+    }
+
+    override func hookUpSubViews(_ inlineViewSubViews: [Any]!) {
+        self.textLabel = inlineViewSubViews[0] as? UILabel
+    }
+}

--- a/src/Catty/XML/XMLHandler/Bricks/Embroidery/StopCurrentStitchBrick+CBXMLHandler.swift
+++ b/src/Catty/XML/XMLHandler/Bricks/Embroidery/StopCurrentStitchBrick+CBXMLHandler.swift
@@ -1,0 +1,33 @@
+/**
+ *  Copyright (C) 2010-2022 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+extension StopCurrentStitchBrick: CBXMLNodeProtocol {
+    static func parse(from xmlElement: GDataXMLElement, with context: CBXMLParserContext) -> Self {
+        CBXMLParserHelper.validate(xmlElement, forNumberOfChildNodes: 0)
+        return self.init()
+    }
+
+    func xmlElement(with context: CBXMLSerializerContext) -> GDataXMLElement? {
+        let brick = super.xmlElement(for: "StopCurrentStitchBrick", with: context)
+        return brick
+    }
+}

--- a/src/CattyTests/Bricks/StopCurrentStitchBrickTests.swift
+++ b/src/CattyTests/Bricks/StopCurrentStitchBrickTests.swift
@@ -1,0 +1,51 @@
+/**
+ *  Copyright (C) 2010-2022 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import XCTest
+
+@testable import Pocket_Code
+
+final class StopCurrentStitchBrickTests: AbstractBrickTest {
+
+    func testStopCurrentStitchPattern() {
+        super.setUp()
+        let spriteObject = SpriteObject()
+        let scene = Scene(name: "StopCurrentTest")
+        spriteObject.scene = scene
+
+        let spriteNode = CBSpriteNode(spriteObject: spriteObject)
+        let embStream = spriteNode.embroideryStream
+
+        embStream.activePattern = RunningStitchPattern(for: embStream, at: .zero, with: 20)
+
+        let script = Script()
+        script.object = spriteObject
+
+        let brick = StopCurrentStitchBrick()
+        brick.script = script
+
+        let action = brick.actionBlock(self.formulaInterpreter)
+        action()
+
+        XCTAssertNil(spriteNode.embroideryStream.activePattern)
+    }
+}

--- a/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
+++ b/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
@@ -352,6 +352,8 @@ let kLocalizedAlwaysAllowWebRequestDescription = NSLocalizedString("Be very care
 let kLocalizedStitch = NSLocalizedString("Stitch", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedStartRunningStitch = NSLocalizedString("Start running stitch with length", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedSewUp = NSLocalizedString("Sew up", bundle: Bundle(for: LanguageTranslation.self), comment: "literally; Sewing up a thread at the end of an embroidered pattern, so that said thread is fixed in the fabric.")
+let kLocalizedStopCurrentStitch = NSLocalizedString("Stop current stitch", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+
 // control bricks
 let kLocalizedScript = NSLocalizedString("Script", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedWhenProjectStarted = NSLocalizedString("When project starts", bundle: Bundle(for: LanguageTranslation.self), comment: "")


### PR DESCRIPTION
This PR adds a Brick to stop currently running stitching patterns such as the `RunningStitchPattern`.


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
