### PR TITLE
CATTY-502 Incorrect placement of Say/Think bubbles

### DIFF
--- a/src/Catty/Helpers/BrickHelpers/BubbleBrickHelper.swift
+++ b/src/Catty/Helpers/BrickHelpers/BubbleBrickHelper.swift
@@ -43,8 +43,8 @@ let kSentenceLength = 10
         let fullTextLength = fullTextNode.frame.size.width
         var sentenceSubStringLength = Int(fullTextLength)
 
-         if fullTextLength > CGFloat(kMaxBubbleWidth) {
-             while sentencePosition + kSentenceLength < text.count {
+        if fullTextLength > CGFloat(kMaxBubbleWidth) {
+            while sentencePosition + kSentenceLength < text.count {
 
                 let sentencePosIndex = text.index(text.startIndex, offsetBy: sentencePosition)
                 let sentenceLengthIndex = text.index(text.startIndex, offsetBy: sentencePosition + kSentenceLength)
@@ -56,16 +56,16 @@ let kSentenceLength = 10
                 let charRange = lowerCharIndex..<UpperCharIndex
                 let nextCharInLine = String(text[charRange])
 
-                 if nextCharInLine == " " {
+                if nextCharInLine == " " {
                     sentenceSubString += "-"
-                 }
+                }
 
-                 addSentence(toLabel: labelNode, withSentence: sentenceSubString, andPosition: (CGFloat)(verticalPosition))
-                 sentencePosition += kSentenceLength
+                addSentence(toLabel: labelNode, withSentence: sentenceSubString, andPosition: (CGFloat)(verticalPosition))
+                sentencePosition += kSentenceLength
                 verticalPosition += SpriteKitDefines.defaultLabelFontSize + 5
                 bubbleHeight += SpriteKitDefines.defaultLabelFontSize + 5
-                 sentenceSubStringLength = Int(SKLabelNode(text: sentenceSubString).frame.size.width)
-             }
+                sentenceSubStringLength = Int(SKLabelNode(text: sentenceSubString).frame.size.width)
+            }
 
             let lowerSubStringIndex = text.index(text.startIndex, offsetBy: sentencePosition)
             let UpperSubStringIndex = text.index(text.startIndex, offsetBy: text.count)
@@ -73,7 +73,7 @@ let kSentenceLength = 10
             let sentenceSubString = String(text[subStringRange])
 
             addSentence(toLabel: labelNode, withSentence: sentenceSubString, andPosition: (CGFloat)(verticalPosition))
-         } else {
+        } else {
             addSentence(toLabel: labelNode, withSentence: text, andPosition: (CGFloat)(verticalPosition))
         }
 
@@ -93,6 +93,30 @@ let kSentenceLength = 10
         bubble.addChild(labelNode)
         sprite.addChild(bubble)
     }
+
+    private static func getTopRightMostPixel(_ image: UIImage?) -> CGPoint? {
+        guard let image = image, let cgImage = image.cgImage, let dataProvider = cgImage.dataProvider else {
+            return nil
+        }
+
+        let pixelData = dataProvider.data
+        let data: UnsafePointer<UInt8> = CFDataGetBytePtr(pixelData)
+        let imageWidth = Int(image.size.width)
+        let imageHeight = Int(image.size.height)
+
+        for y in 0..<imageHeight {
+            for x in 0..<imageWidth {
+                let pixelIndex = ((imageWidth * y) + imageWidth - x) * 4
+                let alpha = data[pixelIndex + 3]
+                if alpha != 0 {
+                    return CGPoint(x: x, y: y)
+                }
+            }
+        }
+
+        return nil
+    }
+
     private static func createBubble(with sprite: CBSpriteNode, width: CGFloat, height: CGFloat, type: CBBubbleType)
         -> SKShapeNode {
 
@@ -102,15 +126,20 @@ let kSentenceLength = 10
                                                       bubbleTailHeight: bubbleTailHeight,
                                                       type: type))
 
-        let bubbleInitialPosition = CGPoint(x: sprite.frame.size.width / 2,
-                                            y: sprite.frame.size.height / (2 * sprite.yScale))
+        let pixel = getTopRightMostPixel(sprite.currentUIImageLook) ?? .zero
+        let offsetX = abs(sprite.size.width / 2 - pixel.x)
+        let offsetY = abs(sprite.size.height / (2 * sprite.yScale) - pixel.y)
+        let offset = CGPoint(x: pixel.x < sprite.size.width / 2 ? offsetX : -offsetX, y: offsetY)
 
-        bubble.constraints = (NSArray(object: SpriteBubbleConstraint(bubble: bubble,
-                                                                     parent: sprite,
-                                                                     width: width,
-                                                                     height: height,
-                                                                     position: bubbleInitialPosition,
-                                                                     bubbleTailHeight: bubbleTailHeight)) as! [SKConstraint])
+        let bubbleInitialPosition = CGPoint(x: offset.x, y: offset.y)
+
+        bubble.constraints = [SpriteBubbleConstraint(bubble: bubble,
+                                                     parent: sprite,
+                                                     width: width,
+                                                     height: height,
+                                                     position: bubbleInitialPosition,
+                                                     bubbleTailHeight: bubbleTailHeight)]
+
         bubble.name = SpriteKitDefines.bubbleBrickNodeName
         bubble.fillColor = UIColor.white
         bubble.strokeColor = UIColor.black

--- a/src/Catty/PlayerEngine/Stage/Constraints/SpriteBubbleConstraint.swift
+++ b/src/Catty/PlayerEngine/Stage/Constraints/SpriteBubbleConstraint.swift
@@ -27,13 +27,15 @@ final class SpriteBubbleConstraint: SKConstraint {
     private let bubbleWidth: CGFloat
     private let bubbleHeight: CGFloat
     private let bubbleInitialPosition: CGPoint
+    private let bubbleInvertedInitialPosition: CGPoint
 
-    @objc init(bubble: SKNode, parent: SKNode, width: CGFloat, height: CGFloat, position: CGPoint, bubbleTailHeight: CGFloat) {
+    @objc init(bubble: SKNode, parent: SKNode, width: CGFloat, height: CGFloat, position: CGPoint, invertedPosition: CGPoint, bubbleTailHeight: CGFloat) {
         self.bubble = bubble
         self.parent = parent
         self.bubbleWidth = width
         self.bubbleHeight = height + bubbleTailHeight
         self.bubbleInitialPosition = position
+        self.bubbleInvertedInitialPosition = invertedPosition
 
         super.init()
         self.enabled = true
@@ -62,16 +64,21 @@ final class SpriteBubbleConstraint: SKConstraint {
         }
 
         let isBubbleInverted = bubble.xScale < 0
-        var leftBubbleBorder = parent.position.x + bubbleInitialPosition.x
-        var rightBubbleBorder = parent.position.x + bubbleInitialPosition.x
+        var leftBubbleBorder = parent.position.x
+        var rightBubbleBorder = parent.position.x
 
-        leftBubbleBorder -= isBubbleInverted ? bubbleWidth : 0
-        rightBubbleBorder += isBubbleInverted ? 0 : bubbleWidth
+        if isBubbleInverted {
+            leftBubbleBorder += bubbleInvertedInitialPosition.x - bubbleWidth
+            rightBubbleBorder += bubbleInvertedInitialPosition.x
+            bubble.position.x = bubbleInvertedInitialPosition.x
+        } else {
+            leftBubbleBorder += bubbleInitialPosition.x
+            rightBubbleBorder += bubbleInitialPosition.x + bubbleWidth
+            bubble.position.x = bubbleInitialPosition.x
+        }
 
         let rightSceneEdge = scene.size.width
         let leftSceneEdge = CGFloat(0)
-
-        bubble.position.x = bubbleInitialPosition.x
 
         if (rightBubbleBorder > rightSceneEdge && !isBubbleInverted && leftBubbleBorder > leftSceneEdge) ||
             (leftBubbleBorder < leftSceneEdge && isBubbleInverted && rightBubbleBorder < rightSceneEdge) {

--- a/src/CattyTests/PlayerEngine/Scene/Constraints/SpriteBubbleConstraintsTests.swift
+++ b/src/CattyTests/PlayerEngine/Scene/Constraints/SpriteBubbleConstraintsTests.swift
@@ -29,6 +29,9 @@ final class SpriteBubbleConstraintsTests: XCTestCase {
     var parent: CBSpriteNodeMock!
     var child: SKNode!
     var bubbleConstraint: SpriteBubbleConstraint!
+    var bubbleInitialPosition: CGPoint!
+    var bubbleInvertedInitialPosition: CGPoint!
+    var bubbleSize: CGSize!
 
     override func setUp() {
         let object = SpriteObject()
@@ -40,11 +43,16 @@ final class SpriteBubbleConstraintsTests: XCTestCase {
         BubbleBrickHelper.addBubble(to: parent, withText: "Hello", andType: CBBubbleType.thought)
         child = parent.children.first!
 
+        bubbleInitialPosition = CGPoint(x: 300, y: 400)
+        bubbleInvertedInitialPosition = CGPoint(x: -300, y: 400)
+        bubbleSize = CGSize(width: 200, height: 200)
+
         bubbleConstraint = SpriteBubbleConstraint(bubble: child,
                                                   parent: parent,
-                                                  width: 200,
-                                                  height: 200,
-                                                  position: CGPoint(x: 300, y: 400),
+                                                  width: bubbleSize.width,
+                                                  height: bubbleSize.height,
+                                                  position: bubbleInitialPosition,
+                                                  invertedPosition: bubbleInvertedInitialPosition,
                                                   bubbleTailHeight: 48)
 
     }
@@ -62,18 +70,34 @@ final class SpriteBubbleConstraintsTests: XCTestCase {
         XCTAssertEqual(-parent.zRotation, child.zRotation, accuracy: 0.000001)
     }
 
-    func testRightXCollision() {
+    func testBubbleCollisionX() {
+        let bubbleOffsetX = bubbleInitialPosition.x
+        let bubbleWidth = bubbleSize.width
+        let sceneWidth = parent.scene.frame.width
+        let delta: CGFloat = 10
+
+        let bubbleIntersectsRightSceneEdge = sceneWidth - bubbleWidth - bubbleOffsetX
+
+        parent.position.x = bubbleIntersectsRightSceneEdge - delta
+        bubbleConstraint.apply()
         XCTAssertEqual(child.xScale, 1)
-        parent.position.x = 1000
+        XCTAssertEqual(child.position.x, bubbleOffsetX, accuracy: delta)
+
+        parent.position.x = bubbleIntersectsRightSceneEdge + delta
         bubbleConstraint.apply()
         XCTAssertEqual(child.xScale, -1)
-    }
+        XCTAssertEqual(child.position.x, bubbleOffsetX, accuracy: delta)
 
-    func testLeftXCollision() {
-        parent.position.x = 1000
+        let bubbleIntersectsLeftSceneEdge = bubbleWidth + bubbleOffsetX
+
+        parent.position.x = bubbleIntersectsLeftSceneEdge + delta
         bubbleConstraint.apply()
-        parent.position.x = -1000
+        XCTAssertEqual(child.xScale, -1)
+        XCTAssertEqual(child.position.x, -bubbleOffsetX, accuracy: delta)
+
+        parent.position.x = bubbleIntersectsLeftSceneEdge - delta
         bubbleConstraint.apply()
         XCTAssertEqual(child.xScale, 1)
+        XCTAssertEqual(child.position.x, -bubbleOffsetX, accuracy: delta)
     }
 }

--- a/src/CattyTests/PlayerEngine/Scene/Constraints/SpriteBubbleConstraintsTests.swift
+++ b/src/CattyTests/PlayerEngine/Scene/Constraints/SpriteBubbleConstraintsTests.swift
@@ -76,44 +76,4 @@ final class SpriteBubbleConstraintsTests: XCTestCase {
         bubbleConstraint.apply()
         XCTAssertEqual(child.xScale, 1)
     }
-
-    func testTopYCollision() {
-        bubbleConstraint.apply()
-        XCTAssertEqual(0, CGFloat(child.position.y), accuracy: 1)
-        parent.position.y = 100000
-        bubbleConstraint.apply()
-        let topEdge = parent.scene.size.height - parent.yScale * child.frame.size.height
-        guard let yCollision = parent.mockedStage?.convert(child.position, from: parent).y else {
-            XCTAssert(false)
-            return
-        }
-        XCTAssertEqual(topEdge, CGFloat(yCollision), accuracy: 200)
-    }
-
-    func testBottomYCollision() {
-        parent.position.y = 100000
-        bubbleConstraint.apply()
-        parent.position.y = -100000
-        bubbleConstraint.apply()
-        guard let yCollision = parent.mockedStage?.convert(child.position, from: parent).y else {
-            XCTAssert(false)
-            return
-        }
-        XCTAssertEqual(0, yCollision, accuracy: 1)
-    }
-
-    func testRotationCollision() {
-        bubbleConstraint.apply()
-        XCTAssertEqual(0, CGFloat(child.position.y), accuracy: 1)
-        parent.zRotation = .pi
-        parent.position.y = 10000
-        bubbleConstraint.apply()
-
-        guard let yCollision = parent.mockedStage?.convert(child.position, from: parent).y else {
-            XCTAssert(false)
-            return
-        }
-        let topEdge = parent.scene.size.height - parent.yScale * child.frame.size.height
-        XCTAssertEqual(topEdge, CGFloat(yCollision), accuracy: 200)
-    }
 }


### PR DESCRIPTION
https://jira.catrob.at/browse/CATTY-502

Speaking and thinking bubbles are placed next to the visible part of the look (ignoring transparent parts of the bounding box). 
In addition, the behaviour when sprites touch or move beyond the edge of the screen has been adapted to match Catroid's behaviour. 
Also removes unit tests for Y-axis collision handling, since Y-axis collisions are ignored now. 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
