### PR TITLE
CATTY-651 Enable face detection for two faces

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -339,6 +339,13 @@
 		46F0D30E25E593F5002252E6 /* SetLookBrick+CBXMLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F0D30D25E593F5002252E6 /* SetLookBrick+CBXMLHandler.swift */; };
 		46F1754E24C46837006B2ACA /* ScriptCollectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F1754D24C46837006B2ACA /* ScriptCollectionViewControllerTests.swift */; };
 		4926233C27AA8A2800866183 /* SceneTableViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4926233B27AA8A2800866183 /* SceneTableViewControllerExtension.swift */; };
+		49358BC927DB3A37005F96B4 /* VNFaceObservationMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49358BC827DB3A37005F96B4 /* VNFaceObservationMock.swift */; };
+		49519D2F27DCD6B100E32E88 /* SecondFaceDetectedSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49519D2E27DCD6B100E32E88 /* SecondFaceDetectedSensor.swift */; };
+		49519D3327DCE0EC00E32E88 /* SecondFacePositionXSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49519D3227DCE0EC00E32E88 /* SecondFacePositionXSensor.swift */; };
+		49519D3527DCE0FE00E32E88 /* SecondFacePositionYSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49519D3427DCE0FE00E32E88 /* SecondFacePositionYSensor.swift */; };
+		49519D3727DCE11700E32E88 /* SecondFaceSizeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49519D3627DCE11700E32E88 /* SecondFaceSizeSensor.swift */; };
+		49530A8227FDDADC003A9E24 /* FaceDetectionSensors.xml in Resources */ = {isa = PBXBuildFile; fileRef = 49530A8127FDDADC003A9E24 /* FaceDetectionSensors.xml */; };
+		49530A8427FDDC04003A9E24 /* BackwardsCompatibleFaceDetectionSensors.xml in Resources */ = {isa = PBXBuildFile; fileRef = 49530A8327FDDC03003A9E24 /* BackwardsCompatibleFaceDetectionSensors.xml */; };
 		4C0076DA25F6AF79002D754D /* StagePresenterSideMenuViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0076D725F6AF79002D754D /* StagePresenterSideMenuViewTests.swift */; };
 		4C03A4BE2133FD05007BFFD2 /* FormulaManager+Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C03A4BD2133FD05007BFFD2 /* FormulaManager+Resources.swift */; };
 		4C03A4C22133FDE7007BFFD2 /* FormulaManager+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C03A4C12133FDE7007BFFD2 /* FormulaManager+Editor.swift */; };
@@ -2335,6 +2342,13 @@
 		46F1754D24C46837006B2ACA /* ScriptCollectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptCollectionViewControllerTests.swift; sourceTree = "<group>"; };
 		481639B0D938C88A5E2E6963 /* ms */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ms; path = ms.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4926233B27AA8A2800866183 /* SceneTableViewControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneTableViewControllerExtension.swift; sourceTree = "<group>"; };
+		49358BC827DB3A37005F96B4 /* VNFaceObservationMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VNFaceObservationMock.swift; sourceTree = "<group>"; };
+		49519D2E27DCD6B100E32E88 /* SecondFaceDetectedSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondFaceDetectedSensor.swift; sourceTree = "<group>"; };
+		49519D3227DCE0EC00E32E88 /* SecondFacePositionXSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondFacePositionXSensor.swift; sourceTree = "<group>"; };
+		49519D3427DCE0FE00E32E88 /* SecondFacePositionYSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondFacePositionYSensor.swift; sourceTree = "<group>"; };
+		49519D3627DCE11700E32E88 /* SecondFaceSizeSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondFaceSizeSensor.swift; sourceTree = "<group>"; };
+		49530A8127FDDADC003A9E24 /* FaceDetectionSensors.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = FaceDetectionSensors.xml; sourceTree = "<group>"; };
+		49530A8327FDDC03003A9E24 /* BackwardsCompatibleFaceDetectionSensors.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = BackwardsCompatibleFaceDetectionSensors.xml; sourceTree = "<group>"; };
 		4997640FD2AB79927E45C4EF /* ca */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4C0076D725F6AF79002D754D /* StagePresenterSideMenuViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StagePresenterSideMenuViewTests.swift; sourceTree = "<group>"; };
 		4C03A4BD2133FD05007BFFD2 /* FormulaManager+Resources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FormulaManager+Resources.swift"; sourceTree = "<group>"; };
@@ -5217,6 +5231,8 @@
 				E5EC6D7126B010C40031F13A /* Sensors_09993.xml */,
 				E5DAAD5D26C5485400C2457F /* Sensors_09997.xml */,
 				C84B21702714A2690077CF70 /* TouchesEdgeSensor.xml */,
+				49530A8327FDDC03003A9E24 /* BackwardsCompatibleFaceDetectionSensors.xml */,
+				49530A8127FDDADC003A9E24 /* FaceDetectionSensors.xml */,
 			);
 			path = Sensors;
 			sourceTree = "<group>";
@@ -7033,6 +7049,10 @@
 				F45AF6FC212960A3000F88A6 /* FacePositionXSensor.swift */,
 				F45AF702212960D4000F88A6 /* FacePositionYSensor.swift */,
 				4CE3D68A2107A89B00005629 /* FaceDetectionManager.swift */,
+				49519D2E27DCD6B100E32E88 /* SecondFaceDetectedSensor.swift */,
+				49519D3227DCE0EC00E32E88 /* SecondFacePositionXSensor.swift */,
+				49519D3427DCE0FE00E32E88 /* SecondFacePositionYSensor.swift */,
+				49519D3627DCE11700E32E88 /* SecondFaceSizeSensor.swift */,
 			);
 			path = Camera;
 			sourceTree = "<group>";
@@ -7460,6 +7480,7 @@
 				180DDF422506800600EA526C /* AnalyticsMock.swift */,
 				59B7A8D22504E83F001C736A /* StageMock.swift */,
 				2E5E767A260DEB9400D4DEBD /* WebRequestDownloaderMock.swift */,
+				49358BC827DB3A37005F96B4 /* VNFaceObservationMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -11123,6 +11144,7 @@
 				E5EC6D4A26B00F3E0031F13A /* Air_fight_0.5_09993.xml in Resources */,
 				2ED4187A241120B000AFE2FD /* InsertItemIntoUserListBrick0991.xml in Resources */,
 				2ED41877241120B000AFE2FD /* LogicBricks_0991.xml in Resources */,
+				49530A8427FDDC04003A9E24 /* BackwardsCompatibleFaceDetectionSensors.xml in Resources */,
 				2ED417D4241120AF00AFE2FD /* Demonstration_097.xml in Resources */,
 				2ED417B1241120AF00AFE2FD /* Tic_Tac_Toe_Master_091.xml in Resources */,
 				E5DAAD4626C5477900C2457F /* Pong_Starter_09997.xml in Resources */,
@@ -11409,6 +11431,7 @@
 				4C55CD0324BF2BCD00FB8393 /* EscapingChars_0992.xml in Resources */,
 				CAE3E4EC1B4C509800CC88BD /* test2.png in Resources */,
 				9EE674D62325319B0029D153 /* PlaySameSoundTwiceSameObject.xml in Resources */,
+				49530A8227FDDADC003A9E24 /* FaceDetectionSensors.xml in Resources */,
 				E59108DF26931F88008D254A /* Demonstration_0994.xml in Resources */,
 				9EE674E32325447C0029D153 /* half_seconds_patchwork.mp3 in Resources */,
 				E5DAAD5E26C5485400C2457F /* Sensors_09997.xml in Resources */,
@@ -11918,6 +11941,7 @@
 				4C822660213FA7A400F3D750 /* FaceDetectionSensorTest.swift in Sources */,
 				4C4B4CE623EEA6C00054C861 /* BaseTableViewControllerTests.swift in Sources */,
 				461C7DC025BA0A0C00E50D69 /* SetBackgroundAndWaitBrickTests.swift in Sources */,
+				49358BC927DB3A37005F96B4 /* VNFaceObservationMock.swift in Sources */,
 				4C6FE176212D2D2E0067B7D5 /* LetterFunctionTest.swift in Sources */,
 				4CEB22511B95E47500B3BE2F /* BrickMoveManagerRepeatTests.m in Sources */,
 				4C1329041CD9259900F16E48 /* AudioManagerTests.swift in Sources */,
@@ -12327,6 +12351,7 @@
 				4C0F9F34204ADC4000E71B2D /* PreviousLookBrick.swift in Sources */,
 				92B46FA31BC7BDF7004980C1 /* ArduinoSendPWMValueBrickCell.m in Sources */,
 				4CB2CFA11D7AD762009F3034 /* SetColorBrick.m in Sources */,
+				49519D3327DCE0EC00E32E88 /* SecondFacePositionXSensor.swift in Sources */,
 				057B183026DD0A3400C47E60 /* StartRunningStitchBrick+CBXMLHandler.swift in Sources */,
 				4C0F9F94204BD29600E71B2D /* ChooseCameraBrickCell.m in Sources */,
 				BA987D0B2194E25A002DAA05 /* WaitUntilBrickCell.m in Sources */,
@@ -12651,6 +12676,7 @@
 				9200C2DB1C8084AA002F5CA4 /* HideTextBrick+CBXMLHandler.m in Sources */,
 				AA74EEDD1BC057B900D1E954 /* ForeverBrick+CBXMLHandler.m in Sources */,
 				4C4778B0267C7B2400CAF398 /* URLSessionJsonExtension.swift in Sources */,
+				49519D2F27DCD6B100E32E88 /* SecondFaceDetectedSensor.swift in Sources */,
 				59EA52BB24FD468900AC6E8D /* WhenConditionScript.swift in Sources */,
 				4C0F9F22204ADBAF00E71B2D /* IfThenLogicEndBrick+CBXMLHandler.m in Sources */,
 				22412CFE26ECE5B70074915C /* PaddingLabel.swift in Sources */,
@@ -12744,6 +12770,7 @@
 				C8A0338326064F3C00702911 /* SetTempoToBrick+CBXMLHandler.swift in Sources */,
 				9218B2101CC4AB75007B4C60 /* PipetteTool.m in Sources */,
 				4C0F9F66204BD18600E71B2D /* SayBubbleBrick+CBXMLHandler.m in Sources */,
+				49519D3527DCE0FE00E32E88 /* SecondFacePositionYSensor.swift in Sources */,
 				923503901BA707DE00021F6A /* BaseLoginViewController.m in Sources */,
 				4C595F4921CAEB7E0097D850 /* NotEqualOperator.swift in Sources */,
 				4C11795120AEBE38006C6E32 /* LongitudeSensor.swift in Sources */,
@@ -12905,6 +12932,7 @@
 				E50579C425B0BC68003FAEE5 /* CollisionFunction.swift in Sources */,
 				F4E6E58C210DFEFE00D86FE6 /* PiFunction.swift in Sources */,
 				4CF0729220D6697300F93AB5 /* LocationAccuracySensor.swift in Sources */,
+				49519D3727DCE11700E32E88 /* SecondFaceSizeSensor.swift in Sources */,
 				4C724E601B4D3E8C00E27479 /* Parser.m in Sources */,
 				92DFB0161A38949E00FA9B0F /* InternFormulaState.m in Sources */,
 				AA74F0C51BC05FCE00D1E954 /* PlaySoundBrickCell.m in Sources */,

--- a/src/Catty/Defines/LanguageTranslationDefines.h
+++ b/src/Catty/Defines/LanguageTranslationDefines.h
@@ -778,10 +778,14 @@
 #define kLocalizedInternet NSLocalizedString(@"Internet", nil)
 #define kLocalizedNotAvailable NSLocalizedString(@"not available. Continue anyway?", nil)
 
-#define kUIFESensorFaceDetected NSLocalizedString(@"face detected", nil)
-#define kUIFESensorFaceSize NSLocalizedString(@"facesize", nil)
-#define kUIFESensorFaceX NSLocalizedString(@"faceposition x", nil)
-#define kUIFESensorFaceY NSLocalizedString(@"faceposition y", nil)
+#define kUIFESensorFaceDetected NSLocalizedString(@"first face visible", nil)
+#define kUIFESensorFaceSize NSLocalizedString(@"first face size", nil)
+#define kUIFESensorFaceX NSLocalizedString(@"first face x position", nil)
+#define kUIFESensorFaceY NSLocalizedString(@"first face y position", nil)
+#define kUIFESensorSecondFaceDetected NSLocalizedString(@"second face visible", nil)
+#define kUIFESensorSecondFaceSize NSLocalizedString(@"second face size", nil)
+#define kUIFESensorSecondFaceX NSLocalizedString(@"second face x position", nil)
+#define kUIFESensorSecondFaceY NSLocalizedString(@"second face y position", nil)
 
 #define kUIFEUnknownElementType NSLocalizedString(@"Unknown Element", nil)
 

--- a/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
+++ b/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
@@ -778,10 +778,14 @@ let kLocalizedSensorLED = NSLocalizedString("LED", comment: "")
 let kLocalizedInternet = NSLocalizedString("Internet", comment: "")
 let kLocalizedNotAvailable = NSLocalizedString("not available. Continue anyway?", comment: "")
 
-let kUIFESensorFaceDetected = NSLocalizedString("face detected", comment: "")
-let kUIFESensorFaceSize = NSLocalizedString("facesize", comment: "")
-let kUIFESensorFaceX = NSLocalizedString("faceposition x", comment: "")
-let kUIFESensorFaceY = NSLocalizedString("faceposition y", comment: "")
+let kUIFESensorFaceDetected = NSLocalizedString("first face visible", comment: "")
+let kUIFESensorFaceSize = NSLocalizedString("first face size", comment: "")
+let kUIFESensorFaceX = NSLocalizedString("first face x position", comment: "")
+let kUIFESensorFaceY = NSLocalizedString("first face y position", comment: "")
+let kUIFESensorSecondFaceDetected = NSLocalizedString("second face visible", comment: "")
+let kUIFESensorSecondFaceSize = NSLocalizedString("second face size", comment: "")
+let kUIFESensorSecondFaceX = NSLocalizedString("second face x position", comment: "")
+let kUIFESensorSecondFaceY = NSLocalizedString("second face y position", comment: "")
 
 let kUIFEUnknownElementType = NSLocalizedString("Unknown Element", comment: "")
 

--- a/src/Catty/PlayerEngine/Sensors/Camera/FaceDetectedSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FaceDetectedSensor.swift
@@ -39,7 +39,7 @@ class FaceDetectedSensor: DeviceDoubleSensor {
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
-        guard let isFaceDetected = self.getFaceDetectionManager()?.isFaceDetected else { return type(of: self).defaultRawValue }
+        guard let isFaceDetected = self.getFaceDetectionManager()?.isFaceDetected[0] else { return type(of: self).defaultRawValue }
         return isFaceDetected ? 1.0 : 0.0
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Camera/FacePositionYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FacePositionYSensor.swift
@@ -22,10 +22,10 @@
 
 class FacePositionYSensor: DeviceDoubleSensor {
 
-    static let tag = "FACE_Y_POSITION"
+    static let tag = "FACE_Y"
     static let name = kUIFESensorFaceY
     static let defaultRawValue = 0.0
-    static let position = 240
+    static let position = 250
     static let requiredResource = ResourceType.faceDetection
 
     let getFaceDetectionManager: () -> FaceDetectionManagerProtocol?
@@ -41,7 +41,7 @@ class FacePositionYSensor: DeviceDoubleSensor {
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
-        guard let positionY = self.getFaceDetectionManager()?.facePositionRatioFromBottom else { return type(of: self).defaultRawValue }
+        guard let positionY = self.getFaceDetectionManager()?.facePositionRatioFromBottom[0] else { return type(of: self).defaultRawValue }
         return positionY
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Camera/FaceSizeSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/FaceSizeSensor.swift
@@ -25,7 +25,7 @@ class FaceSizeSensor: DeviceDoubleSensor {
     static let tag = "FACE_SIZE"
     static let name = kUIFESensorFaceSize
     static let defaultRawValue = 0.0
-    static let position = 250
+    static let position = 230
     static let requiredResource = ResourceType.faceDetection
 
     let getFaceDetectionManager: () -> FaceDetectionManagerProtocol?
@@ -41,7 +41,7 @@ class FaceSizeSensor: DeviceDoubleSensor {
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
-        guard let faceSize = self.getFaceDetectionManager()?.faceSizeRatio else { return type(of: self).defaultRawValue }
+        guard let faceSize = self.getFaceDetectionManager()?.faceSizeRatio[0] else { return type(of: self).defaultRawValue }
         return Double(faceSize)
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Camera/SecondFaceDetectedSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/SecondFaceDetectedSensor.swift
@@ -20,22 +20,18 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-class FacePositionXSensor: DeviceDoubleSensor {
+class SecondFaceDetectedSensor: DeviceDoubleSensor {
 
-    static let tag = "FACE_X"
-    static let name = kUIFESensorFaceX
+    static let tag = "SECOND_FACE_DETECTED"
+    static let name = kUIFESensorSecondFaceDetected
     static let defaultRawValue = 0.0
-    static let position = 240
+    static let position = 260
     static let requiredResource = ResourceType.faceDetection
 
     let getFaceDetectionManager: () -> FaceDetectionManagerProtocol?
-    let stageWidth: Double?
-    let stageHeight: Double?
 
-    init(stageSize: CGSize, faceDetectionManagerGetter: @escaping () -> FaceDetectionManagerProtocol?) {
+    init(faceDetectionManagerGetter: @escaping () -> FaceDetectionManagerProtocol?) {
         self.getFaceDetectionManager = faceDetectionManagerGetter
-        self.stageWidth = Double(stageSize.width)
-        self.stageHeight = Double(stageSize.height)
     }
 
     func tag() -> String {
@@ -43,18 +39,12 @@ class FacePositionXSensor: DeviceDoubleSensor {
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
-        guard let positionX = self.getFaceDetectionManager()?.facePositionRatioFromLeft[0] else { return type(of: self).defaultRawValue }
-        return positionX
+        guard let isFaceDetected = self.getFaceDetectionManager()?.isFaceDetected[1] else { return type(of: self).defaultRawValue }
+        return isFaceDetected ? 1.0 : 0.0
     }
 
     func convertToStandardized(rawValue: Double) -> Double {
-        if rawValue == type(of: self).defaultRawValue {
-            return rawValue
-        }
-        guard let stageWidth = self.stageWidth, let stageHeight = self.stageHeight, let frameHeight = self.getFaceDetectionManager()?.faceDetectionFrameSize?.height else {
-            return type(of: self).defaultRawValue }
-        let scaledPreviewWidthRatio = stageHeight / frameHeight
-        return (stageWidth * rawValue - stageWidth / 2.0) * scaledPreviewWidthRatio
+        rawValue
     }
 
     func formulaEditorSections(for spriteObject: SpriteObject) -> [FormulaEditorSection] {

--- a/src/Catty/PlayerEngine/Sensors/Camera/SecondFacePositionXSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/SecondFacePositionXSensor.swift
@@ -20,12 +20,12 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-class FacePositionXSensor: DeviceDoubleSensor {
+class SecondFacePositionXSensor: DeviceDoubleSensor {
 
-    static let tag = "FACE_X"
-    static let name = kUIFESensorFaceX
+    static let tag = "SECOND_FACE_X"
+    static let name = kUIFESensorSecondFaceX
     static let defaultRawValue = 0.0
-    static let position = 240
+    static let position = 280
     static let requiredResource = ResourceType.faceDetection
 
     let getFaceDetectionManager: () -> FaceDetectionManagerProtocol?
@@ -43,7 +43,7 @@ class FacePositionXSensor: DeviceDoubleSensor {
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
-        guard let positionX = self.getFaceDetectionManager()?.facePositionRatioFromLeft[0] else { return type(of: self).defaultRawValue }
+        guard let positionX = self.getFaceDetectionManager()?.facePositionRatioFromLeft[1] else { return type(of: self).defaultRawValue }
         return positionX
     }
 

--- a/src/Catty/PlayerEngine/Sensors/Camera/SecondFacePositionYSensor.swift
+++ b/src/Catty/PlayerEngine/Sensors/Camera/SecondFacePositionYSensor.swift
@@ -20,21 +20,19 @@
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
 
-class FacePositionXSensor: DeviceDoubleSensor {
+class SecondFacePositionYSensor: DeviceDoubleSensor {
 
-    static let tag = "FACE_X"
-    static let name = kUIFESensorFaceX
+    static let tag = "SECOND_FACE_Y"
+    static let name = kUIFESensorSecondFaceY
     static let defaultRawValue = 0.0
-    static let position = 240
+    static let position = 290
     static let requiredResource = ResourceType.faceDetection
 
     let getFaceDetectionManager: () -> FaceDetectionManagerProtocol?
-    let stageWidth: Double?
     let stageHeight: Double?
 
     init(stageSize: CGSize, faceDetectionManagerGetter: @escaping () -> FaceDetectionManagerProtocol?) {
         self.getFaceDetectionManager = faceDetectionManagerGetter
-        self.stageWidth = Double(stageSize.width)
         self.stageHeight = Double(stageSize.height)
     }
 
@@ -43,18 +41,16 @@ class FacePositionXSensor: DeviceDoubleSensor {
     }
 
     func rawValue(landscapeMode: Bool) -> Double {
-        guard let positionX = self.getFaceDetectionManager()?.facePositionRatioFromLeft[0] else { return type(of: self).defaultRawValue }
-        return positionX
+        guard let positionY = self.getFaceDetectionManager()?.facePositionRatioFromBottom[1] else { return type(of: self).defaultRawValue }
+        return positionY
     }
 
     func convertToStandardized(rawValue: Double) -> Double {
         if rawValue == type(of: self).defaultRawValue {
             return rawValue
         }
-        guard let stageWidth = self.stageWidth, let stageHeight = self.stageHeight, let frameHeight = self.getFaceDetectionManager()?.faceDetectionFrameSize?.height else {
-            return type(of: self).defaultRawValue }
-        let scaledPreviewWidthRatio = stageHeight / frameHeight
-        return (stageWidth * rawValue - stageWidth / 2.0) * scaledPreviewWidthRatio
+        guard let stageHeight = self.stageHeight else { return type(of: self).defaultRawValue }
+        return stageHeight * rawValue - stageHeight / 2.0
     }
 
     func formulaEditorSections(for spriteObject: SpriteObject) -> [FormulaEditorSection] {

--- a/src/Catty/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en.lproj/Localizable.strings
@@ -713,18 +713,6 @@
 "FA" = "FA";
 
 /* No comment provided by engineer. */
-"face detected" = "face detected";
-
-/* No comment provided by engineer. */
-"faceposition x" = "faceposition x";
-
-/* No comment provided by engineer. */
-"faceposition y" = "faceposition y";
-
-/* No comment provided by engineer. */
-"facesize" = "facesize";
-
-/* No comment provided by engineer. */
 "Failed to import item" = "Failed to import item";
 
 /* No comment provided by engineer. */
@@ -753,6 +741,18 @@
 
 /* paint */
 "Fill" = "Fill";
+
+/* No comment provided by engineer. */
+"first face size" = "first face size";
+
+/* No comment provided by engineer. */
+"first face visible" = "first face visible";
+
+/* No comment provided by engineer. */
+"first face x position" = "first face x position";
+
+/* No comment provided by engineer. */
+"first face y position" = "first face y position";
 
 /* No comment provided by engineer. */
 "Flashlight off" = "Flashlight off";
@@ -1584,6 +1584,18 @@
 
 /* No comment provided by engineer. */
 "second " = "second ";
+
+/* No comment provided by engineer. */
+"second face size" = "second face size";
+
+/* No comment provided by engineer. */
+"second face visible" = "second face visible";
+
+/* No comment provided by engineer. */
+"second face x position" = "second face x position";
+
+/* No comment provided by engineer. */
+"second face y position" = "second face y position";
 
 /* No comment provided by engineer. */
 "seconds" = "seconds";

--- a/src/Catty/Setup/CatrobatSetup+Sensors.swift
+++ b/src/Catty/Setup/CatrobatSetup+Sensors.swift
@@ -60,6 +60,10 @@ extension CatrobatSetup {
          FaceSizeSensor(stageSize: stageSize, faceDetectionManagerGetter: { faceDetectionManager }),
          FacePositionXSensor(stageSize: stageSize, faceDetectionManagerGetter: { faceDetectionManager }),
          FacePositionYSensor(stageSize: stageSize, faceDetectionManagerGetter: { faceDetectionManager }),
+         SecondFaceDetectedSensor(faceDetectionManagerGetter: { faceDetectionManager }),
+         SecondFaceSizeSensor(stageSize: stageSize, faceDetectionManagerGetter: { faceDetectionManager }),
+         SecondFacePositionXSensor(stageSize: stageSize, faceDetectionManagerGetter: { faceDetectionManager }),
+         SecondFacePositionYSensor(stageSize: stageSize, faceDetectionManagerGetter: { faceDetectionManager }),
 
          PhiroFrontLeftSensor(bluetoothServiceGetter: { bluetoothService }),
          PhiroFrontRightSensor(bluetoothServiceGetter: { bluetoothService }),

--- a/src/Catty/XML/XMLHandler/Formula/FormulaElement+CBXMLHandler.m
+++ b/src/Catty/XML/XMLHandler/Formula/FormulaElement+CBXMLHandler.m
@@ -45,6 +45,14 @@
     GDataXMLElement *valueElement = [xmlElement childWithElementName:@"value"];
     NSString *stringValue = [valueElement stringValue];
     
+    if ([type isEqualToString:@"SENSOR"]) {
+        if ([stringValue isEqualToString:@"FACE_X_POSITION"]) {
+            stringValue = @"FACE_X";
+        } else if ([stringValue isEqualToString:@"FACE_Y_POSITION"]) {
+            stringValue = @"FACE_Y";
+        }
+    }
+    
     FormulaElement *formulaTree = [[FormulaElement alloc] initWithType:type
                                                                  value:stringValue
                                                              leftChild:nil

--- a/src/CattyTests/Mocks/VNFaceObservationMock.swift
+++ b/src/CattyTests/Mocks/VNFaceObservationMock.swift
@@ -19,20 +19,21 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
+import Vision
 
-protocol FaceDetectionManagerProtocol {
+class VNFaceObservationMock: VNFaceObservation {
+    private let mockedBoundingBox: CGRect
 
-    var isFaceDetected: [Bool] { get }
-    var facePositionRatioFromLeft: [Double?] { get }
-    var facePositionRatioFromBottom: [Double?] { get }
-    var faceSizeRatio: [Double?] { get }
-    var faceDetectionFrameSize: CGSize? { get }
+    init(boundingBox: CGRect) {
+        self.mockedBoundingBox = boundingBox
+        super.init()
+    }
+    required init(coder decoder: NSCoder) {
+        self.mockedBoundingBox = CGRect.zero
+        super.init(coder: decoder)!
+    }
 
-    func start()
-
-    func stop()
-
-    func reset()
-
-    func available() -> Bool
+    override var boundingBox: CGRect {
+        mockedBoundingBox
+    }
 }

--- a/src/CattyTests/PlayerEngine/Sensors/Camera/FaceDetectionSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Camera/FaceDetectionSensorTest.swift
@@ -26,61 +26,78 @@ import XCTest
 
 final class FaceDetectionSensorTest: XCTestCase {
 
-    var sensor: FaceDetectedSensor!
+    var faceDetectedSensors = [DeviceDoubleSensor]()
     var cameraManagerMock: FaceDetectionManagerMock!
 
     func testDefaultRawValue() {
-        let sensor = FaceDetectedSensor { nil }
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        let firstFaceSensor = FaceDetectedSensor { nil }
+        XCTAssertEqual(type(of: firstFaceSensor).defaultRawValue, firstFaceSensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: firstFaceSensor).defaultRawValue, firstFaceSensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+
+        let secondFaceSensor = SecondFaceDetectedSensor { nil }
+        XCTAssertEqual(type(of: secondFaceSensor).defaultRawValue, secondFaceSensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: secondFaceSensor).defaultRawValue, secondFaceSensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     override func setUp() {
         super.setUp()
         self.cameraManagerMock = FaceDetectionManagerMock()
-        self.sensor = FaceDetectedSensor { [ weak self ] in self?.cameraManagerMock }
+        self.faceDetectedSensors.append(FaceDetectedSensor { [ weak self ] in self?.cameraManagerMock })
+        self.faceDetectedSensors.append(SecondFaceDetectedSensor { [ weak self ] in self?.cameraManagerMock })
     }
 
     override func tearDown() {
         self.cameraManagerMock = nil
-        self.sensor = nil
+        self.faceDetectedSensors.removeAll()
         super.tearDown()
     }
 
     func testRawValue() {
-        self.cameraManagerMock.isFaceDetected = true
-        XCTAssertEqual(1, self.sensor.rawValue(landscapeMode: false))
-        XCTAssertEqual(1, self.sensor.rawValue(landscapeMode: true))
+        for faceIndex in 0..<FaceDetectionManager.maxFaceCount {
+            self.cameraManagerMock.isFaceDetected[faceIndex] = true
+            XCTAssertEqual(1, self.faceDetectedSensors[faceIndex].rawValue(landscapeMode: false))
+            XCTAssertEqual(1, self.faceDetectedSensors[faceIndex].rawValue(landscapeMode: true))
 
-        self.cameraManagerMock.isFaceDetected = false
-        XCTAssertEqual(0, self.sensor.rawValue(landscapeMode: false))
-        XCTAssertEqual(0, self.sensor.rawValue(landscapeMode: true))
+            self.cameraManagerMock.isFaceDetected[faceIndex] = false
+            XCTAssertEqual(0, self.faceDetectedSensors[faceIndex].rawValue(landscapeMode: false))
+            XCTAssertEqual(0, self.faceDetectedSensors[faceIndex].rawValue(landscapeMode: true))
+        }
     }
 
     func testConvertToStandardized() {
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0))
-        XCTAssertEqual(1, sensor.convertToStandardized(rawValue: 1))
+        for faceIndex in 0..<FaceDetectionManager.maxFaceCount {
+            XCTAssertEqual(0, faceDetectedSensors[faceIndex].convertToStandardized(rawValue: 0))
+            XCTAssertEqual(1, faceDetectedSensors[faceIndex].convertToStandardized(rawValue: 1))
+        }
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
-        let standardizedValue = sensor.standardizedValue(landscapeMode: false)
-        let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
-        XCTAssertEqual(convertToStandardizedValue, standardizedValue)
-        XCTAssertEqual(standardizedValue, standardizedValueLandscape)
+        for faceIndex in 0..<FaceDetectionManager.maxFaceCount {
+            let convertToStandardizedValue = faceDetectedSensors[faceIndex].convertToStandardized(rawValue: faceDetectedSensors[faceIndex].rawValue(landscapeMode: false))
+            let standardizedValue = faceDetectedSensors[faceIndex].standardizedValue(landscapeMode: false)
+            let standardizedValueLandscape = faceDetectedSensors[faceIndex].standardizedValue(landscapeMode: true)
+            XCTAssertEqual(convertToStandardizedValue, standardizedValue)
+            XCTAssertEqual(standardizedValue, standardizedValueLandscape)
+        }
     }
 
     func testTag() {
-        XCTAssertEqual("FACE_DETECTED", sensor.tag())
+        XCTAssertEqual("FACE_DETECTED", faceDetectedSensors[0].tag())
+        XCTAssertEqual("SECOND_FACE_DETECTED", faceDetectedSensors[1].tag())
     }
 
     func testRequiredResources() {
-        XCTAssertEqual(ResourceType.faceDetection, type(of: sensor).requiredResource)
+        for faceIndex in 0..<FaceDetectionManager.maxFaceCount {
+            XCTAssertEqual(ResourceType.faceDetection, type(of: faceDetectedSensors[faceIndex]).requiredResource)
+        }
     }
 
     func testFormulaEditorSections() {
-        let sections = sensor.formulaEditorSections(for: SpriteObject())
-        XCTAssertEqual(1, sections.count)
-        XCTAssertEqual(.sensors(position: type(of: sensor).position, subsection: .visual), sections.first)
+        for faceIndex in 0..<FaceDetectionManager.maxFaceCount {
+            let sections = faceDetectedSensors[faceIndex].formulaEditorSections(for: SpriteObject())
+            XCTAssertEqual(1, sections.count)
+            let position = faceIndex == 0 ? FaceDetectedSensor.position : SecondFaceDetectedSensor.position
+            XCTAssertEqual(.sensors(position: position, subsection: .visual), sections.first)
+        }
     }
 }

--- a/src/CattyTests/PlayerEngine/Sensors/Camera/FaceSizeSensorTest.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Camera/FaceSizeSensorTest.swift
@@ -26,7 +26,7 @@ import XCTest
 
 final class FaceSizeSensorTest: XCTestCase {
 
-    var sensor: FaceSizeSensor!
+    var faceSizeSensors = [DeviceDoubleSensor]()
     var cameraManagerMock: FaceDetectionManagerMock!
     var stageSize: CGSize!
 
@@ -34,70 +34,87 @@ final class FaceSizeSensorTest: XCTestCase {
         super.setUp()
         self.cameraManagerMock = FaceDetectionManagerMock()
         self.stageSize = CGSize(width: 640, height: 1136)
-        self.sensor = FaceSizeSensor(stageSize: stageSize, faceDetectionManagerGetter: { [ weak self ] in self?.cameraManagerMock })
+        self.faceSizeSensors.append(FaceSizeSensor(stageSize: stageSize, faceDetectionManagerGetter: { [ weak self ] in self?.cameraManagerMock }))
+        self.faceSizeSensors.append(SecondFaceSizeSensor(stageSize: stageSize, faceDetectionManagerGetter: { [ weak self ] in self?.cameraManagerMock }))
     }
 
     override func tearDown() {
         self.cameraManagerMock = nil
-        self.sensor = nil
+        self.faceSizeSensors.removeAll()
         super.tearDown()
     }
 
     func testDefaultRawValue() {
-        let sensor = FaceSizeSensor(stageSize: stageSize, faceDetectionManagerGetter: { nil })
+        let firstFaceSizeSensor = FaceSizeSensor(stageSize: stageSize, faceDetectionManagerGetter: { nil })
+        XCTAssertEqual(type(of: firstFaceSizeSensor).defaultRawValue, firstFaceSizeSensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: firstFaceSizeSensor).defaultRawValue, firstFaceSizeSensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        let secondFaceSizeSensor = SecondFaceSizeSensor(stageSize: stageSize, faceDetectionManagerGetter: { nil })
+        XCTAssertEqual(type(of: secondFaceSizeSensor).defaultRawValue, secondFaceSizeSensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
+        XCTAssertEqual(type(of: secondFaceSizeSensor).defaultRawValue, secondFaceSizeSensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
     }
 
     func testRawValue() {
-        self.cameraManagerMock.faceSizeRatio = 0.2
-        XCTAssertEqual(0.2, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(0.2, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        for faceIndex in 0..<FaceDetectionManager.maxFaceCount {
+            self.cameraManagerMock.faceSizeRatio[faceIndex] = 0.2
+            XCTAssertEqual(0.2, faceSizeSensors[faceIndex].rawValue(landscapeMode: false), accuracy: Double.epsilon)
+            XCTAssertEqual(0.2, faceSizeSensors[faceIndex].rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
-        self.cameraManagerMock.faceSizeRatio = 0.5
-        XCTAssertEqual(0.5, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(0.5, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+            self.cameraManagerMock.faceSizeRatio[faceIndex] = 0.5
+            XCTAssertEqual(0.5, faceSizeSensors[faceIndex].rawValue(landscapeMode: false), accuracy: Double.epsilon)
+            XCTAssertEqual(0.5, faceSizeSensors[faceIndex].rawValue(landscapeMode: true), accuracy: Double.epsilon)
 
-        self.cameraManagerMock.faceSizeRatio = 1.0
-        XCTAssertEqual(1.0, sensor.rawValue(landscapeMode: false), accuracy: Double.epsilon)
-        XCTAssertEqual(1.0, sensor.rawValue(landscapeMode: true), accuracy: Double.epsilon)
+            self.cameraManagerMock.faceSizeRatio[faceIndex] = 1.0
+            XCTAssertEqual(1.0, faceSizeSensors[faceIndex].rawValue(landscapeMode: false), accuracy: Double.epsilon)
+            XCTAssertEqual(1.0, faceSizeSensors[faceIndex].rawValue(landscapeMode: true), accuracy: Double.epsilon)
+        }
     }
 
     func testConvertToStandardized() {
-        let frameWidth = 400
-        let scaleFactor = Double(self.stageSize.width) / Double(frameWidth)
-        self.cameraManagerMock.faceDetectionFrameSize = CGSize(width: frameWidth, height: 700)
+        for faceIndex in 0..<FaceDetectionManager.maxFaceCount {
+            let frameWidth = 400
+            let scaleFactor = Double(self.stageSize.width) / Double(frameWidth)
+            self.cameraManagerMock.faceDetectionFrameSize = CGSize(width: frameWidth, height: 700)
 
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: 0), accuracy: Double.epsilon)
-        XCTAssertEqual(0.5 * scaleFactor * 100, sensor.convertToStandardized(rawValue: 0.5), accuracy: Double.epsilon)
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 1), accuracy: Double.epsilon)
-        XCTAssertEqual(0, sensor.convertToStandardized(rawValue: -20), accuracy: Double.epsilon)
-        XCTAssertEqual(100, sensor.convertToStandardized(rawValue: 150), accuracy: Double.epsilon)
+            XCTAssertEqual(0, faceSizeSensors[faceIndex].convertToStandardized(rawValue: 0), accuracy: Double.epsilon)
+            XCTAssertEqual(0.5 * scaleFactor * 100, faceSizeSensors[faceIndex].convertToStandardized(rawValue: 0.5), accuracy: Double.epsilon)
+            XCTAssertEqual(100, faceSizeSensors[faceIndex].convertToStandardized(rawValue: 1), accuracy: Double.epsilon)
+            XCTAssertEqual(0, faceSizeSensors[faceIndex].convertToStandardized(rawValue: -20), accuracy: Double.epsilon)
+            XCTAssertEqual(100, faceSizeSensors[faceIndex].convertToStandardized(rawValue: 150), accuracy: Double.epsilon)
 
-        self.cameraManagerMock.faceDetectionFrameSize = nil
-        XCTAssertEqual(type(of: sensor).defaultRawValue, sensor.convertToStandardized(rawValue: 20), accuracy: Double.epsilon)
+            self.cameraManagerMock.faceDetectionFrameSize = nil
+            XCTAssertEqual(type(of: faceSizeSensors[faceIndex]).defaultRawValue, faceSizeSensors[faceIndex].convertToStandardized(rawValue: 20), accuracy: Double.epsilon)
+        }
     }
 
     func testStandardizedValue() {
-        let convertToStandardizedValue = sensor.convertToStandardized(rawValue: sensor.rawValue(landscapeMode: false))
-        let standardizedValue = sensor.standardizedValue(landscapeMode: false)
-        let standardizedValueLandscape = sensor.standardizedValue(landscapeMode: true)
-        XCTAssertEqual(convertToStandardizedValue, standardizedValue)
-        XCTAssertEqual(standardizedValue, standardizedValueLandscape)
+        for faceIndex in 0..<FaceDetectionManager.maxFaceCount {
+            let convertToStandardizedValue = faceSizeSensors[faceIndex].convertToStandardized(rawValue: faceSizeSensors[faceIndex].rawValue(landscapeMode: false))
+            let standardizedValue = faceSizeSensors[faceIndex].standardizedValue(landscapeMode: false)
+            let standardizedValueLandscape = faceSizeSensors[faceIndex].standardizedValue(landscapeMode: true)
+            XCTAssertEqual(convertToStandardizedValue, standardizedValue)
+            XCTAssertEqual(standardizedValue, standardizedValueLandscape)
+        }
     }
 
     func testTag() {
-        XCTAssertEqual("FACE_SIZE", sensor.tag())
+        XCTAssertEqual("FACE_SIZE", faceSizeSensors[0].tag())
+        XCTAssertEqual("SECOND_FACE_SIZE", faceSizeSensors[1].tag())
     }
 
     func testRequiredResources() {
-        XCTAssertEqual(ResourceType.faceDetection, type(of: sensor).requiredResource)
+        for faceIndex in 0..<FaceDetectionManager.maxFaceCount {
+            XCTAssertEqual(ResourceType.faceDetection, type(of: faceSizeSensors[faceIndex]).requiredResource)
+        }
     }
 
     func testFormulaEditorSections() {
-        let sections = sensor.formulaEditorSections(for: SpriteObject())
-        XCTAssertEqual(1, sections.count)
-        XCTAssertEqual(.sensors(position: type(of: sensor).position, subsection: .visual), sections.first)
+        for faceIndex in 0..<FaceDetectionManager.maxFaceCount {
+            let sections = faceSizeSensors[faceIndex].formulaEditorSections(for: SpriteObject())
+            XCTAssertEqual(1, sections.count)
+
+            let position = faceIndex == 0 ? FaceSizeSensor.position : SecondFaceSizeSensor.position
+            XCTAssertEqual(.sensors(position: position, subsection: .visual), sections.first)
+        }
     }
 }

--- a/src/CattyTests/PlayerEngine/Sensors/Mocks/FaceDetectionManagerMock.swift
+++ b/src/CattyTests/PlayerEngine/Sensors/Mocks/FaceDetectionManagerMock.swift
@@ -38,4 +38,8 @@ final class FaceDetectionManagerMock: FaceDetectionManager {
     override func available() -> Bool {
         isAvailable
     }
+
+    func setFaceDetectionFrameSize(_ frameSize: CGSize) {
+        self.faceDetectionFrameSize = frameSize
+    }
 }

--- a/src/CattyTests/Resources/ParserTests/Custom/Sensors/BackwardsCompatibleFaceDetectionSensors.xml
+++ b/src/CattyTests/Resources/ParserTests/Custom/Sensors/BackwardsCompatibleFaceDetectionSensors.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<program>
+  <header>
+    <applicationBuildName>Catty</applicationBuildName>
+    <applicationBuildNumber>47</applicationBuildNumber>
+    <applicationName>Pocket Code</applicationName>
+    <applicationVersion>0.6.19</applicationVersion>
+    <catrobatLanguageVersion>0.9993</catrobatLanguageVersion>
+    <dateTimeUpload/>
+    <description/>
+    <deviceName>iPhone11,2</deviceName>
+    <isCastProject>false</isCastProject>
+    <landscapeMode>false</landscapeMode>
+    <mediaLicense>https://developer.catrobat.org/ccbysa_v4</mediaLicense>
+    <platform>iOS</platform>
+    <platformVersion>15.3</platformVersion>
+    <programLicense>https://developer.catrobat.org/agpl_v3</programLicense>
+    <programName>FaceDetectionSensors</programName>
+    <remixOf/>
+    <scenesEnabled>true</scenesEnabled>
+    <screenHeight>2436</screenHeight>
+    <screenMode>STRETCH</screenMode>
+    <screenWidth>1125</screenWidth>
+    <tags/>
+    <url/>
+    <userHandle/>
+  </header>
+  <settings/>
+  <scenes>
+    <scene>
+      <name>Scene 1</name>
+      <objectList>
+        <object type="SingleSprite" name="Background">
+          <lookList/>
+          <soundList/>
+          <scriptList>
+            <script type="StartScript">
+              <brickList>
+                <brick type="ChooseCameraBrick">
+                  <commentedOut>false</commentedOut>
+                  <spinnerSelectionID>0</spinnerSelectionID>
+                </brick>
+                <brick type="CameraBrick">
+                  <commentedOut>false</commentedOut>
+                  <spinnerSelectionID>1</spinnerSelectionID>
+                </brick>
+              </brickList>
+              <commentedOut>false</commentedOut>
+            </script>
+          </scriptList>
+          <nfcTagList/>
+          <userVariables/>
+          <userLists/>
+        </object>
+        <object type="SingleSprite" name="FirstFace">
+          <lookList>
+            <look fileName="9372DA6BC628AC3B0FE01EC39128DBBF_look.png" name="look"/>
+          </lookList>
+          <soundList/>
+          <scriptList>
+            <script type="StartScript">
+              <brickList>
+                <brick type="ForeverBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="IfLogicBeginBrick">
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="IF_CONDITION">
+                      <type>SENSOR</type>
+                      <value>FACE_DETECTED</value>
+                    </formula>
+                  </formulaList>
+                </brick>
+                <brick type="SetSizeToBrick">
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="SIZE">
+                      <type>SENSOR</type>
+                      <value>FACE_SIZE</value>
+                    </formula>
+                  </formulaList>
+                </brick>
+                <brick type="PlaceAtBrick">
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="Y_POSITION">
+                      <type>SENSOR</type>
+                      <value>FACE_Y_POSITION</value>
+                    </formula>
+                    <formula category="X_POSITION">
+                      <type>SENSOR</type>
+                      <value>FACE_X_POSITION</value>
+                    </formula>
+                  </formulaList>
+                </brick>
+                <brick type="ShowBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="IfLogicElseBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="HideBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="IfLogicEndBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="LoopEndlessBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+              </brickList>
+              <commentedOut>false</commentedOut>
+            </script>
+          </scriptList>
+          <nfcTagList/>
+          <userVariables/>
+          <userLists/>
+        </object>
+      </objectList>
+    </scene>
+  </scenes>
+  <programVariableList/>
+  <programListOfLists/>
+</program>
+

--- a/src/CattyTests/Resources/ParserTests/Custom/Sensors/FaceDetectionSensors.xml
+++ b/src/CattyTests/Resources/ParserTests/Custom/Sensors/FaceDetectionSensors.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<program>
+  <header>
+    <applicationBuildName>Catty</applicationBuildName>
+    <applicationBuildNumber>47</applicationBuildNumber>
+    <applicationName>Pocket Code</applicationName>
+    <applicationVersion>0.6.19</applicationVersion>
+    <catrobatLanguageVersion>0.9993</catrobatLanguageVersion>
+    <dateTimeUpload/>
+    <description/>
+    <deviceName>iPhone11,2</deviceName>
+    <isCastProject>false</isCastProject>
+    <landscapeMode>false</landscapeMode>
+    <mediaLicense>https://developer.catrobat.org/ccbysa_v4</mediaLicense>
+    <platform>iOS</platform>
+    <platformVersion>15.3</platformVersion>
+    <programLicense>https://developer.catrobat.org/agpl_v3</programLicense>
+    <programName>FaceDetectionSensors</programName>
+    <remixOf/>
+    <scenesEnabled>true</scenesEnabled>
+    <screenHeight>2436</screenHeight>
+    <screenMode>STRETCH</screenMode>
+    <screenWidth>1125</screenWidth>
+    <tags/>
+    <url/>
+    <userHandle/>
+  </header>
+  <settings/>
+  <scenes>
+    <scene>
+      <name>Scene 1</name>
+      <objectList>
+        <object type="SingleSprite" name="Background">
+          <lookList/>
+          <soundList/>
+          <scriptList>
+            <script type="StartScript">
+              <brickList>
+                <brick type="ChooseCameraBrick">
+                  <commentedOut>false</commentedOut>
+                  <spinnerSelectionID>0</spinnerSelectionID>
+                </brick>
+                <brick type="CameraBrick">
+                  <commentedOut>false</commentedOut>
+                  <spinnerSelectionID>1</spinnerSelectionID>
+                </brick>
+              </brickList>
+              <commentedOut>false</commentedOut>
+            </script>
+          </scriptList>
+          <nfcTagList/>
+          <userVariables/>
+          <userLists/>
+        </object>
+        <object type="SingleSprite" name="FirstFace">
+          <lookList>
+            <look fileName="9372DA6BC628AC3B0FE01EC39128DBBF_look.png" name="look"/>
+          </lookList>
+          <soundList/>
+          <scriptList>
+            <script type="StartScript">
+              <brickList>
+                <brick type="ForeverBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="IfLogicBeginBrick">
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="IF_CONDITION">
+                      <type>SENSOR</type>
+                      <value>FACE_DETECTED</value>
+                    </formula>
+                  </formulaList>
+                </brick>
+                <brick type="SetSizeToBrick">
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="SIZE">
+                      <type>SENSOR</type>
+                      <value>FACE_SIZE</value>
+                    </formula>
+                  </formulaList>
+                </brick>
+                <brick type="PlaceAtBrick">
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="Y_POSITION">
+                      <type>SENSOR</type>
+                      <value>FACE_Y</value>
+                    </formula>
+                    <formula category="X_POSITION">
+                      <type>SENSOR</type>
+                      <value>FACE_X</value>
+                    </formula>
+                  </formulaList>
+                </brick>
+                <brick type="ShowBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="IfLogicElseBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="HideBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="IfLogicEndBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="LoopEndlessBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+              </brickList>
+              <commentedOut>false</commentedOut>
+            </script>
+          </scriptList>
+          <nfcTagList/>
+          <userVariables/>
+          <userLists/>
+        </object>
+        <object type="SingleSprite" name="SecondFace">
+          <lookList>
+            <look fileName="9372DA6BC628AC3B0FE01EC39128DBBF_look.png" name="look"/>
+          </lookList>
+          <soundList/>
+          <scriptList>
+            <script type="StartScript">
+              <brickList>
+                <brick type="ForeverBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="IfLogicBeginBrick">
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="IF_CONDITION">
+                      <type>SENSOR</type>
+                      <value>SECOND_FACE_DETECTED</value>
+                    </formula>
+                  </formulaList>
+                </brick>
+                <brick type="SetSizeToBrick">
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="SIZE">
+                      <type>SENSOR</type>
+                      <value>SECOND_FACE_SIZE</value>
+                    </formula>
+                  </formulaList>
+                </brick>
+                <brick type="PlaceAtBrick">
+                  <commentedOut>false</commentedOut>
+                  <formulaList>
+                    <formula category="Y_POSITION">
+                      <type>SENSOR</type>
+                      <value>SECOND_FACE_Y</value>
+                    </formula>
+                    <formula category="X_POSITION">
+                      <type>SENSOR</type>
+                      <value>SECOND_FACE_X</value>
+                    </formula>
+                  </formulaList>
+                </brick>
+                <brick type="ShowBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="IfLogicElseBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="HideBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="IfLogicEndBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+                <brick type="LoopEndlessBrick">
+                  <commentedOut>false</commentedOut>
+                </brick>
+              </brickList>
+              <commentedOut>false</commentedOut>
+            </script>
+          </scriptList>
+          <nfcTagList/>
+          <userVariables/>
+          <userLists/>
+        </object>
+      </objectList>
+    </scene>
+  </scenes>
+  <programVariableList/>
+  <programListOfLists/>
+</program>

--- a/src/CattyTests/XML/Parser/CatrobatLanguage0.9993/XMLParserTests09993.swift
+++ b/src/CattyTests/XML/Parser/CatrobatLanguage0.9993/XMLParserTests09993.swift
@@ -47,6 +47,75 @@ class XMLParserTests09993: XMLAbstractTest {
         XCTAssertEqual(0, project.unsupportedElements.count)
     }
 
+    func testBackwardsCompatibleFaceDetectionSensors() {
+        let project = self.getProjectForXML(xmlFile: "BackwardsCompatibleFaceDetectionSensors")
+
+        let objectCount = 2
+        XCTAssertEqual(project.scene.objects().count, objectCount, "Invalid object list")
+        let object = project.scene.object(at: 1)!
+        XCTAssertEqual(object.scriptList.count, 1, "Invalid script list")
+        let script = object.scriptList.object(at: 0) as! Script
+        XCTAssertEqual(script.brickList.count, 9, "Invalid brick list")
+
+        let ifLogicBrick = script.brickList.object(at: 1) as! IfLogicBeginBrick
+        let setSizeToBrick = script.brickList.object(at: 2) as! SetSizeToBrick
+        let placeAtBrick = script.brickList.object(at: 3) as! PlaceAtBrick
+
+        XCTAssertEqual(ElementType.SENSOR, ifLogicBrick.ifCondition.formulaTree.type)
+        XCTAssertEqual(ElementType.SENSOR, setSizeToBrick.getFormulas()[0].formulaTree.type)
+        XCTAssertEqual(ElementType.SENSOR, placeAtBrick.getFormulas()[0].formulaTree.type)
+        XCTAssertEqual(ElementType.SENSOR, placeAtBrick.getFormulas()[1].formulaTree.type)
+
+        XCTAssertEqual(FaceDetectedSensor.tag, ifLogicBrick.ifCondition.formulaTree.value)
+        XCTAssertEqual(FaceSizeSensor.tag, setSizeToBrick.getFormulas()[0].formulaTree.value)
+        XCTAssertEqual(FacePositionXSensor.tag, placeAtBrick.getFormulas()[0].formulaTree.value)
+        XCTAssertEqual(FacePositionYSensor.tag, placeAtBrick.getFormulas()[1].formulaTree.value)
+    }
+
+    func testFaceDetectionSensors() {
+        let project = self.getProjectForXML(xmlFile: "FaceDetectionSensors")
+
+        let objectCount = 3
+        XCTAssertEqual(project.scene.objects().count, objectCount, "Invalid object list")
+        var object = project.scene.object(at: 1)!
+        XCTAssertEqual(object.scriptList.count, 1, "Invalid script list")
+        var script = object.scriptList.object(at: 0) as! Script
+        XCTAssertEqual(script.brickList.count, 9, "Invalid brick list")
+
+        var ifLogicBrick = script.brickList.object(at: 1) as! IfLogicBeginBrick
+        var setSizeToBrick = script.brickList.object(at: 2) as! SetSizeToBrick
+        var placeAtBrick = script.brickList.object(at: 3) as! PlaceAtBrick
+
+        XCTAssertEqual(ElementType.SENSOR, ifLogicBrick.ifCondition.formulaTree.type)
+        XCTAssertEqual(ElementType.SENSOR, setSizeToBrick.getFormulas()[0].formulaTree.type)
+        XCTAssertEqual(ElementType.SENSOR, placeAtBrick.getFormulas()[0].formulaTree.type)
+        XCTAssertEqual(ElementType.SENSOR, placeAtBrick.getFormulas()[1].formulaTree.type)
+
+        XCTAssertEqual(FaceDetectedSensor.tag, ifLogicBrick.ifCondition.formulaTree.value)
+        XCTAssertEqual(FaceSizeSensor.tag, setSizeToBrick.getFormulas()[0].formulaTree.value)
+        XCTAssertEqual(FacePositionXSensor.tag, placeAtBrick.getFormulas()[0].formulaTree.value)
+        XCTAssertEqual(FacePositionYSensor.tag, placeAtBrick.getFormulas()[1].formulaTree.value)
+
+        object = project.scene.object(at: 2)!
+        XCTAssertEqual(object.scriptList.count, 1, "Invalid script list")
+        script = object.scriptList.object(at: 0) as! Script
+        XCTAssertEqual(script.brickList.count, 9, "Invalid brick list")
+
+        ifLogicBrick = script.brickList.object(at: 1) as! IfLogicBeginBrick
+        setSizeToBrick = script.brickList.object(at: 2) as! SetSizeToBrick
+        placeAtBrick = script.brickList.object(at: 3) as! PlaceAtBrick
+
+        XCTAssertEqual(ElementType.SENSOR, ifLogicBrick.ifCondition.formulaTree.type)
+        XCTAssertEqual(ElementType.SENSOR, setSizeToBrick.getFormulas()[0].formulaTree.type)
+        XCTAssertEqual(ElementType.SENSOR, placeAtBrick.getFormulas()[0].formulaTree.type)
+        XCTAssertEqual(ElementType.SENSOR, placeAtBrick.getFormulas()[1].formulaTree.type)
+
+        XCTAssertEqual(SecondFaceDetectedSensor.tag, ifLogicBrick.ifCondition.formulaTree.value)
+        XCTAssertEqual(SecondFaceSizeSensor.tag, setSizeToBrick.getFormulas()[0].formulaTree.value)
+        XCTAssertEqual(SecondFacePositionXSensor.tag, placeAtBrick.getFormulas()[0].formulaTree.value)
+        XCTAssertEqual(SecondFacePositionYSensor.tag, placeAtBrick.getFormulas()[1].formulaTree.value)
+    }
+
     func testGlideToBrick() {
         let project = self.getProjectForXML(xmlFile: "ValidProjectAllBricks0998")
         let glideToBrick = (project.scene.object(at: 0)!.scriptList.object(at: 0) as! Script).brickList.object(at: 10) as! Brick

--- a/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
+++ b/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
@@ -778,10 +778,14 @@ let kLocalizedSensorLED = NSLocalizedString("LED", bundle: Bundle(for: LanguageT
 let kLocalizedInternet = NSLocalizedString("Internet", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedNotAvailable = NSLocalizedString("not available. Continue anyway?", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 
-let kUIFESensorFaceDetected = NSLocalizedString("face detected", bundle: Bundle(for: LanguageTranslation.self), comment: "")
-let kUIFESensorFaceSize = NSLocalizedString("facesize", bundle: Bundle(for: LanguageTranslation.self), comment: "")
-let kUIFESensorFaceX = NSLocalizedString("faceposition x", bundle: Bundle(for: LanguageTranslation.self), comment: "")
-let kUIFESensorFaceY = NSLocalizedString("faceposition y", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kUIFESensorFaceDetected = NSLocalizedString("first face visible", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kUIFESensorFaceSize = NSLocalizedString("first face size", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kUIFESensorFaceX = NSLocalizedString("first face x position", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kUIFESensorFaceY = NSLocalizedString("first face y position", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kUIFESensorSecondFaceDetected = NSLocalizedString("second face visible", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kUIFESensorSecondFaceSize = NSLocalizedString("second face size", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kUIFESensorSecondFaceX = NSLocalizedString("second face x position", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kUIFESensorSecondFaceY = NSLocalizedString("second face y position", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 
 let kUIFEUnknownElementType = NSLocalizedString("Unknown Element", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 


### PR DESCRIPTION
https://jira.catrob.at/browse/CATTY-651

- refactor existing face detection from CoreImage to Vision framework
- change XML Tags and sensor names from previous single face detection and make it backwards compatible
- add sensors for second face detection

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
