### PR TITLE
CATTY-657 Focus on variable name

### DIFF
--- a/src/Catty/FormulaEditor/ViewController/FormulaEditorSectionViewController/CreateVariableOrListViewController.swift
+++ b/src/Catty/FormulaEditor/ViewController/FormulaEditorSectionViewController/CreateVariableOrListViewController.swift
@@ -122,7 +122,8 @@
                     self.name = text
                 }, returnAction: {
                     self.view.endEditing(true)
-                }, placeholder: kLocalizedName)
+                }, placeholder: kLocalizedName,
+                   focus: true)
             ],
             [
                 FormCheckItem(title: kUIFEActionVarPro, selectAction: {

--- a/src/Catty/ViewController/CatrobatTableViewController/FormTableViewController/FormItem.swift
+++ b/src/Catty/ViewController/CatrobatTableViewController/FormTableViewController/FormItem.swift
@@ -85,14 +85,16 @@ class FormTextFieldItem: FormItem {
     var placeholder: String?
     var typeAction: ((String) -> Void)?
     var returnAction: (() -> Void)?
+    var focus = false
 
-    init(typeAction: ((String) -> Void)? = nil, returnAction: (() -> Void)? = nil, placeholder: String?) {
+    init(typeAction: ((String) -> Void)? = nil, returnAction: (() -> Void)? = nil, placeholder: String?, focus: Bool) {
         super.init()
 
         self.placeholder = placeholder
         self.typeAction = typeAction
         self.returnAction = returnAction
         self.cellType = FormTextFieldTableViewCell.self
+        self.focus = focus
     }
 }
 

--- a/src/Catty/ViewController/CatrobatTableViewController/FormTableViewController/FormTextFieldTableViewCell.swift
+++ b/src/Catty/ViewController/CatrobatTableViewController/FormTableViewController/FormTextFieldTableViewCell.swift
@@ -74,6 +74,9 @@ class FormTextFieldTableViewCell: FormTableViewCell, UITextFieldDelegate {
             typeAction = item.typeAction
             returnAction = item.returnAction
             textField.placeholder = item.placeholder
+            if item.focus {
+                textField.becomeFirstResponder()
+            }
         }
     }
 }

--- a/src/CattyUITests/ScriptCollectionView/BrickCellPickerViewerTest.swift
+++ b/src/CattyUITests/ScriptCollectionView/BrickCellPickerViewerTest.swift
@@ -52,7 +52,6 @@ class BrickCellPickerViewerTests: XCTestCase {
             app.tables.cells.element(boundBy: 2).tap()
 
             let textField = app.textFields.element(matching: .textField, identifier: "formTextField")
-            textField.tap()
             textField.typeText(variable)
 
             app.buttons[kLocalizedDone].firstMatch.tap()


### PR DESCRIPTION
(https://jira.catrob.at/browse/CATTY-657)

When creating new variables or lists the focus should be inside the variable name field

For testing: Add a new data brick to any script and create a new variable. Focus should be in the text field

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
