### PR TITLE
CATTY-637 Starting a project which has not been saved yet

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -1742,6 +1742,7 @@
 		BB9EC0E727D62CBA009FF8CE /* FormSwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9EC0E027D62CBA009FF8CE /* FormSwitchTableViewCell.swift */; };
 		BB9EC0E827D62CBA009FF8CE /* CreateVariableOrListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9EC0E127D62CBA009FF8CE /* CreateVariableOrListViewController.swift */; };
 		BB9EC0E927D62CBA009FF8CE /* FormItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9EC0E227D62CBA009FF8CE /* FormItem.swift */; };
+		BBA41C96287C3EEE00B099D3 /* BaseTableViewControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA41C95287C3EEE00B099D3 /* BaseTableViewControllerMock.swift */; };
 		BC19327F21186504009DE43A /* CreateProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC19327E21186504009DE43A /* CreateProjectTests.swift */; };
 		BC35168C231D00B90090872A /* SpriteBubbleConstraintsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC35168B231D00B90090872A /* SpriteBubbleConstraintsTests.swift */; };
 		BCF2787F22F4354200B6D337 /* BubbleBrickHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF2787E22F4354200B6D337 /* BubbleBrickHelper.swift */; };
@@ -4361,6 +4362,7 @@
 		BB9EC0E027D62CBA009FF8CE /* FormSwitchTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormSwitchTableViewCell.swift; sourceTree = "<group>"; };
 		BB9EC0E127D62CBA009FF8CE /* CreateVariableOrListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreateVariableOrListViewController.swift; sourceTree = "<group>"; };
 		BB9EC0E227D62CBA009FF8CE /* FormItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormItem.swift; sourceTree = "<group>"; };
+		BBA41C95287C3EEE00B099D3 /* BaseTableViewControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewControllerMock.swift; sourceTree = "<group>"; };
 		BC19327E21186504009DE43A /* CreateProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProjectTests.swift; sourceTree = "<group>"; };
 		BC35168B231D00B90090872A /* SpriteBubbleConstraintsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpriteBubbleConstraintsTests.swift; sourceTree = "<group>"; };
 		BCF2787E22F4354200B6D337 /* BubbleBrickHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BubbleBrickHelper.swift; sourceTree = "<group>"; };
@@ -7755,6 +7757,7 @@
 			isa = PBXGroup;
 			children = (
 				4C21C8C0274FB1CE009F7C7F /* AlertControllerBuilderMock.swift */,
+				BBA41C95287C3EEE00B099D3 /* BaseTableViewControllerMock.swift */,
 				4CB73A8F23FC1F0300D5E9A7 /* CatrobatTableViewControllerMock.swift */,
 				6F4B2FC02466F58500B5F0ED /* CBFileManagerMock.swift */,
 				4C2048782671DF7000AE2E1B /* CBScriptContextMock.swift */,
@@ -12541,6 +12544,7 @@
 				4C7054E025DE457900B265DC /* BrickCellFormulaDataTests.swift in Sources */,
 				4C3B151B23F07C7800527D4A /* ErrorMock.swift in Sources */,
 				4CC50A53213AE386004BC914 /* FormulaManagerIdempotenceTests.swift in Sources */,
+				BBA41C96287C3EEE00B099D3 /* BaseTableViewControllerMock.swift in Sources */,
 				E55F4287261335360005DB5A /* CBSpriteNodePhysicsTests.swift in Sources */,
 				4C822666213FA7A400F3D750 /* LongitudeSensorTest.swift in Sources */,
 				4C2CBB4625A5AA8400C1C143 /* XMLParserHeaderTests093.swift in Sources */,

--- a/src/Catty/ViewController/BaseViewController/BaseCollectionViewController.m
+++ b/src/Catty/ViewController/BaseViewController/BaseCollectionViewController.m
@@ -125,15 +125,25 @@
 
 - (void)playSceneAction:(id)sender
 {
+    [self showLoadingView];
+
     ((AppDelegate*)[UIApplication sharedApplication].delegate).enabledOrientation = true;
-    if (!Project.lastUsedProject.header.landscapeMode) {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
-        [UINavigationController attemptRotationToDeviceOrientation];
-    } else {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationLandscapeRight) forKey:@"orientation"];
-        [UINavigationController attemptRotationToDeviceOrientation];
-    }
-    [self.stagePresenterViewController checkResourcesAndPushViewControllerTo:self.navigationController];
+    dispatch_queue_t lastProjectQueue = dispatch_queue_create("lastProjectQueue", NULL);
+    dispatch_async(lastProjectQueue, ^{
+        BOOL landscapeMode = Project.lastUsedProject.header.landscapeMode;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (! landscapeMode) {
+                [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
+                [UINavigationController attemptRotationToDeviceOrientation];
+            } else {
+                [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationLandscapeRight) forKey:@"orientation"];
+                [UINavigationController attemptRotationToDeviceOrientation];
+            }
+            [self.stagePresenterViewController checkResourcesAndPushViewControllerTo:self.navigationController completion:^{
+                [self hideLoadingView];
+            }];
+        });
+    });
 }
 
 #pragma mark - Setup Toolbar

--- a/src/Catty/ViewController/BaseViewController/BaseTableViewController.h
+++ b/src/Catty/ViewController/BaseViewController/BaseTableViewController.h
@@ -30,6 +30,7 @@
 @property (nonatomic, strong, readonly) UIBarButtonItem *selectAllRowsButtonItem;
 @property (nonatomic, strong) PlaceHolderView *placeHolderView;
 
+- (void)setStagePresenterViewController:(StagePresenterViewController*) mockViewController;
 - (void)showPlaceHolder:(BOOL)show;
 - (BOOL)tableView:(UITableView*)tableView canEditRowAtIndexPath:(NSIndexPath*)indexPath;
 - (void)tableView:(UITableView*)tableView didSelectRowAtIndexPath:(NSIndexPath*)indexPath;

--- a/src/Catty/ViewController/BaseViewController/BaseTableViewController.m
+++ b/src/Catty/ViewController/BaseViewController/BaseTableViewController.m
@@ -177,6 +177,11 @@
     return _selectAllRowsButtonItem;
 }
 
++ (void)setStagePresenterViewController:(StagePresenterViewController*) mockViewController
+{
+    self.stagePresenterViewController = mockViewController;
+}
+
 #pragma mark - table view delegates
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
@@ -406,15 +411,26 @@
 
 - (void)playSceneAction:(id)sender
 {
+    [self showLoadingView];
+
     ((AppDelegate*)[UIApplication sharedApplication].delegate).enabledOrientation = true;
-    if (!Project.lastUsedProject.header.landscapeMode) {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
-        [UINavigationController attemptRotationToDeviceOrientation];
-    } else {
-        [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationLandscapeRight) forKey:@"orientation"];
-        [UINavigationController attemptRotationToDeviceOrientation];
-    }
-    [self.stagePresenterViewController checkResourcesAndPushViewControllerTo:self.navigationController];
+    dispatch_queue_t lastProjectQueue = dispatch_queue_create("lastProjectQueue", NULL);
+    dispatch_async(lastProjectQueue, ^{
+        BOOL landscapeMode = Project.lastUsedProject.header.landscapeMode;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (! landscapeMode) {
+                [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
+                [UINavigationController attemptRotationToDeviceOrientation];
+            } else {
+                [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationLandscapeRight) forKey:@"orientation"];
+                [UINavigationController attemptRotationToDeviceOrientation];
+            }
+
+            [self.stagePresenterViewController checkResourcesAndPushViewControllerTo:self.navigationController completion:^{
+                [self hideLoadingView];
+            }];
+        });
+    });
 }
 
 - (void)showLoadingView

--- a/src/Catty/ViewController/Stage/StagePresenterViewControllerResourcesExtension.swift
+++ b/src/Catty/ViewController/Stage/StagePresenterViewControllerResourcesExtension.swift
@@ -22,18 +22,16 @@
 
 import BluetoothHelper
 import CoreBluetooth
+import UIKit
 
 @objc extension StagePresenterViewController {
 
-    @objc(checkResourcesAndPushViewControllerTo:)
-    func checkResourcesAndPushViewController(to navigationController: UINavigationController) {
-        navigationController.view.addSubview(self.loadingView)
-        self.showLoadingView()
-
+    @objc(checkResourcesAndPushViewControllerTo:completion:)
+    func checkResourcesAndPushViewController(to navigationController: UINavigationController, completion: @escaping () -> Void = {}) {
         DispatchQueue.global(qos: .userInitiated).async {
             guard let project = Project.init(loadingInfo: Util.lastUsedProjectLoadingInfo()) else {
                 DispatchQueue.main.async {
-                    self.hideLoadingView()
+                    completion()
                     Util.alert(text: kLocalizedInvalidZip)
                 }
                 return
@@ -42,10 +40,11 @@ import CoreBluetooth
             DispatchQueue.main.async {
                 self.formulaManager = FormulaManager(stageSize: Util.screenSize(true), landscapeMode: self.project.header.landscapeMode)
                 let readyToStart = self.notifyUserAboutUnavailableResources(navigationController: navigationController)
+
+                completion()
+
                 if readyToStart && !(self.navigationController?.topViewController is StagePresenterViewController) {
                     navigationController.pushViewController(self, animated: true)
-                } else {
-                    self.hideLoadingView()
                 }
             }
         }

--- a/src/CattyTests/Mocks/BaseTableViewControllerMock.swift
+++ b/src/CattyTests/Mocks/BaseTableViewControllerMock.swift
@@ -22,12 +22,16 @@
 
 @testable import Pocket_Code
 
-class StagePresenterViewControllerMock: StagePresenterViewController {
+class BaseTableViewControllerMock: BaseTableViewController {
 
-    var latestPresentedViewController: UIViewController?
-    var embroideryService: EmbroideryProtocol?
+    var showLoadingViewCalls = 0
+    var hideLoadingViewCalls = 0
 
-    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
-        self.latestPresentedViewController = viewControllerToPresent
+    override func showLoadingView() {
+        showLoadingViewCalls += 1
+    }
+
+    override func hideLoadingView() {
+        hideLoadingViewCalls += 1
     }
 }

--- a/src/CattyTests/ViewController/BaseCollectionViewControllerTests.swift
+++ b/src/CattyTests/ViewController/BaseCollectionViewControllerTests.swift
@@ -27,8 +27,20 @@ import XCTest
 
 final class BaseTableViewControllerTests: XCTestCase {
 
+    var baseTableViewControllerMock: BaseTableViewControllerMock!
+    var project: Project!
+    var projectManager: ProjectManager!
+
     override func setUp() {
         super.setUp()
+
+        baseTableViewControllerMock = BaseTableViewControllerMock()
+
+        let stagePresenterViewControllerMock = StagePresenterViewControllerMock()
+        baseTableViewControllerMock.setStagePresenter(stagePresenterViewControllerMock)
+        projectManager = ProjectManager.shared
+
+        project = projectManager.createProject(name: kDefaultProjectBundleName, projectId: kNoProjectIDYetPlaceholder)
     }
 
     func testNotification() {
@@ -36,5 +48,25 @@ final class BaseTableViewControllerTests: XCTestCase {
         let expectedNotification = Notification(name: .baseTableViewControllerDidAppear, object: controller)
 
         expect(controller.viewDidAppear(true)).to(postNotifications(contain(expectedNotification)))
+    }
+
+    func testPlaySceneAction() {
+        CBFileManager.shared()?.deleteAllFilesInDocumentsDirectory()
+        CBFileManager.shared()?.addDefaultProjectToProjectsRootDirectoryIfNoProjectsExist()
+        Util.setLastProjectWithName(kDefaultProjectBundleName, projectID: kNoProjectIDYetPlaceholder)
+
+        baseTableViewControllerMock.playSceneAction(UIButton())
+
+        expect(self.baseTableViewControllerMock.showLoadingViewCalls).toEventually(equal(1), timeout: .seconds(3))
+        expect(self.baseTableViewControllerMock.hideLoadingViewCalls).toEventually(equal(1), timeout: .seconds(3))
+    }
+
+    func testPlaySceneActionInvalidProject() {
+        Util.setLastProjectWithName("InvalidProject", projectID: Date().timeIntervalSinceNow.description)
+
+        baseTableViewControllerMock.playSceneAction(UIButton())
+
+        expect(self.baseTableViewControllerMock.showLoadingViewCalls).toEventually(equal(1), timeout: .seconds(3))
+        expect(self.baseTableViewControllerMock.hideLoadingViewCalls).toEventually(equal(1), timeout: .seconds(3))
     }
 }

--- a/src/CattyTests/ViewController/Stage/StagePresenterViewControllerTests.swift
+++ b/src/CattyTests/ViewController/Stage/StagePresenterViewControllerTests.swift
@@ -88,15 +88,10 @@ final class StagePresenterViewControllerTest: XCTestCase {
         Util.setLastProjectWithName(kDefaultProjectBundleName, projectID: kNoProjectIDYetPlaceholder)
 
         XCTAssertNil(navigationController.currentViewController)
-        XCTAssertEqual(0, navigationController.view.subviews.count)
-        XCTAssertEqual(0, vc.showLoadingViewCalls)
 
         vc.checkResourcesAndPushViewController(to: navigationController)
 
         expect(self.navigationController.currentViewController).toEventually(equal(vc), timeout: .seconds(5))
-        expect(self.navigationController.view.subviews.count).toEventually(equal(1), timeout: .seconds(5))
-        expect(self.vc.showLoadingViewCalls).toEventually(equal(1), timeout: .seconds(5))
-        expect(self.vc.hideLoadingViewCalls).toEventually(equal(0), timeout: .seconds(5))
     }
 
     func testCheckResourcesAndPushViewControllerInvalidProject() {
@@ -107,9 +102,6 @@ final class StagePresenterViewControllerTest: XCTestCase {
         vc.checkResourcesAndPushViewController(to: navigationController)
 
         expect(self.navigationController.currentViewController).toEventually(beNil(), timeout: .seconds(3))
-        expect(self.navigationController.view.subviews.count).toEventually(equal(1), timeout: .seconds(3))
-        expect(self.vc.showLoadingViewCalls).toEventually(equal(1), timeout: .seconds(3))
-        expect(self.vc.hideLoadingViewCalls).toEventually(equal(1), timeout: .seconds(3))
     }
 
     func testShareDST() {

--- a/src/CattyUITests/ScenePresenterVCTests.swift
+++ b/src/CattyUITests/ScenePresenterVCTests.swift
@@ -53,4 +53,19 @@ class ScenePresenterVCTests: XCTestCase {
         app.toolbars.buttons["Play"].tap()
         XCTAssertTrue(UIApplication.shared.statusBarOrientation == .portrait)
     }
+
+    func testScenePresenterLoadingViewShown() {
+        let projectName = "testProject"
+        let loadingText = "\(kLocalizedLoading)..."
+
+        app.tables.staticTexts[kLocalizedNewProject].tap()
+        let alertQuery = app.alerts[kLocalizedNewProject]
+        alertQuery.textFields[kLocalizedEnterYourProjectNameHere].typeText(projectName)
+        app.alerts[kLocalizedNewProject].buttons[kLocalizedOK].tap()
+        XCTAssertNotNil(waitForElementToAppear(app.navigationBars[projectName]))
+
+        app.toolbars.buttons["Play"].tap()
+        XCTAssertTrue(app.staticTexts[loadingText].exists)
+        XCTAssertFalse(waitForElementToDisappear(app.staticTexts[loadingText]).exists)
+    }
 }


### PR DESCRIPTION
Displays a loading screen when a project is started, until the project serialization has finished. 

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
