### PR TITLE
CATTY-698 Unify UI and tint colors

### DIFF
--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryOverviewController.swift
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryOverviewController.swift
@@ -65,7 +65,7 @@ import UIKit
         brickCategoryOverviewCollectionView.register(BrickCategoryOverviewCollectionViewCell.self, forCellWithReuseIdentifier: BrickCategoryOverviewCollectionViewCell.identifier)
         brickCategoryOverviewCollectionView.delegate = self
         brickCategoryOverviewCollectionView.dataSource = self
-        brickCategoryOverviewCollectionView.backgroundColor = UIColor.white
+        brickCategoryOverviewCollectionView.backgroundColor = UIColor.background
         brickCategoryOverviewCollectionView.autoresizesSubviews = true
         brickCategoryOverviewCollectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainScript/BrickCategoryViewController.m
@@ -65,7 +65,7 @@
     }
     
     self.collectionView.backgroundColor = UIColor.clearColor;
-    self.view.backgroundColor = UIColor.whiteColor;
+    self.view.backgroundColor = UIColor.background;
 }
 
 -(void)reloadData {


### PR DESCRIPTION
Check if all references of (tint)colors are defined in UIColorExtension.swift.
If not, add them, which has been done on 2 occasions

https://jira.catrob.at/browse/CATTY-698


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
