### PR TITLE
CATTY-587 Choose image from selected photos

### DIFF
--- a/src/Catty/Defines/LanguageTranslationDefines.h
+++ b/src/Catty/Defines/LanguageTranslationDefines.h
@@ -306,6 +306,7 @@
 #define kLocalizedRemovedKnownBluetoothDevices NSLocalizedString(@"All known Bluetooth devices successfully removed", nil)
 #define kLocalizedArduinoBricksDescription NSLocalizedString(@"Allow the app to control Arduino boards", nil)
 #define kLocalizedEmbroideryBricksDescription NSLocalizedString(@"Create patterns for stiching machines", nil)
+#define kLocalizedAllowAccessToPhotos NSLocalizedString(@"Allow access to your photos", nil)
 
 //************************************************************************************************************
 //**********************************       LONG DESCRIPTIONS      ********************************************
@@ -343,6 +344,7 @@
 #define kLocalizedNoAccesToMicrophoneCheckSettingsDescription NSLocalizedString(@"Pocket Code has no access to your microphone. To permit access, tap settings and activate microphone.", nil)
 #define kLocalizedUnsupportedElementsDescription NSLocalizedString(@"Following features used in this project are not compatible with this version of Pocket Code:", nil)
 #define kLocalizedAlwaysAllowWebRequestDescription NSLocalizedString(@"Be very careful before allowing access, since the link may expose your personal information, such as your precise geographical location or any text you have entered to malicious other persons or to the public. See our wiki for more information why this can be extremely dangerous. By always allowing access, you will not be asked again to confirm web addresses from this domain. If you want to revoke this permission later, you can remove the domain from the list of trusted domains in the settings of this app.", nil)
+#define kLocalizedAllowAccessToPhotosDescription NSLocalizedString(@"Pocket Code has no access to this images. To permit access, tap settings and activate images.", nil)
 
 //************************************************************************************************************
 //*******************************       BRICK TITLE TRANSLATIONS      ****************************************

--- a/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
+++ b/src/Catty/Defines/LanguageTranslationDefinesSwift.swift
@@ -306,6 +306,7 @@ let kLocalizedDisconnectBluetoothDevices = NSLocalizedString("All Bluetooth devi
 let kLocalizedRemovedKnownBluetoothDevices = NSLocalizedString("All known Bluetooth devices successfully removed", comment: "")
 let kLocalizedArduinoBricksDescription = NSLocalizedString("Allow the app to control Arduino boards", comment: "")
 let kLocalizedEmbroideryBricksDescription = NSLocalizedString("Create patterns for stiching machines", comment: "")
+let kLocalizedAllowAccessToPhotos = NSLocalizedString("Allow access to your photos", comment: "")
 
 //************************************************************************************************************
 //**********************************       LONG DESCRIPTIONS      ********************************************
@@ -343,6 +344,7 @@ let kLocalizedNoAccesToCameraCheckSettingsDescription = NSLocalizedString("Pocke
 let kLocalizedNoAccesToMicrophoneCheckSettingsDescription = NSLocalizedString("Pocket Code has no access to your microphone. To permit access, tap settings and activate microphone.", comment: "")
 let kLocalizedUnsupportedElementsDescription = NSLocalizedString("Following features used in this project are not compatible with this version of Pocket Code:", comment: "")
 let kLocalizedAlwaysAllowWebRequestDescription = NSLocalizedString("Be very careful before allowing access, since the link may expose your personal information, such as your precise geographical location or any text you have entered to malicious other persons or to the public. See our wiki for more information why this can be extremely dangerous. By always allowing access, you will not be asked again to confirm web addresses from this domain. If you want to revoke this permission later, you can remove the domain from the list of trusted domains in the settings of this app.", comment: "")
+let kLocalizedAllowAccessToPhotosDescription = NSLocalizedString("Pocket Code has no access to this images. To permit access, tap settings and activate images.", comment: "")
 
 //************************************************************************************************************
 //*******************************       BRICK TITLE TRANSLATIONS      ****************************************

--- a/src/Catty/Resources/Localization/en.lproj/Localizable.strings
+++ b/src/Catty/Resources/Localization/en.lproj/Localizable.strings
@@ -71,6 +71,9 @@
 "All known Bluetooth devices successfully removed" = "All known Bluetooth devices successfully removed";
 
 /* No comment provided by engineer. */
+"Allow access to your photos" = "Allow access to your photos";
+
+/* No comment provided by engineer. */
 "Allow the app to control Arduino boards" = "Allow the app to control Arduino boards";
 
 /* No comment provided by engineer. */
@@ -285,6 +288,9 @@
 
 /* No comment provided by engineer. */
 "Change color " = "Change color ";
+
+/* No comment provided by engineer. */
+"Change Settings to allow Pocket Code full access to this photo." = "Change Settings to allow Pocket Code full access to this photo.";
 
 /* No comment provided by engineer. */
 "Change size by" = "Change size by";
@@ -1464,6 +1470,9 @@
 
 /* No comment provided by engineer. */
 "Open" = "Open";
+
+/* No comment provided by engineer. */
+"Open Settings" = "Open Settings";
 
 /* No comment provided by engineer. */
 "or" = "or";

--- a/src/Catty/Supporting Files/App-Info.plist
+++ b/src/Catty/Supporting Files/App-Info.plist
@@ -79,6 +79,8 @@
 	<string>Record your own sounds or use the microphone for screen recording.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Import pictures from your Photo Library to use as Look or Background.</string>
+	<key>PHPhotoLibraryPreventAutomaticLimitedAccessAlert</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController+MediaLibrary.swift
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController+MediaLibrary.swift
@@ -19,6 +19,7 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see http://www.gnu.org/licenses/.
  */
+import PhotosUI
 
 extension LooksTableViewController {
 
@@ -44,6 +45,37 @@ extension LooksTableViewController {
         let alertController = UIAlertController.init(title: alertTitle, message: alertMessage, preferredStyle: .alert)
         alertController.addAction(title: buttonTitle, style: .default, handler: nil)
         self.present(alertController, animated: true, completion: nil)
+    }
+}
+
+extension LooksTableViewController {
+
+    @available(iOS 14, *)
+    @objc
+    func checkAndUpdateLimitedPhotosAccess() {
+        let accessLevel: PHAccessLevel = .readWrite
+        let status = PHPhotoLibrary.authorizationStatus(for: accessLevel)
+
+        if status == .limited {
+            AlertControllerBuilder.alert(title: kLocalizedAllowAccessToPhotos, message: kLocalizedAllowAccessToPhotosDescription)
+                .addDefaultAction(title: kLocalizedSettings) {
+                    self.gotoAppPrivacySettings()
+                }
+                .addCancelAction(title: kLocalizedCancel, handler: {
+                })
+                .build()
+                .showWithController(self)
+        }
+    }
+
+    func gotoAppPrivacySettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString),
+            UIApplication.shared.canOpenURL(url) else {
+                assertionFailure("Not able to open App privacy settings")
+                return
+        }
+
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
 }
 

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController.m
@@ -536,6 +536,11 @@ UITextFieldDelegate>
                             [self saveImageData:imageData withFileName:@"" andImageFileNameExtension:@""];
                         }
                     }];
+                } else {
+                    // if asset cannot be found and iOS Version > 14 the access to the image might be limited and need to be checked
+                    if (@available(iOS 14, *)) {
+                        [self checkAndUpdateLimitedPhotosAccess];
+                    }
                 }
             } else if(picker.sourceType == UIImagePickerControllerSourceTypeCamera){
                 NSData *imageData = UIImagePNGRepresentation(image);

--- a/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
+++ b/src/CattyUITests/Defines/LanguageTranslationDefinesUI.swift
@@ -283,6 +283,7 @@ let kLocalizedAboutUs = NSLocalizedString("About Us", bundle: Bundle(for: Langua
 let kLocalizedCatrobatWebsite = NSLocalizedString("Catrobat website", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedViewTermsOfUse = NSLocalizedString("View Terms of Use and Service", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedTrustedDomains = NSLocalizedString("Trusted domains", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kLocalizedOpenSettings = NSLocalizedString("Open Settings", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 
 //************************************************************************************************************
 //**********************************       SHORT DESCRIPTIONS      *******************************************
@@ -306,6 +307,7 @@ let kLocalizedDisconnectBluetoothDevices = NSLocalizedString("All Bluetooth devi
 let kLocalizedRemovedKnownBluetoothDevices = NSLocalizedString("All known Bluetooth devices successfully removed", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedArduinoBricksDescription = NSLocalizedString("Allow the app to control Arduino boards", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedEmbroideryBricksDescription = NSLocalizedString("Create patterns for stiching machines", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kLocalizedAllowAccessToPhotos = NSLocalizedString("Allow access to your photos", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 
 //************************************************************************************************************
 //**********************************       LONG DESCRIPTIONS      ********************************************
@@ -343,6 +345,7 @@ let kLocalizedNoAccesToCameraCheckSettingsDescription = NSLocalizedString("Pocke
 let kLocalizedNoAccesToMicrophoneCheckSettingsDescription = NSLocalizedString("Pocket Code has no access to your microphone. To permit access, tap settings and activate microphone.", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedUnsupportedElementsDescription = NSLocalizedString("Following features used in this project are not compatible with this version of Pocket Code:", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 let kLocalizedAlwaysAllowWebRequestDescription = NSLocalizedString("Be very careful before allowing access, since the link may expose your personal information, such as your precise geographical location or any text you have entered to malicious other persons or to the public. See our wiki for more information why this can be extremely dangerous. By always allowing access, you will not be asked again to confirm web addresses from this domain. If you want to revoke this permission later, you can remove the domain from the list of trusted domains in the settings of this app.", bundle: Bundle(for: LanguageTranslation.self), comment: "")
+let kLocalizedAllowAccessToPhotosDescription = NSLocalizedString("Change Settings to allow Pocket Code full access to this photo.", bundle: Bundle(for: LanguageTranslation.self), comment: "")
 
 //************************************************************************************************************
 //*******************************       BRICK TITLE TRANSLATIONS      ****************************************


### PR DESCRIPTION
JIRA Ticket: (https://jira.catrob.at/browse/CATTY-587)
Bug Description: When the app has limited access to Photos (selected Photos in the settings) sometimes when choosing an image it doesn't get chosen and it is unclear for the user why nothing happened.

Root Cause: In iOS 14, the option for limited access has been added. In the old API (which we use) limited access looks the same as full access (for compatibility reason). See (https://developer.apple.com/documentation/photokit/phauthorizationstatus) for reference.
When trying to read the photo info of a limited file the access is denied. The app doesn't crash but also doesn't ready any data and hence nothing happens in the app.

Solution: Whenever nothing can be read from the image a check is made that verifies the iOS version and the authorizationStatus. If the status is limited a notification is shown if the user wants to change the settings of the app.
Usually, after each app start the app asks automatically to change the settings (but only once). This has been removed as there is now an explicit check for this.

Steps to test:
1.  set photos access to limited in options
2. navigate to any project -> pick any object -> choose looks
3. add a new image -> choose image
4. Pick any image that is not limited -> normal behaviour as always
5. Pick any image that is restricted -> Notification pops up with the option to change the limited photos selection

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
