### PR TITLE
CATTY-704 GlideToBrick does not work with EmbroideryStreams

### DIFF
--- a/src/Catty/PlayerEngine/Instructions/Motion/GlideToBrick+Instruction.swift
+++ b/src/Catty/PlayerEngine/Instructions/Motion/GlideToBrick+Instruction.swift
@@ -43,8 +43,18 @@
             fatalError("This should never happen!")
         }
         let destPoint = CGPoint(x: scene.size.width / 2 + CGFloat(xDestination), y: scene.size.height / 2 + CGFloat(yDestination))
+        let startX = scene.size.width / 2 + spriteNode.catrobatPosition.x
+        let startY = scene.size.height / 2 + spriteNode.catrobatPosition.y
 
-        let action = SKAction.move(to: destPoint, duration: duration)
-        return action
+        let moveAction = SKAction.customAction(withDuration: duration) { node, elapsedTime in
+            let progress = elapsedTime / duration
+            let intermediateX = startX + (destPoint.x - startX) * progress
+            let intermediateY = startY + (destPoint.y - startY) * progress
+            node.position = CGPoint(x: intermediateX, y: intermediateY)
+            if let activePattern = spriteNode.embroideryStream.activePattern {
+                activePattern.spriteDidMove(to: CGPoint(x: intermediateX, y: intermediateY), rotation: Double(spriteNode.catrobatRotation))
+            }
+        }
+        return moveAction
     }
 }


### PR DESCRIPTION
*Please enter a short description of your pull request and add a reference to the Jira ticket.*

CATTY-704: https://jira.catrob.at/browse/CATTY-704

EmbroideryStreams did not work with GlideToBricks because the protocols of the Stitches were never called in the moveAction, now they work as expected.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
