### PR TITLE
CATTY-707 fix landscape mode

### DIFF
--- a/src/Catty/ViewController/BaseViewController/BaseCollectionViewController.m
+++ b/src/Catty/ViewController/BaseViewController/BaseCollectionViewController.m
@@ -134,10 +134,8 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             if (! landscapeMode) {
                 [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
-                [UINavigationController attemptRotationToDeviceOrientation];
             } else {
                 [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationLandscapeRight) forKey:@"orientation"];
-                [UINavigationController attemptRotationToDeviceOrientation];
             }
             [self.stagePresenterViewController checkResourcesAndPushViewControllerTo:self.navigationController completion:^{
                 [self hideLoadingView];

--- a/src/Catty/ViewController/BaseViewController/BaseTableViewController.m
+++ b/src/Catty/ViewController/BaseViewController/BaseTableViewController.m
@@ -421,10 +421,8 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             if (! landscapeMode) {
                 [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationPortrait) forKey:@"orientation"];
-                [UINavigationController attemptRotationToDeviceOrientation];
             } else {
                 [[UIDevice currentDevice] setValue:@(UIInterfaceOrientationLandscapeRight) forKey:@"orientation"];
-                [UINavigationController attemptRotationToDeviceOrientation];
             }
 
             [self.stagePresenterViewController checkResourcesAndPushViewControllerTo:self.navigationController completion:^{


### PR DESCRIPTION
[CATTY-707](https://jira.catrob.at/browse/CATTY-707)

fixed MenuView (buttons now look good again)
fixed Axis arrows
fixed alignment in landscape mode

<img width="871" alt="Screenshot 2023-05-05 at 09 23 04" src="https://user-images.githubusercontent.com/48297076/236399136-ec2fc6b3-a38b-43e8-93bf-b4588579402b.png">

<img width="883" alt="Screenshot 2023-05-05 at 09 23 45" src="https://user-images.githubusercontent.com/48297076/236399301-c8954759-7f90-496a-ad6a-03ae55ca7cbd.png">

<img width="869" alt="Screenshot 2023-05-05 at 09 24 10" src="https://user-images.githubusercontent.com/48297076/236402660-19a66c55-2f8b-43f7-902a-e33faf53ec42.png">


### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [x] After the PR, verify that all CI checks have passed
- [x] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
