### PR TITLE
CATTY-717 Allow selection of images from files

### DIFF
--- a/src/Catty.xcodeproj/project.pbxproj
+++ b/src/Catty.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		05E68028255B5DEE00D1E295 /* EmbroideryDSTServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E68024255B5DED00D1E295 /* EmbroideryDSTServiceTests.swift */; };
 		05E6802C255B5E3400D1E295 /* CGVectorExtentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05E6802B255B5E3400D1E295 /* CGVectorExtentions.swift */; };
 		05E6802F255B602700D1E295 /* stitch.dst in Resources */ = {isa = PBXBuildFile; fileRef = 05E6802E255B602700D1E295 /* stitch.dst */; };
+		175605302CC1E46400E3B27E /* LooksTableViewController+SelectFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756052F2CC1E46400E3B27E /* LooksTableViewController+SelectFile.swift */; };
 		1764E6382A06CC940013102B /* SoundRecorderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1764E6372A06CC940013102B /* SoundRecorderViewController.swift */; };
 		17A0218A2726F36700F0489E /* AudioKit in Frameworks */ = {isa = PBXBuildFile; productRef = 17A021892726F36700F0489E /* AudioKit */; };
 		17A0218D2726F3C600F0489E /* DunneAudioKit in Frameworks */ = {isa = PBXBuildFile; productRef = 17A0218C2726F3C600F0489E /* DunneAudioKit */; };
@@ -2204,6 +2205,7 @@
 		0C64E34E5347DA71ECB56DE6 /* pt */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		113CDA22CF21176FFA49E694 /* sd */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = sd; path = sd.lproj/Localizable.strings; sourceTree = "<group>"; };
 		13B5EB79EDA9CF73908FF75C /* no */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = no; path = no.lproj/Localizable.strings; sourceTree = "<group>"; };
+		1756052F2CC1E46400E3B27E /* LooksTableViewController+SelectFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LooksTableViewController+SelectFile.swift"; sourceTree = "<group>"; };
 		1764E6372A06CC940013102B /* SoundRecorderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundRecorderViewController.swift; sourceTree = "<group>"; };
 		17A8AC642644E6A900DDD480 /* ForceInit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ForceInit.m; sourceTree = "<group>"; };
 		17A8AC6B2644E6B500DDD480 /* ForceInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ForceInit.h; sourceTree = "<group>"; };
@@ -9243,6 +9245,7 @@
 				92FF311C1A24DEB300093DA7 /* LooksTableViewController.h */,
 				92FF311D1A24DEB300093DA7 /* LooksTableViewController.m */,
 				59ABDC5F2021BBFB00061403 /* LooksTableViewController+MediaLibrary.swift */,
+				1756052F2CC1E46400E3B27E /* LooksTableViewController+SelectFile.swift */,
 			);
 			path = MaintainLooks;
 			sourceTree = "<group>";
@@ -13364,6 +13367,7 @@
 				4CF0729D20D66F8D00F93AB5 /* LookNumberSensor.swift in Sources */,
 				05E6802C255B5E3400D1E295 /* CGVectorExtentions.swift in Sources */,
 				597AB56E202081E8007CD10D /* LibrarySoundCollectionViewCell.swift in Sources */,
+				175605302CC1E46400E3B27E /* LooksTableViewController+SelectFile.swift in Sources */,
 				4C724E5B1B4D3E8C00E27479 /* Script+CBXMLHandler.m in Sources */,
 				92EC985E1BC3ABB90003A891 /* PhiroMotorStopBrick+CBXMLHandler.m in Sources */,
 				4C0F9F9F204BD2B100E71B2D /* SayForBubbleBrickCell.m in Sources */,

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController+MediaLibrary.swift
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController+MediaLibrary.swift
@@ -36,7 +36,7 @@ extension LooksTableViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
 
-    private func showImportAlert(itemName: String) {
+    public func showImportAlert(itemName: String) {
         let alertTitle = kLocalizedMediaLibraryImportFailedTitle
         let alertMessage = "\(kLocalizedMediaLibraryImportFailedMessage) \(itemName)"
         let buttonTitle = kLocalizedOK

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController+SelectFile.swift
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController+SelectFile.swift
@@ -1,0 +1,75 @@
+/**
+ *  Copyright (C) 2010-2024 The Catrobat Team
+ *  (http://developer.catrobat.org/credits)
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  An additional term exception under section 7 of the GNU Affero
+ *  General Public License, version 3, is available at
+ *  (http://developer.catrobat.org/license_additional_term)
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+
+import MobileCoreServices
+
+extension LooksTableViewController {
+
+    @available(iOS 14.0, *)
+    static var supportedFileFormats = [UTType.png, UTType.jpeg]
+    static let supportedFileFormatsBackwardsCompatibility = ["public.png", "public.jpeg"]
+
+    @objc
+    func showImagesSelectFile() {
+        var documentPicker: UIDocumentPickerViewController
+        if #available(iOS 14.0, *) {
+            documentPicker = UIDocumentPickerViewController.init(forOpeningContentTypes: type(of: self).supportedFileFormats, asCopy: true)
+        } else {
+            documentPicker = UIDocumentPickerViewController(documentTypes: type(of: self).supportedFileFormatsBackwardsCompatibility, in: .import)
+        }
+
+        documentPicker.allowsMultipleSelection = false
+        documentPicker.delegate = self
+        documentPicker.modalPresentationStyle = .formSheet
+        present(documentPicker, animated: true)
+    }
+}
+
+extension LooksTableViewController: UIDocumentPickerDelegate, UINavigationControllerDelegate {
+    public func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        let documents = URL(fileURLWithPath:
+                                CBFileManager.shared().documentsDirectory)
+
+        for url in urls {
+            let fileName = UUID().uuidString
+            let name = url.deletingPathExtension().lastPathComponent
+            let fileURL = documents
+                .appendingPathComponent(fileName)
+                .appendingPathExtension(url.pathExtension)
+
+            do {
+                let data = try Data.init(contentsOf: url)
+                try data.write(to: fileURL, options: .atomic)
+                if let image = UIImage(data: data) {
+                    self.addMediaLibraryLoadedImage(image, withName: name)
+                }
+            } catch {
+                self.showImportAlert(itemName: name)
+            }
+        }
+        controller.dismiss(animated: true)
+    }
+
+    public func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        controller.dismiss(animated: true)
+    }
+}

--- a/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController.m
+++ b/src/Catty/ViewController/Continue&New/MaintainObject/MaintainLooks/LooksTableViewController.m
@@ -637,7 +637,7 @@ UITextFieldDelegate>
         }
     }
     
-    [[[[actionSheet
+    [[[[[actionSheet
         addDefaultActionWithTitle:kLocalizedDrawNewImage handler:^{
         dispatch_async(dispatch_get_main_queue(), ^{
             PaintViewController *vc = [self.storyboard instantiateViewControllerWithIdentifier:kPaintViewControllerIdentifier];
@@ -658,7 +658,13 @@ UITextFieldDelegate>
                 [self showLooksMediaLibrary];
             }
         });
-    }] build]
+    }]
+      addDefaultActionWithTitle:kLocalizedSelectFile handler:^{
+          dispatch_async(dispatch_get_main_queue(), ^{
+              [self showImagesSelectFile];
+          });
+      }]
+      build]
      showWithController:self];
 }
 


### PR DESCRIPTION
Implementation of feature CATTY-717 Allow selection of images from files

Implementation of feature CATTY-717. 
The Implementation is very similar to the Implementation for selecting sound files from the Finder.

### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catty/blob/develop/README.md) and [wiki pages](https://github.com/Catrobat/Catroid/wiki/) of this repository.

- [x] Include the name of the Jira ticket in the PR’s title
- [x] Verify that the Jira ticket is in the status *Ready for Development*
- [x] Include a summary of the changes plus the relevant context
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no compiler or linter warnings
- [x] Perform a self-review of the changes
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Confirm that new and existing unit tests pass locally
- [x] Check that the commits’ message style matches the [project’s guideline](https://github.com/Catrobat/Catroid/wiki/Commit-Message-Guidelines)
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] After the PR, verify that all CI checks have passed
- [ ] Post a message in the *#catty* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer
