### PR TITLE
CATTY-719 Make stage axis pass through touch events

### DIFF
--- a/src/Catty/Defines/UIDefines.swift
+++ b/src/Catty/Defines/UIDefines.swift
@@ -52,7 +52,7 @@ class UIDefines: NSObject {
     @objc static let iPadScreenHeight = CGFloat(1028.0)
 
     // ScenePresenterViewController
-    @objc static let slidingStartArea = 80
+    @objc static let slidingStartArea = 60
     @objc static let firstSwipeDuration = CGFloat(0.65)
     @objc static let hideMenuViewDelay = CGFloat(0.45)
 

--- a/src/Catty/ViewController/Stage/StagePresenterViewController.m
+++ b/src/Catty/ViewController/Stage/StagePresenterViewController.m
@@ -275,6 +275,8 @@
     [positiveHeight sizeToFit];
     [negativeHeight sizeToFit];
     
+    [self.gridView setUserInteractionEnabled:false];
+    
     [self.view insertSubview:self.gridView aboveSubview:self.skView];
 }
 


### PR DESCRIPTION
CATTY-719 Touch-Events werden durch Achsen im laufenden Spiel blockiert

**Beschreibung:**

Im laufenden Spiel blockieren die Achsen derzeit Touch-Events die direkt auf Höhe der Achsen liegen. 

Dies führt dazu, dass Nutzer keine Interaktionen mit anderen Spielkomponenten durchführen können, wenn diese auf den Achsen liegen und solange die Achsen aktiv sind.

Die Achsen können über das Seitenmenü aktiviert/deaktiviert werden können. (siehe Screenshot)

**Erwartetes Verhalten:**

Die Achsen sollten "transparent" für Touch-Events sein, d.h., selbst wenn die Achsen aktiviert sind, sollten die Nutzer immer noch in der Lage sein, andere Elemente im Projekt zu berühren die dahinter liegen. 